### PR TITLE
New asserters on phpArray * COMPATIBILITY BREAK *

### DIFF
--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -72,155 +72,195 @@ class phpArray extends asserters\variable
 		return $this;
 	}
 
-    public function strictlyContains($value, $failMessage = null)
-    {
-        return $this->containsCommon($value, $failMessage, true);
-    }
+	public function strictlyContains($value, $failMessage = null)
+	{
+		return $this->containsValue($value, $failMessage, true);
+	}
 
 	public function contains($value, $failMessage = null)
-    {
-        return $this->containsCommon($value, $failMessage, false);
-    }
+	{
+		return $this->containsValue($value, $failMessage, false);
+	}
 
-    public function strictlyNotContains($value, $failMessage = null)
-    {
-        return $this->notContainsCommon($value, $failMessage, true);
-    }
+	public function strictlyNotContains($value, $failMessage = null)
+	{
+		return $this->notContainsValue($value, $failMessage, true);
+	}
 
 	public function notContains($value, $failMessage = null)
-    {
-        return $this->notContainsCommon($value, $failMessage, false);
-    }
+	{
+		return $this->notContainsValue($value, $failMessage, false);
+	}
 
-    public function hasKeys (array $values, $failMessage = null)
-    {
-        $missing = array();
-        foreach ($values as $value)
-        {
-            if (!array_key_exists($value, $this->value))
-            {
-                $missing[] = $value;
-            }
-        }
-        if (count($missing))
-        {
-            $this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should have keys %s'), $this, $this->getTypeOf($missing))));
-        }
-        else
-        {
-            $this->pass();
-        }
-        return $this;
-    }
+	public function hasKeys(array $keys, $failMessage = null)
+	{
+		if (sizeof($undefinedKeys = array_diff($keys, array_keys($this->value))) <= 0)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should have keys %s'), $this, $this->getTypeOf($undefinedKeys))));
+		}
 
-    public function notHasKeys (array $values, $failMessage = null)
-    {
-        $shouldNotBePresent = array();
-        foreach ($values as $value)
-        {
-            if (array_key_exists($value, $this->value))
-            {
-                $shouldNotBePresent[] = $value;
-            }
-        }
-        if (count($shouldNotBePresent))
-        {
-            $this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should not have keys %s'), $this, $this->getTypeOf($shouldNotBePresent))));
-        }
-        else
-        {
-            $this->pass();
-        }
-        return $this;
-    }
+		return $this;
+	}
 
-    public function hasKey ($value, $failMessage = null)
-    {
-        if (array_key_exists($value, $this->value))
-        {
-            $this->pass();
-        }
-        else
-        {
-            $this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s has no key %s'), $this, $this->getTypeOf($value))));
-        }
-        return $this;
-    }
+	public function notHasKeys(array $keys, $failMessage = null)
+	{
+		if (sizeof($definedKeys = array_intersect(array_keys($this->value), $keys)) <= 0)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should not have keys %s'), $this, $this->getTypeOf($definedKeys))));
+		}
 
-    public function notHasKey ($value, $failMessage = null)
-    {
-        if (!array_key_exists($value, $this->value))
-        {
-            $this->pass();
-        }
-        else
-        {
-            $this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s has a key %s'), $this, $this->getTypeOf($value))));
-        }
-        return $this;
-    }
+		return $this;
+	}
 
-    public function containsValues (array $values, $failMessage = null)
-    {
-        return $this->containsValuesCommon($values, $failMessage, false);
-    }
+	public function hasKey($key, $failMessage = null)
+	{
+		if (array_key_exists($key, $this->value))
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s has no key %s'), $this, $this->getTypeOf($key))));
+		}
 
-    public function strictlyContainsValues (array $values, $failMessage = null)
-    {
-        return $this->containsValuesCommon($values, $failMessage, true);
-    }
+		return $this;
+	}
 
