### PR TITLE
improve invalid argument exception message

### DIFF
--- a/classes/script/arguments/parser.php
+++ b/classes/script/arguments/parser.php
@@ -76,7 +76,7 @@ class parser implements \iteratorAggregate
 
 			if (self::isArgument($value) === false)
 			{
-				throw new exceptions\runtime\unexpectedValue('First argument is invalid');
+				throw new exceptions\runtime\unexpectedValue(sprintf('First argument (%s) is invalid', $value));
 			}
 
 			$argument = $value;


### PR DESCRIPTION
Exception does not refers to the argument that is invalid, so its no
easy to debug.
Add argument name in exception message.
