### PR TITLE
fix constants.php if phar extension not loaded

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -5,7 +5,7 @@ namespace mageekguy\atoum;
 if (defined(__NAMESPACE__ . '\running') === false)
 {
 	define(__NAMESPACE__ . '\running',  true);
-	define(__NAMESPACE__ . '\directory', \phar::running(true) ?: realpath(__DIR__));
+	define(__NAMESPACE__ . '\directory', extension_loaded('phar') && \phar::running(true) ?: realpath(__DIR__));
 	define(__NAMESPACE__ . '\version', preg_replace('/\$Rev: ([^ ]+) \$/', '$1', '$Rev: DEVELOPMENT $'));
 	define(__NAMESPACE__ . '\author', 'Frédéric Hardy');
 	define(__NAMESPACE__ . '\mail', 'support@atoum.org');


### PR DESCRIPTION
  atoum wasn't working if the php-phar extension was not loaded.
  so, we make \phar::running only if phar extension is loaded