-    public function notContainsValues (array $values, $failMessage = null)
-    {
-        return $this->notContainsValuesCommon($values, $failMessage, false);
-    }
+	public function notHasKey($key, $failMessage = null)
+	{
+		if (array_key_exists($key, $this->value) === false)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s has a key %s'), $this, $this->getTypeOf($key))));
+		}
 
-    public function strictlyNotContainsValues (array $values, $failMessage = null)
-    {
-        return $this->notContainsValuesCommon($values, $failMessage, true);
-    }
+		return $this;
+	}
 
-    protected function containsValuesCommon ($values, $failMessage, $strict)
-    {
-        $missing = array();
-        foreach ($values as $value)
-        {
-            if (!in_array($value, $this->value, $strict))
-            {
-                $missing[] = $value;
-            }
-        }
-        if (count($missing))
-        {
-            $this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s does not contain values %s'), $this, $this->getTypeOf($missing))));
-        }
-        else
-        {
-            $this->pass();
-        }
-        return $this;
-    }
+	public function containsValues(array $values, $failMessage = null)
+	{
+		return $this->containsArray($values, $failMessage, false);
+	}
 
-    protected function notContainsValuesCommon ($values, $failMessage, $strict)
-    {
-        $shouldNotBePresent = array();
-        foreach ($values as $value)
-        {
-            if (in_array($value, $this->value, $strict))
-            {
-                $shouldNotBePresent[] = $value;
-            }
-        }
-        if (count($shouldNotBePresent))
-        {
-            $this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should not contain values %s'), $this, $this->getTypeOf($shouldNotBePresent))));
-        }
-        else
-        {
-            $this->pass();
-        }
-        return $this;
-    }
+	public function strictlyContainsValues(array $values, $failMessage = null)
+	{
+		return $this->containsArray($values, $failMessage, true);
+	}
+
+	public function notContainsValues(array $values, $failMessage = null)
+	{
+		return $this->notContainsArray($values, $failMessage, false);
+	}
+
+	public function strictlyNotContainsValues(array $values, $failMessage = null)
+	{
+		return $this->notContainsArray($values, $failMessage, true);
+	}
+
+	protected function containsValue($value, $failMessage = null, $strict)
+	{
+		if (in_array($value, $this->valueIsSet()->value, $strict) === true)
+		{
+			$this->pass();
+		}
+		else if ($strict === false)
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s does not contain %s'), $this, $this->getTypeOf($value)));
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s does not strictly contain %s'), $this, $this->getTypeOf($value)));
+		}
+
+		return $this;
+	}
+
+	protected function notContainsValue($value, $failMessage = null, $strict)
+	{
+		if (in_array($value, $this->valueIsSet()->value, $strict) === false)
+		{
+			$this->pass();
+		}
+		else if ($strict === false)
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s contains %s'), $this, $this->getTypeOf($value)));
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s contains strictly %s'), $this, $this->getTypeOf($value)));
+		}
+
+		return $this;
+	}
+
+	protected function containsArray(array $values, $failMessage, $strict)
+	{
+		$unknownValues = array();
+
+		if ($strict === false)
+		{
+			$unknownValues = array_diff($values, $this->value);
+		}
+		else foreach ($values as $value) if (in_array($value, $this->value, true) === false)
+		{
+			$unknownValues[] = $value;
+		}
+
+		if (sizeof($unknownValues) <= 0)
+		{
+			$this->pass();
+		}
+		else if ($strict === false)
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s does not contain values %s'), $this, $this->getTypeOf($unknownValues))));
+		}
+		else
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s does not contain strictly values %s'), $this, $this->getTypeOf($unknownValues))));
+		}
+
+		return $this;
+	}
+
+	protected function notContainsArray(array $values, $failMessage, $strict)
+	{
+		$knownValues = array();
+
+		if ($strict === false)
+		{
+			$knownValues = array_intersect($values, $this->value);
+		}
+		else foreach ($values as $value) if (in_array($value, $this->value, $strict) === true)
+		{
+			$knownValues[] = $value;
+		}
+
+		if (sizeof($knownValues) <= 0)
+		{
+			$this->pass();
+		}
+		else if ($strict === false)
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should not contain values %s'), $this, $this->getTypeOf($knownValues))));
+		}
+		else
+		{
+			$this->fail(($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s should not contain strictly values %s'), $this, $this->getTypeOf($knownValues))));
+		}
+
+		return $this;
+	}
 
 	protected function valueIsSet($message = 'Array is undefined')
 	{
@@ -233,32 +273,6 @@ class phpArray extends asserters\variable
 		{
 			throw new exceptions\logic\invalidArgument('Argument of ' . $method . '() must be an array');
 		}
-	}
-
-    protected function containsCommon($value, $failMessage = null, $strict)
-	{
-        if (in_array($value, $this->valueIsSet()->value, $strict) === true)
-        {
-            $this->pass();
-        }
-        else
-        {
-            $this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s does not contain %s'), $this, $this->getTypeOf($value)));
-        }
-		return $this;
-	}
-
-    protected function notContainsCommon($value, $failMessage = null, $strict)
-	{
-        if (in_array($value, $this->valueIsSet()->value, $strict) === false)
-        {
-            $this->pass();
-        }
-        else
-        {
-            $this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s contains %s'), $this, $this->getTypeOf($value)));
-        }
-		return $this;
 	}
 
 	protected static function isArray($value)

--- a/tests/units/classes/asserters/phpArray.php
+++ b/tests/units/classes/asserters/phpArray.php
@@ -344,87 +344,86 @@ class phpArray extends atoum\test
         ;
 	}
 
