### PR TITLE
fix the argurments passed to the parent class of the runner

### DIFF
--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -215,7 +215,7 @@ class runner extends atoum\script
 			array('--testIt')
 		);
 
-		parent::run(sizeof($arguments) <= 0 ? $arguments : $this->arguments);
+		parent::run(sizeof($arguments) > 0 ? $arguments : $this->arguments);
 
 		if ($this->runTests === true)
 		{


### PR DESCRIPTION
  in the run method of the runenr the condition to set the arguments
to the parents shoud be the opposite. We want to pass the
$this->arguements if we have no $arguements.
