### PR TITLE
Draft implementation of callTo.

### DIFF
--- a/classes/asserters/callTo.php
+++ b/classes/asserters/callTo.php
@@ -67,6 +67,12 @@ class callTo extends asserters\variable
 		return $this->generator->$assertName($this->return);
 	}
 
+	public function getReturn()
+	{
+		$this->executeCallback();
+		return $this->return;
+	}
+
 	public function hasOutput($compareTo, $failMessage = null)
 	{
 		$this->executeCallback();
@@ -86,6 +92,12 @@ class callTo extends asserters\variable
 	{
 		$this->executeCallback();
 		return $this->generator->string($this->output);
+	}
+
+	public function getOutput()
+	{
+		$this->executeCallback();
+		return $this->output;
 	}
 
 	private function executeCallback()


### PR DESCRIPTION
Just a draft for now. Please review.
### Basic usage

``` php
<?php
    $callback = function() {
      print  implode(',', func_get_args());
    };
    $this->assert
      ->callTo($callback)
      ->withArguments('a', 'b', 'c')
            ->hasOutput('a,b,c');
```

``` php
<?php
    $callback = function() {
      return implode(':', func_get_args());
    };
    $this->assert
      ->callTo($callback)
      ->withArguments('d', 'e', 'f')
      ->return('d:e:f');
```
### Conversion

``` php
<?php
    $callback = function() {
      print  implode(',', func_get_args());
    };
    $this->assert
      ->callTo($callback)
      ->withArguments('g', 'h', 'i')
            ->outputAsString() // Conversion to string assert
                    ->match('#g,h,i#');
```

``` php
<?php
    $callback = function() {
      return func_get_args();
    };
    $this->assert
      ->callTo($callback)
      ->withArguments('j', 'k', 'l')
      ->returnAs('PhpArray') // Conversion to phpArray assert
        ->contains('k');
```

``` php
<?php
    $this->assert
      ->callTo('rand')
      ->withArguments(10, 20)
      ->returnAs('Integer')
        ->isGreaterThanOrEqualTo(10)
        ->isLowerThanOrEqualTo(20);
```
### Imbricated asserts

``` php
<?php
$return = $this->assert
                  ->callTo('rand')
                  ->withArguments(10, 20)
                  ->getReturn();
$this->assert
      ->integer($return)
              ->isGreaterThanOrEqualTo(10)
              ->isLowerThanOrEqualTo(20);
```
### Chained call

``` php
<?php
    $callback = function($arg) {
      return $arg;
    };
    $return = $this->assert
               ->callTo($callback)
                            ->withArguments('a')->return('a')
                            ->withArguments(500)->return(500)
                            ->withArguments(true)->return(true)
                            ->withArguments($callback)->return($callback)
                            ->withArguments(array('m', 'n', 'o'))->return(array('m', 'n', 'o'));

```