-    public function testNotContainsValues()
-    {
-        $asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
+	public function testNotContainsValues()
+	{
+		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
-        $this->assert
-            ->boolean($asserter->wasSet())->isFalse()
-            ->exception(function() use ($asserter) {
-                    $asserter->contains(uniqid());
-                }
-            )
-                ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-                ->hasMessage('Array is undefined')
-        ;
+		$this->assert
+			->boolean($asserter->wasSet())->isFalse()
+			->exception(function() use ($asserter) {
+					$asserter->contains(uniqid());
+					}
+					)
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Array is undefined')
+			;
 
-        $asserter->setWith(array(1, 2, 3, 4, 5));
+		$asserter->setWith(array(1, 2, 3, 4, 5));
 
-        $score->reset();
+		$score->reset();
 
-        $this->assert
-            ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->notContainsValues(array(1, 6)); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                ->hasMessage(sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1))))
-            ->integer($score->getPassNumber())->isEqualTo(0)
-            ->integer($score->getFailNumber())->isEqualTo(1)
-            ->array($score->getFailAssertions())->isEqualTo(array(
-                    array(
-                        'case' => null,
-                        'class' => __CLASS__,
-                        'method' => $test->getCurrentMethod(),
-                        'file' => __FILE__,
-                        'line' => $line,
-                        'asserter' => get_class($asserter) . '::notContainsValues()',
-                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1)))
-                    )
-                )
-            )
-        ;
+		$this->assert
+			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->notContainsValues(array(1, 6)); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1))))
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1)
+			->array($score->getFailAssertions())->isEqualTo(array(
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::notContainsValues()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1)))
+							)
+						)
+					)
+			;
 
-        $score->reset();
-        $this->assert
-            ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->notContainsValues(array("1", "6")); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                ->hasMessage(sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array("1"))))
-            ->integer($score->getPassNumber())->isEqualTo(0)
-            ->integer($score->getFailNumber())->isEqualTo(1)
-            ->array($score->getFailAssertions())->isEqualTo(array(
-                    array(
-                        'case' => null,
-                        'class' => __CLASS__,
-                        'method' => $test->getCurrentMethod(),
-                        'file' => __FILE__,
-                        'line' => $line,
-                        'asserter' => get_class($asserter) . '::notContainsValues()',
-                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array("1")))
-                    )
-                )
-            )
-        ;
+		$score->reset();
+		$this->assert
+			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->notContainsValues(array("1", "6")); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array("1"))))
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1)
+			->array($score->getFailAssertions())->isEqualTo(array(
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::notContainsValues()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array("1")))
+							)
+						)
+					)
+			;
 
