### PR TITLE
ReflectionException when invoking atoum

### DIFF
--- a/classes/factory.php
+++ b/classes/factory.php
@@ -63,7 +63,14 @@ class factory
 					self::$classes[$class] = new \reflectionClass($class);
 				}
 
-				$instance = self::$classes[$class]->newInstanceArgs($arguments);
+                try
+                {
+                    $instance = self::$classes[$class]->newInstanceArgs($arguments);
+                }
+                catch(\ReflectionException $e)
+                {
+                    $instance = self::$classes[$class]->newInstance();
+                }
 			}
 		}
 


### PR DESCRIPTION
Each time I try to invoke atoum by using either the Phar or the runner script, I get a ReflectionException :

```
PHP Fatal error:  Uncaught exception 'ReflectionException' with message 'Class mageekguy\atoum\adapter does not have a constructor, so you cannot pass any constructor arguments' in phar:///usr/share/php/mageekguy.atoum.phar/1/classes/factory.php:66
Stack trace:
#0 phar:///usr/share/php/mageekguy.atoum.phar/1/classes/factory.php(66): ReflectionClass->newInstanceArgs(Array)
#1 phar:///usr/share/php/mageekguy.atoum.phar/1/classes/script.php(32): mageekguy\atoum\factory->build('atoum\adapter')
#2 phar:///usr/share/php/mageekguy.atoum.phar/1/classes/scripts/runner.php(31): mageekguy\atoum\script->__construct('/usr/share/php/...', NULL)
#3 phar:///usr/share/php/mageekguy.atoum.phar/1/classes/scripts/runner.php(244): mageekguy\atoum\scripts\runner->__construct('/usr/share/php/...')
#4 /usr/share/php/mageekguy.atoum.phar(27): mageekguy\atoum\scripts\runner::autorun('/usr/share/php/...')
#5 /home/jubianchi/Applications/atoum(3): include('/usr/share/php/...')
#6 {main}
thrown in phar:///usr/share/php/mageekguy.atoum.phar/1/classes/factory.php on line 66
```

Here is the configuration I used :
- PHP 5.3.2-1ubuntu4.11 with Suhosin-Patch (cli)
- Xdebug v2.0.5
- phar.readonly => On => On / phar.readonly => Off => Off
- Ubuntu 10.04 (lucid) x86 Kernel 2.6.32-37-generic
- mageek.atoum.phar located in /usr/share/php/mageekguy.atoum.phar

Tested with atoum's sources and Phar archive 
