### PR TITLE
Add "contains" method to the string asserter

### DIFF
--- a/classes/asserters/string.php
+++ b/classes/asserters/string.php
@@ -112,18 +112,18 @@ class string extends variable
 		return $this;
 	}
 
-    public function contains($fragment)
-    {
-        if(strpos($this->valueIsSet()->value, $fragment) !== false)
-        {
-            $this->pass();
-        }
-        else
-        {
-            $this->fail(sprintf($this->getLocale()->_('String does not contain %s'), $fragment));
-        }
-        return $this;
-    }
+	public function contains($fragment, $failMessage = null)
+	{
+		if (strpos($this->valueIsSet()->value, $fragment) !== false)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('String does not contain %s'), $fragment));
+		}
+		return $this;
+	}
 
 	protected static function check($value, $method)
 	{

--- a/tests/units/classes/asserters/string.php
+++ b/tests/units/classes/asserters/string.php
@@ -170,31 +170,31 @@ class string extends atoum\test
 		;
 	}
 
-    public function testContains()
-    {
-        $this
-            ->if($asserter = new asserters\string($generator = new asserter\generator()))
-            ->then
-            ->exception(function() use ($asserter)
-        {
-            $asserter->contains('fragment');
-        })
-            ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-            ->hasMessage('Value is undefined')
-            ->if($asserter->setWith('string'))
-            ->and($diff = new diffs\variable())
-            ->then
-            ->exception(function() use ($asserter, & $fragment)
-        {
-            $asserter->contains($fragment = 'fragment');
-        })
-            ->isInstanceOf('mageekguy\atoum\asserter\exception')
-            ->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
-            ->object($asserter->contains('string'))->isIdenticalTo($asserter)
-            ->if($asserter->setWith($string = 'string'))
-            ->then
-            ->object($asserter->contains('string'))->isIdenticalTo($asserter);
-    }
+	public function testContains()
+	{
+		$this
+			->if($asserter = new asserters\string($generator = new asserter\generator()))
+			->then
+			->exception(function() use ($asserter)
+		{
+			$asserter->contains('fragment');
+		})
+			->isInstanceOf('mageekguy\atoum\exceptions\logic')
+			->hasMessage('Value is undefined')
+			->if($asserter->setWith('string'))
+			->and($diff = new diffs\variable())
+			->then
+			->exception(function() use ($asserter, & $fragment)
+		{
+			$asserter->contains($fragment = 'fragment');
+		})
+			->isInstanceOf('mageekguy\atoum\asserter\exception')
+			->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
+			->object($asserter->contains('string'))->isIdenticalTo($asserter)
+			->if($asserter->setWith($string = 'string'))
+			->then
+			->object($asserter->contains('string'))->isIdenticalTo($asserter);
+	}
 }
 
 ?>


### PR DESCRIPTION
I recently had to check some string was contained in another one. I found using the "match" method a bit cumbersome so I propose to add a simple "contains" method to the string asserter.