-        $score->reset();
-        $this->assert
-            ->object($asserter->containsValues(array(1)))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0)
-        ;
+		$score->reset();
+		$this->assert
+			->object($asserter->containsValues(array(1)))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0)
+			;
 
-        $score->reset();
-        $this->assert
-            ->object($asserter->containsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0)
-        ;
+		$score->reset();
+		$this->assert
+			->object($asserter->containsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0)
+			;
 
-        $score->reset();
-        $this->assert
-            ->object($asserter->containsValues(array("1", 2, "4")))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0)
-        ;
-    }
-
+		$score->reset();
+		$this->assert
+			->object($asserter->containsValues(array("1", 2, "4")))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0)
+			;
+	}
 
 	public function testStrictlyContainsValues()
 	{
@@ -447,7 +446,7 @@ class phpArray extends atoum\test
 		$this->assert
 			->exception(function() use (& $line, $asserter, & $notInArray) { $line = __LINE__; $asserter->strictlyContainsValues(array(6)); })
 				->isInstanceOf('mageekguy\atoum\asserter\exception')
-				->hasMessage(sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array(6))))
+				->hasMessage(sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(6))))
 			->integer($score->getPassNumber())->isEqualTo(0)
 			->integer($score->getFailNumber())->isEqualTo(1)
 			->array($score->getFailAssertions())->isEqualTo(array(
@@ -458,7 +457,7 @@ class phpArray extends atoum\test
 						'file' => __FILE__,
 						'line' => $line,
 						'asserter' => get_class($asserter) . '::strictlyContainsValues()',
-						'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array(6)))
+						'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(6)))
 					)
 				)
 			)
@@ -468,7 +467,7 @@ class phpArray extends atoum\test
         $this->assert
             ->exception(function() use (& $line, $asserter, & $notInArray) { $line = __LINE__; $asserter->strictlyContainsValues(array("6")); })
                 ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                ->hasMessage(sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array("6"))))
+                ->hasMessage(sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array("6"))))
             ->integer($score->getPassNumber())->isEqualTo(0)
             ->integer($score->getFailNumber())->isEqualTo(1)
             ->array($score->getFailAssertions())->isEqualTo(array(
@@ -479,7 +478,7 @@ class phpArray extends atoum\test
                         'file' => __FILE__,
                         'line' => $line,
                         'asserter' => get_class($asserter) . '::strictlyContainsValues()',
-                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array("6")))
+                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array("6")))
                     )
                 )
             )
@@ -489,7 +488,7 @@ class phpArray extends atoum\test
         $this->assert
             ->exception(function() use (& $line, $asserter, & $notInArray) { $line = __LINE__; $asserter->strictlyContainsValues(array("1")); })
                 ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                ->hasMessage(sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array("1"))))
+                ->hasMessage(sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array("1"))))
             ->integer($score->getPassNumber())->isEqualTo(0)
             ->integer($score->getFailNumber())->isEqualTo(1)
             ->array($score->getFailAssertions())->isEqualTo(array(
@@ -500,7 +499,7 @@ class phpArray extends atoum\test
                         'file' => __FILE__,
                         'line' => $line,
                         'asserter' => get_class($asserter) . '::strictlyContainsValues()',
-                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array("1")))
+                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array("1")))
                     )
                 )
             )
@@ -524,7 +523,7 @@ class phpArray extends atoum\test
         $this->assert
                 ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->strictlyContainsValues(array("1", 2, "4")); })
                     ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array("1", "4"))))
