### PR TITLE
Some typo fixes and language tweaks

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -207,5 +207,5 @@ You can also ask for help from the *atoum* development staff on the IRC channel 
 
 ### Error: Constant __COMPILER_HALT_OFFSET__ already defined /path/to/mageekguy.atoum.phar
 
-This error comes from the fact the *atoum* PHAR archive is included in more than one place within your code, using `include` or `require`.  
+This error comes from the fact the *atoum* PHAR archive is included in more than one place within your code using `include` or `require`.  
 To fix this problem, you just need to include the archive by using only `include_once` or `require_once`, in order to ensure it is not included several times.


### PR DESCRIPTION
I noticed a couple typos and little English quirks in README.markdown, so I fixed them in three separate commits.  
