### PR TITLE
Allows wildcard feature for directory argument.

### DIFF
--- a/classes/runner.php
+++ b/classes/runner.php
@@ -454,9 +454,25 @@ class runner implements observable, adapter\aggregator
 
 	public function addTestsFromDirectory($directory)
 	{
+		$wildcard = strpos($directory, '*');
+		if ($wildcard > 0)
+		{
+			$directory = rtrim($directory, DIRECTORY_SEPARATOR.'*');
+		    while(substr($directory, --$wildcard, 1) != DIRECTORY_SEPARATOR);
+
+		    $basePathname = substr($directory, 0, $wildcard);
+		    $subPatterns = explode('/', ltrim(str_replace($basePathname, '', $directory), DIRECTORY_SEPARATOR));
+
+		    $filteredDirectoryIterator = new atoum\src\iterator\wildcardfilter(new \recursiveDirectoryIterator($basePathname), $basePathname, $subPatterns);
+		}
+		else
+		{
+			$filteredDirectoryIterator = new atoum\src\iterator\filter(new \recursiveDirectoryIterator($directory));
+		}
+
 		try
 		{
-			foreach (new \recursiveIteratorIterator(new atoum\src\iterator\filter(new \recursiveDirectoryIterator($directory))) as $path)
+			foreach (new \recursiveIteratorIterator($filteredDirectoryIterator) as $path)
 			{
 				$this->addTest($path);
 			}

--- a/classes/src/iterator/wildcardfilter.php
+++ b/classes/src/iterator/wildcardfilter.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace mageekguy\atoum\src\iterator;
+
+use
+    mageekguy\atoum
+;
+
+/**
+ * Wildcard filter
+ *
+ * Class that allow directory argument to be specified with a wildcard parameter.
+ * It does not support custom regex and double wildcard marker.
+ */
+class wildcardFilter extends \recursiveFilterIterator
+{
+    /**
+     * @var string The base pattern (path) without delimiter
+     */
+    protected $basePattern;
+
+    /**
+     * @var string The pattern with delimiter
+     */
+    protected $pattern;
+
+    /**
+     * @var array A list of children pattern
+     */
+    protected $subPatterns;
+
+    /**
+     * __construct
+     *
+     * Initialize the current pattern for the iterator
+     *
+     * @param \RecursiveIterator $iterator    RecursiveFilterIterator implementation
+     * @param string             $basePattern Base parent pattern (parent path)
+     * @param array              $subPatterns List of all children patterns
+     */
+    public function __construct(\RecursiveIterator $iterator, $basePattern, array $subPatterns)
+    {
+        // Append children pattern & remove it from the subPatterns list.
+        // If no more children are available/specified, allows everything not starting by a dot.
+        $childrenPattern = array_shift($subPatterns);
+        $this->basePattern .= ($childrenPattern === null)
+                           ? DIRECTORY_SEPARATOR.'[^\.]{0}.*'
+                           : DIRECTORY_SEPARATOR.str_replace('*', '(?=[^\.])[^/]*', $childrenPattern);
+
+        // Add delimiter to the basePattern (optimization to avoid on-the-fly concatenation in the accept method)
+        $this->pattern = '#^'.$this->basePattern.'$#';
+
+        // Store subpattern to pass them into further nested filter
+        $this->subPatterns = $subPatterns;
+
+        parent::__construct($iterator);
+    }
+
+    public function accept(\splFileInfo $file = null)
+    {
+        if ($file === null)
+        {
+            $file = $this->getInnerIterator()->current();
+        }
+
+        return (preg_match($this->pattern, $file->getPathname()) > 0);
+    }
+
+    public function getChildren()
+    {
+        return new self ($this->getInnerIterator()->getChildren(), $this->basePattern, $this->subPatterns);
+    }
+}


### PR DESCRIPTION
Refacto of the previous [pull request #63](https://github.com/mageekguy/atoum/pull/63) and refs the issue #61

The feature is simpler: 
- it supports **only wildcard** parameter.
- it uses the directory argument command (instead of filter)

Usages:

``` bash
$ bin/atoum -d src/*/tests/units
$ bin/atoum -d  src/*Project/tests/units
$ bin/atoum -d src/*/*/*/tests/my*project/subdir
```

Limitations:
- it does not support full regex pattern.
- it does not support double wildcard notation like `dir/**/subdir`