+                    ->hasMessage(sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array("1", "4"))))
                 ->integer($score->getPassNumber())->isEqualTo(0)
                 ->integer($score->getFailNumber())->isEqualTo(1)
                 ->array($score->getFailAssertions())->isEqualTo(array(
@@ -535,124 +534,125 @@ class phpArray extends atoum\test
                             'file' => __FILE__,
                             'line' => $line,
                             'asserter' => get_class($asserter) . '::strictlyContainsValues()',
-                            'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array("1", "4")))
+                            'fail' => $failMessage = sprintf($test->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array("1", "4")))
                         )
                     )
                 )
             ;
 	}
 
-    public function testStrictlyNotContainsValues()
-    {
-        $asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
+	public function testStrictlyNotContainsValues()
+	{
+		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
-        $this->assert
-            ->boolean($asserter->wasSet())->isFalse()
-            ->exception(function() use ($asserter) {
-                    $asserter->contains(uniqid());
-                }
-            )
-                ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-                ->hasMessage('Array is undefined')
-        ;
+		$this->assert
+			->boolean($asserter->wasSet())->isFalse()
+			->exception(function() use ($asserter) {
+					$asserter->contains(uniqid());
+					}
+					)
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Array is undefined')
+			;
 
-        $asserter->setWith(array(1, 2, 3, 4, 5));
+		$asserter->setWith(array(1, 2, 3, 4, 5));
 
-        $score->reset();
+		$score->reset();
 
-        $this->assert
-            ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->strictlyNotContainsValues(array(1)); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                ->hasMessage(sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1))))
-            ->integer($score->getPassNumber())->isEqualTo(0)
-            ->integer($score->getFailNumber())->isEqualTo(1)
-            ->array($score->getFailAssertions())->isEqualTo(array(
-                    array(
-                        'case' => null,
-                        'class' => __CLASS__,
-                        'method' => $test->getCurrentMethod(),
-                        'file' => __FILE__,
-                        'line' => $line,
-                        'asserter' => get_class($asserter) . '::strictlyNotContainsValues()',
-                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1)))
-                    )
-                )
-            )
-        ;
+		$this->assert
+			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->strictlyNotContainsValues(array(1)); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1))))
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1)
+			->array($score->getFailAssertions())->isEqualTo(array(
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::strictlyNotContainsValues()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1)))
+							)
+						)
+					)
+			;
 
-        $score->reset();
-        $this->assert
-            ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->strictlyNotContainsValues(array(1, "2", 3)); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                ->hasMessage(sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1, 3))))
-            ->integer($score->getPassNumber())->isEqualTo(0)
-            ->integer($score->getFailNumber())->isEqualTo(1)
-            ->array($score->getFailAssertions())->isEqualTo(array(
-                    array(
-                        'case' => null,
-                        'class' => __CLASS__,
-                        'method' => $test->getCurrentMethod(),
-                        'file' => __FILE__,
-                        'line' => $line,
-                        'asserter' => get_class($asserter) . '::strictlyNotContainsValues()',
-                        'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1, 3)))
-                    )
-                )
-            )
-        ;
+		$score->reset();
+		$this->assert
+			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->strictlyNotContainsValues(array(1, "2", 3)); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1, 3))))
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1)
+			->array($score->getFailAssertions())->isEqualTo(array(
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::strictlyNotContainsValues()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1, 3)))
+							)
+						)
+					)
+			;
 
-        $score->reset();
-        $this->assert
-            ->object($asserter->strictlyNotContainsValues(array("1")))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0)
-        ;
+		$score->reset();
+		$this->assert
+			->object($asserter->strictlyNotContainsValues(array("1")))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0)
+			;
 
-        $score->reset();
-        $this->assert
-            ->object($asserter->strictlyNotContainsValues(array(6, 7, "2", 8)))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0)
-        ;
-    }
+		$score->reset();
+		$this->assert
+			->object($asserter->strictlyNotContainsValues(array(6, 7, "2", 8)))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0)
+			;
+	}
 
