### PR TITLE
Allow a config file anywhere in the file tree

### DIFF
--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -183,11 +183,22 @@ class runner extends atoum\script
 
 	public function useDefaultConfigFile()
 	{
-		try
+		$searchPath = realpath(atoum\directory);
+
+		do
 		{
-			$this->useConfigFile(atoum\directory . '/' . self::defaultConfigFile);
+			try
+			{
+				$this->useConfigFile(realpath($searchPath . '/' . self::defaultConfigFile));
+			}
+			catch (atoum\includer\exception $exception) {};
+
+			if ($searchPath == '/')
+			{
+				break;
+			}
 		}
-		catch (atoum\includer\exception $exception) {};
+		while ($searchPath = dirname($searchPath));
 
 		return $this;
 	}

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -293,7 +293,7 @@ class runner extends atoum\test
 
 		$this->assert
 			->object($runner->useDefaultConfigFile())->isIdenticalTo($runner)
-			->mock($runner)->call('useConfigFile')->withArguments(atoum\directory . '/' . scripts\runner::defaultConfigFile)->once()
+			->mock($runner)->call('useConfigFile')->withAnyArguments()->exactly(substr_count(atoum\directory, '/') + 1)
 		;
 	}
 }


### PR DESCRIPTION
not really happy with the unit test, but didn't know how to do it better :/

not really happy with useDefaultConfigFile implementation either actually, but the obvious other way (`do { ... } while (strlen($searchPath = dirname($searchPath)) > 1);`) would skip `/`
