### PR TITLE
Fixed error message with import of a configuration file

### DIFF
--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -345,7 +345,7 @@ class runner extends atoum\script
 					}
 					catch (\exception $exception)
 					{
-						throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Configuration file \'%s\' does not exist'), $path));
+						throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_("Unable to import the configuration file '%s'\n\t%s"), $path, $exception->getMessage()));
 					}
 				}
 			},


### PR DESCRIPTION
When an exception is thrown during the import of a config file, the message is:

> Configuration file '.atoum.php' does not exist

This is wrong, my config file exists but an exception was throw.
Also, we need to see exception that occurred in order to fix quickly (without need to hack atoum).