-    public function testStrictlyContains ()
-    {
-        $asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
+	public function testStrictlyContains ()
+	{
+		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
-        $asserter->setWith(array(1));
-        $score->reset();
-        $this->assert
-            ->exception(function() use ($asserter) {$asserter->strictlyContains('1'); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
-            ->integer($score->getPassNumber())->isEqualTo(0)
-            ->integer($score->getFailNumber())->isEqualTo(1);
-        
-        $score->reset();
-        $this->assert
-            ->object($asserter->strictlyContains(1))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0);
-    }
+		$asserter->setWith(array(1));
+		$score->reset();
+		$this->assert
+			->exception(function() use ($asserter) {$asserter->strictlyContains('1'); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1);
 
-    public function testStrictlyNotContains ()
-    {
-        $asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
+		$score->reset();
+		$this->assert
+			->object($asserter->strictlyContains(1))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0);
+	}
 
-        $asserter->setWith(array(1));
-        $score->reset();
-        $this->assert
-            ->exception(function() use ($asserter) {$asserter->strictlyNotContains(1); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
-            ->integer($score->getPassNumber())->isEqualTo(0)
-            ->integer($score->getFailNumber())->isEqualTo(1);
+	public function testStrictlyNotContains ()
+	{
+		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
-        $score->reset();
-        $this->assert
-            ->object($asserter->strictlyNotContains('1'))->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(0);
-    }
+		$asserter->setWith(array(1));
+
+		$score->reset();
+		$this->assert
+			->exception(function() use ($asserter) {$asserter->strictlyNotContains(1); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1);
+
+		$score->reset();
+		$this->assert
+			->object($asserter->strictlyNotContains('1'))->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0);
+	}
 
 	public function testNotContains()
 	{
@@ -707,19 +707,19 @@ class phpArray extends atoum\test
         ;
 	}
 
-    public function testHasKey ()
-    {
+	public function testHasKey ()
+	{
 		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
 		$this->assert
 			->boolean($asserter->wasSet())->isFalse()
 			->exception(function() use ($asserter) {
 					$asserter->hasSize(rand(0, PHP_INT_MAX));
-				}
-			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
-				->hasMessage('Array is undefined')
-		;
+					}
+					)
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Array is undefined')
+			;
 
 		$asserter->setWith(array());
 
@@ -727,23 +727,23 @@ class phpArray extends atoum\test
 
 		$this->assert
 			->exception(function() use (& $line, $asserter, & $key) { $line = __LINE__; $asserter->hasKey($key = rand(1, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
-				->hasMessage(sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key)))
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key)))
 			->integer($score->getPassNumber())->isEqualTo(0)
 			->integer($score->getFailNumber())->isEqualTo(1)
 			->array($score->getFailAssertions())->isEqualTo(array(
-					array(
-						'case' => null,
-						'class' => __CLASS__,
-						'method' => $test->getCurrentMethod(),
-						'file' => __FILE__,
-						'line' => $line,
-						'asserter' => get_class($asserter) . '::hasKey()',
-						'fail' => $failMessage = sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key))
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::hasKey()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key))
+							)
+						)
 					)
-				)
-			)
-		;
+			;
 
 		$asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid()));
 
@@ -766,197 +766,197 @@ class phpArray extends atoum\test
 			->integer($score->getPassNumber())->isEqualTo(5)
 			->integer($score->getFailNumber())->isEqualTo(0)
 			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasKey(5); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
-				->hasMessage(sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf(5)))
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf(5)))
 			->integer($score->getPassNumber())->isEqualTo(5)
 			->integer($score->getFailNumber())->isEqualTo(1)
 			->array($score->getFailAssertions())->isEqualTo(array(
-					array(
-						'case' => null,
-						'class' => __CLASS__,
-						'method' => $test->getCurrentMethod(),
-						'file' => __FILE__,
-						'line' => $line,
-						'asserter' => get_class($asserter) . '::hasKey()',
-						'fail' => $failMessage = sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf(5))
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::hasKey()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf(5))
+							)
+						)
 					)
-				)
-			)
-		;
-    }
+			;
+	}
 
