### PR TITLE
Implements assert phpCallback.

### DIFF
--- a/classes/asserters/phpCallback.php
+++ b/classes/asserters/phpCallback.php
@@ -27,7 +27,7 @@ class phpCallback extends asserters\variable
 	{
 		if (self::isCallback($value) === false)
 		{
-			throw new exceptions\logic\invalidArgument('Argument of ' . $method . '() must be a valid format callback');
+			throw new exceptions\logic\invalidArgument('Argument of ' . $method . '() must be a valid callback');
 		}
 	}
 


### PR DESCRIPTION
Now you can test callbacks like that : 

``` php
<?php
$this->assert->phpCallback(function() {});
$this->assert->phpCallback('my_function');
$this->assert->phpCallback(create_function('', 'return true;'));
$this->assert->phpCallback(array('MyClass', 'method'));
$this->assert->phpCallback(array(new MyClass, 'instanceMethod'));
?>
```

or real life example : 

``` php
<?php
Events::clearRespondersFor('load.entity');
Events::addResponderFor(function() {}, 'load.entity');
$this->assert->phpCallback(reset(Events::getRespondersFor('load.entity')));
?>
```
