### PR TITLE
Replace absolute path by relative path for html coverage report

### DIFF
--- a/classes/report/fields/runner/coverage/html.php
+++ b/classes/report/fields/runner/coverage/html.php
@@ -170,6 +170,7 @@ class html extends report\fields\runner\coverage\cli
 				$classTemplate = $this->templateParser->parseFile($this->templatesDirectory . '/class.tpl');
 
 				$classTemplate->rootUrl = $this->rootUrl;
+				$classTemplate->relativeRootUrl = str_repeat('../', substr_count($className, '\\'));
 				$classTemplate->projectName = $this->projectName;
 
 				$classCoverageAvailableTemplates = $classTemplate->classCoverageAvailable;

--- a/resources/templates/coverage/class.tpl
+++ b/resources/templates/coverage/class.tpl
@@ -5,11 +5,11 @@
 		<meta http-equiv="Content-Language" content="en" />
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title><tpl:projectName /> : code coverage of <tpl:className /></title>
-		<link rel="stylesheet" media="screen" type="text/css" href="<tpl:rootUrl />screen.css" title="Screen" />
+		<link rel="stylesheet" media="screen" type="text/css" href="<tpl:relativeRootUrl />screen.css" title="Screen" />
 	</head>
 	<body>
 		<div id="page">
-			<h1><a href="<tpl:rootUrl />"><tpl:projectName /></a> :  code coverage of <tpl:className /></h1>
+			<h1><a href="<tpl:relativeRootUrl />"><tpl:projectName /></a> :  code coverage of <tpl:className /></h1>
 			<div id="content">
 				<ul class="classSummary">
 					<li class="class">

--- a/resources/templates/coverage/index.tpl
+++ b/resources/templates/coverage/index.tpl
@@ -5,7 +5,7 @@
 		<meta http-equiv="Content-Language" content="en" />
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title>Code coverage of <tpl:projectName /></title>
-		<link rel="stylesheet" media="screen" type="text/css" href="<tpl:rootUrl />screen.css" title="Screen" />
+		<link rel="stylesheet" media="screen" type="text/css" href="screen.css" title="Screen" />
 	</head>
 	<body>
 		<div id="page">
@@ -32,14 +32,14 @@
 								<li>
 									<tpl:classCoverageUnavailable>
 										<div class="bar">
-											<div class="label"><a href="<tpl:rootUrl /><tpl:classUrl />"><tpl:className /></a> <span>n/a</span></div>
+											<div class="label"><a href="<tpl:classUrl />"><tpl:className /></a> <span>n/a</span></div>
 										</div>
 									</tpl:classCoverageUnavailable>
 									<tpl:classCoverageAvailable>
 									<div class="bar">
 										<div class="background"></div>
 										<div class="graph" style="width: <tpl:classCoverageValue />%"></div>
-										<div class="label"><a href="<tpl:rootUrl /><tpl:classUrl />"><tpl:className /></a> <span><tpl:classCoverageValue />%</span></div>
+										<div class="label"><a href="<tpl:classUrl />"><tpl:className /></a> <span><tpl:classCoverageValue />%</span></div>
 									</div>
 									</tpl:classCoverageAvailable>
 								</li>


### PR DESCRIPTION
It's could be better to rely on relative path for html report, for example in jenkins CI, url of the report is dynamic (with the build number inside). At the moment, I don't see any regression to go relative.

I didn't remove the rootPath argument because it's used to display the link in the CLI report.

NB: it also works in local (file://).