-    public function testNotHasKey ()
-    {
+	public function testNotHasKey ()
+	{
 		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
 		$this->assert
 			->boolean($asserter->wasSet())->isFalse()
 			->exception(function() use ($asserter) {
 					$asserter->hasSize(rand(0, PHP_INT_MAX));
-				}
-			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
-				->hasMessage('Array is undefined')
-		;
+					}
+					)
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Array is undefined')
+			;
 
 		$asserter->setWith(array());
 
 		$score->reset();
 		$this->assert
-                ->object($asserter->notHasKey(1))
-                    ->isIdenticalTo($asserter)
-                ->integer($score->getPassNumber())->isEqualTo(1)
-                ->integer($score->getFailNumber())->isEqualTo(0);
+			->object($asserter->notHasKey(1))
+			->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0);
 
 		$asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid()));
 
 		$score->reset();
 		$this->assert
 			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->notHasKey(0); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
-				->hasMessage(sprintf($test->getLocale()->_('%s has a key %s'), $asserter, $asserter->getTypeOf(0)))
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s has a key %s'), $asserter, $asserter->getTypeOf(0)))
 			->integer($score->getPassNumber())->isEqualTo(0)
 			->integer($score->getFailNumber())->isEqualTo(1)
 			->array($score->getFailAssertions())->isEqualTo(array(
-					array(
-						'case' => null,
-						'class' => __CLASS__,
-						'method' => $test->getCurrentMethod(),
-						'file' => __FILE__,
-						'line' => $line,
-						'asserter' => get_class($asserter) . '::notHasKey()',
-						'fail' => $failMessage = sprintf($test->getLocale()->_('%s has a key %s'), $asserter, $asserter->getTypeOf(0))
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::notHasKey()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s has a key %s'), $asserter, $asserter->getTypeOf(0))
+							)
+						)
 					)
-				)
-			)
-            ->object($asserter->notHasKey(5))
-                ->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(1);
+			->object($asserter->notHasKey(5))
+			->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(1);
 		;
-    }
+	}
 
-    public function testNotHasKeys ()
-    {
+	public function testNotHasKeys ()
+	{
 		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
 		$this->assert
 			->boolean($asserter->wasSet())->isFalse()
 			->exception(function() use ($asserter) {
 					$asserter->hasSize(rand(0, PHP_INT_MAX));
-				}
-			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
-				->hasMessage('Array is undefined')
-		;
+					}
+					)
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Array is undefined')
+			;
 
 		$asserter->setWith(array());
 
 		$score->reset();
 		$this->assert
-                ->object($asserter->notHasKeys(array(1)))
-                    ->isIdenticalTo($asserter)
-                ->integer($score->getPassNumber())->isEqualTo(1)
-                ->integer($score->getFailNumber())->isEqualTo(0);
+			->object($asserter->notHasKeys(array(1)))
+			->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0);
 
-        $score->reset();
-        $this->assert
-                ->object($asserter->notHasKeys(array(0, 1)))
-                    ->isIdenticalTo($asserter)
-                ->integer($score->getPassNumber())->isEqualTo(1)
-                ->integer($score->getFailNumber())->isEqualTo(0);
+		$score->reset();
+		$this->assert
+			->object($asserter->notHasKeys(array(0, 1)))
+			->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(0);
 
 		$asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid()));
 
 		$score->reset();
 		$this->assert
 			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->notHasKeys(array(0, "premier", 2)); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
-				->hasMessage(sprintf($test->getLocale()->_('%s should not have keys %s'), $asserter, $asserter->getTypeOf(array(0, 2))))
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should not have keys %s'), $asserter, $asserter->getTypeOf(array(0, 2))))
 			->integer($score->getPassNumber())->isEqualTo(0)
 			->integer($score->getFailNumber())->isEqualTo(1)
 			->array($score->getFailAssertions())->isEqualTo(array(
-					array(
-						'case' => null,
-						'class' => __CLASS__,
-						'method' => $test->getCurrentMethod(),
-						'file' => __FILE__,
-						'line' => $line,
-						'asserter' => get_class($asserter) . '::notHasKeys()',
-						'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not have keys %s'), $asserter, $asserter->getTypeOf(array(0, 2)))
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::notHasKeys()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should not have keys %s'), $asserter, $asserter->getTypeOf(array(0, 2)))
+							)
+						)
 					)
-				)
-			)
-            ->object($asserter->notHasKeys(array(5, "6")))
-                ->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(1);
+			->object($asserter->notHasKeys(array(5, "6")))
+			->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(1);
 		;
-    }
+	}
 
-    public function testHasKeys ()
-    {
+	public function testHasKeys ()
+	{
 		$asserter = new asserters\phpArray(new asserter\generator($test = new self($score = new atoum\score())));
 
 		$this->assert
 			->boolean($asserter->wasSet())->isFalse()
 			->exception(function() use ($asserter) {
 					$asserter->hasSize(rand(0, PHP_INT_MAX));
-				}
-			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
-				->hasMessage('Array is undefined')
-		;
+					}
+					)
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Array is undefined')
+			;
 
 		$asserter->setWith(array());
 
 		$score->reset();
 		$this->assert
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasKeys(array(0)); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array(0))))
-                ->integer($score->getPassNumber())->isEqualTo(0)
-                ->integer($score->getFailNumber())->isEqualTo(1)
-                ->array($score->getFailAssertions())->isEqualTo(array(
-                        array(
-                            'case' => null,
-                            'class' => __CLASS__,
-                            'method' => $test->getCurrentMethod(),
-                            'file' => __FILE__,
-                            'line' => $line,
-                            'asserter' => get_class($asserter) . '::hasKeys()',
-                            'fail' => $failMessage = sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array(2)))
-                        )
-                    )
-                );
+			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasKeys(array(0)); })
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array(0))))
+			->integer($score->getPassNumber())->isEqualTo(0)
+			->integer($score->getFailNumber())->isEqualTo(1)
+			->array($score->getFailAssertions())->isEqualTo(array(
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::hasKeys()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array(2)))
+							)
+						)
+					);
 
 		$asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid()));
 
 		$score->reset();
 		$this->assert
 			->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasKeys(array(0, "first", 2, "second")); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
-				->hasMessage(sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array("first", "second"))))
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array("first", "second"))))
 			->integer($score->getPassNumber())->isEqualTo(0)
 			->integer($score->getFailNumber())->isEqualTo(1)
 			->array($score->getFailAssertions())->isEqualTo(array(
-					array(
-						'case' => null,
-						'class' => __CLASS__,
-						'method' => $test->getCurrentMethod(),
-						'file' => __FILE__,
-						'line' => $line,
-						'asserter' => get_class($asserter) . '::hasKeys()',
-						'fail' => $failMessage = sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array("first", "second")))
+						array(
+							'case' => null,
+							'class' => __CLASS__,
+							'method' => $test->getCurrentMethod(),
+							'file' => __FILE__,
+							'line' => $line,
+							'asserter' => get_class($asserter) . '::hasKeys()',
+							'fail' => $failMessage = sprintf($test->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array("first", "second")))
+							)
+						)
 					)
-				)
-			)
-            ->object($asserter->hasKeys(array(0, 2, 4)))
-                ->isIdenticalTo($asserter)
-            ->integer($score->getPassNumber())->isEqualTo(1)
-            ->integer($score->getFailNumber())->isEqualTo(1);
+			->object($asserter->hasKeys(array(0, 2, 4)))
+			->isIdenticalTo($asserter)
+			->integer($score->getPassNumber())->isEqualTo(1)
+			->integer($score->getFailNumber())->isEqualTo(1);
 		;
-    }
+	}
 }
 
 ?>


### PR DESCRIPTION
on phpArray, new asserters : 
- containsValues
- notContainsValues
- strictlyContainsValues
- strictlyNotContainsValues
- strictlyContains
- strictlyNotContains
- hasKey
- notHasKey
- hasKeys
- notHasKeys

Compatibility break : Removal of atKey()
