### PR TITLE
Remove mageekguy from the atoum namespace

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -13,15 +13,15 @@ Currently, unit test is the documentation.
 You find them in path/to/atoum/tests/units.
 We work to write a real documentation and if you want to help to .
 
-* Why php mageekguy.atoum.phar does not works ?
-Try a "php -n mageekguy.atoum.phar" in a terminal.
+* Why php atoum.phar does not works ?
+Try a "php -n atoum.phar" in a terminal.
 If it works, the problem is in your PHP configuration.
 Try to remove ioncube extension, which seems not compatible with atoum.
 If you use suhosin, you can also add "suhosin.executor.include.whitelist="phar"" to your php.ini.
 Try to add "detect_unicode=0" in your php.ini.
 
 * What can i do to avoid error about __COMPILER_HALT_OFFSET__ ?
-Use only require_once to include mageekguy.atoum.phar in your scripts.
+Use only require_once to include atoum.phar in your scripts.
 
 * Why I get a fail message when testing a class that uses APC ?
 APC is "a free, open, and robust framework for caching and optimizing PHP intermediate code" (http://fr.php.net/manual/en/apc.configuration.php) distributed under the form of a PHP extension.

--- a/README.markdown
+++ b/README.markdown
@@ -2,40 +2,40 @@
 
 ## A simple, modern and intuitive unit testing framework for PHP!
 
-Just like SimpleTest or PHPUnit, *atoum* is a unit testing framework specific to the [PHP](http://www.php.net) language.  
+Just like SimpleTest or PHPUnit, *atoum* is a unit testing framework specific to the [PHP](http://www.php.net) language.
 However, it has been designed from the start with the following ideas in mind :
 
 * Can be implemented *rapidly* ;
 * *Simplify* test development ;
 * Allow for writing *reliable, readable, and clear* unit tests ;
 
-To accomplish that, it massively uses capabilities provided by *PHP 5.3*, to give the developer *a whole new way* of writing unit tests.  
-Therefore, it can be installed and integrated inside an existing project extremely easily, since it is only a *single PHAR archive*, which is the one and only entry point for the developper.  
-Also, thanks to its *fluid interface*, it allows for writing unit tests in a fashion close to natural language.  
-It also makes it easier to implement stubbing within tests, thanks to intelligent uses of *anonymous functions and closures*.  
-*atoum* natively, and by default, performs the execution of each unit test within a separate [PHP](http://www.php.net) process, to warrant *isolation*.  
-Of course, it can be used seamlessly for continuous integration, and given its design, it can be made to cope with specific needs extremely easily.  
-*atoum* also accomplishes all of this without affecting performance, since it has been developed to boast a reduced memory footprint while allowing for hastened test execution.  
-It can also generate unit test execution reports in the Xunit format, which makes it compatible with continuous integration tools such as [Jenkins](http://jenkins-ci.org/).  
-*atoum* also generates code coverage reports, in order to make it possible to supervise unit tests.  
-Finally, even though it is developed mainly on UNIX, it can also work on Windows.  
+To accomplish that, it massively uses capabilities provided by *PHP 5.3*, to give the developer *a whole new way* of writing unit tests.
+Therefore, it can be installed and integrated inside an existing project extremely easily, since it is only a *single PHAR archive*, which is the one and only entry point for the developper.
+Also, thanks to its *fluid interface*, it allows for writing unit tests in a fashion close to natural language.
+It also makes it easier to implement stubbing within tests, thanks to intelligent uses of *anonymous functions and closures*.
+*atoum* natively, and by default, performs the execution of each unit test within a separate [PHP](http://www.php.net) process, to warrant *isolation*.
+Of course, it can be used seamlessly for continuous integration, and given its design, it can be made to cope with specific needs extremely easily.
+*atoum* also accomplishes all of this without affecting performance, since it has been developed to boast a reduced memory footprint while allowing for hastened test execution.
+It can also generate unit test execution reports in the Xunit format, which makes it compatible with continuous integration tools such as [Jenkins](http://jenkins-ci.org/).
+*atoum* also generates code coverage reports, in order to make it possible to supervise unit tests.
+Finally, even though it is developed mainly on UNIX, it can also work on Windows.
 
 ## Prerequisites to use *atoum*
 
-*atoum* absolutely requires *PHP 5.3* or later to work.  
-Should you want to use *atoum* using its PHAR archive, you also need [PHP](http://www.php.net) to be able to access the `phar` module, which is normally available by default.  
+*atoum* absolutely requires *PHP 5.3* or later to work.
+Should you want to use *atoum* using its PHAR archive, you also need [PHP](http://www.php.net) to be able to access the `phar` module, which is normally available by default.
 On UNIX, in order to check whether you have this module or not, you just need to run the following command in your terminal :
 
 	# php -m | grep -i phar
 
-If `Phar` or equivalent gets displayed, then the module is properly installed.  
-Generating reports in the Xunit format requires the `xml` module.  
+If `Phar` or equivalent gets displayed, then the module is properly installed.
+Generating reports in the Xunit format requires the `xml` module.
 On UNIX, in order to check whether you have this module or not, you just need to run the following command in your terminal :
 
 	# php -m | grep -i xml
 
-If `Xml` or equivalent gets displayed, then the module is properly installed.  
-Should you wish to monitor the coverage rate of your code by the unit tests, the [Xdebug](http://xdebug.org/) will be required.  
+If `Xml` or equivalent gets displayed, then the module is properly installed.
+Should you wish to monitor the coverage rate of your code by the unit tests, the [Xdebug](http://xdebug.org/) will be required.
 On UNIX, in order to check whether you have this module or not, you just need to run the following command in your terminal :
 
 	# php -m | grep -i xdebug
@@ -46,13 +46,13 @@ If `Xdebug` or equivalent gets displayed, then the module is properly installed.
 
 ### Step 1 : Install *atoum*
 
-You just have to download [its PHAR archive](http://downloads.atoum.org/nightly/mageekguy.atoum.phar) and store it where you wish, for example under `/path/to/project/tests/mageekguy.atoum.phar`.  
-This PHAR archive contains the latest development version to pass the totality of *atoum*'s unit tests.  
-*atoum*'s source code is also available via [the github repository](https://github.com/mageekguy/atoum).  
-To check if *atoum* works correctly with your configuration, you can execute all its unit tests.  
+You just have to download [its PHAR archive](http://downloads.atoum.org/nightly/atoum.phar) and store it where you wish, for example under `/path/to/project/tests/atoum.phar`.
+This PHAR archive contains the latest development version to pass the totality of *atoum*'s unit tests.
+*atoum*'s source code is also available via [the github repository](https://github.com/mageekguy/atoum).
+To check if *atoum* works correctly with your configuration, you can execute all its unit tests.
 To do that, you just need to run the following command in your terminal :
 
-	# php mageekguy.atoum.phar --testIt
+	# php atoum.phar --testIt
 
 ### Step 2 : Write your tests
 
@@ -63,11 +63,11 @@ Using your preferred text editor, create the file `path/to/project/tests/units/h
 
 namespace vendor\project\tests\units;
 
-require_once 'path/to/mageekguy.atoum.phar';
+require_once 'path/to/atoum.phar';
 
 include 'path/to/project/classes/helloWorld.php';
 
-use \mageekguy\atoum;
+use \atoum;
 use \vendor\project;
 
 class helloWorld extends atoum\test
@@ -141,11 +141,11 @@ You should get the following result, or something equivalent :
 
 namespace vendor\project\tests\units;
 
-require_once 'path/to/mageekguy.atoum.phar';
+require_once 'path/to/atoum.phar';
 
 include_once 'path/to/project/classes/helloWorld.php';
 
-use mageekguy\atoum;
+use atoum;
 use vendor\project;
 
 class helloWorld extends atoum\test
@@ -166,11 +166,11 @@ class helloWorld extends atoum\test
 
 ## To go further
 
-[*atoum*'s documentation](https://github.com/geraldcroes/atoum-s-documentation) is still being written.  
-It's a github repository, so some pull requests are welcome to improve it.  
+[*atoum*'s documentation](https://github.com/geraldcroes/atoum-s-documentation) is still being written.
+It's a github repository, so some pull requests are welcome to improve it.
 However, if you want to further explore immediately *atoum*'s possibilities, we recommend :
 
-* Running in your terminal, either the command `php mageekguy.atoum.phar -h`, or the command `php scripts/runner.php -h` ;
+* Running in your terminal, either the command `php atoum.phar -h`, or the command `php scripts/runner.php -h` ;
 * Exploring the contents of the `configurations` directory in *atoum*'s source, as it contains configuration file samples ;
 * Exploring the contents of the `tests/unit/classes` directory in *atoum*'s source, as it contains all of the unit tests ;
 * Read the [conference supports](http://www.slideshare.net/impossiblium/atoum-le-framework-de-tests-unitaires-pour-php-53-simple-moderne-et-intuitif) about it, available online ;
@@ -181,14 +181,14 @@ However, if you want to further explore immediately *atoum*'s possibilities, we 
 
 ### *atoum*'s PHAR archive seems to not be working
 
-In this case, the first thing you will want to do is confirm whether you have the latest version of the archive.  
-You just need to [download](http://downloads.atoum.org/nightly/mageekguy.atoum.phar) it again.  
+In this case, the first thing you will want to do is confirm whether you have the latest version of the archive.
+You just need to [download](http://downloads.atoum.org/nightly/atoum.phar) it again.
 If it still doesn't work, run the following command in a terminal window :
 
-	# php -n mageekguy.atoum.phar -v
+	# php -n atoum.phar -v
 
-If you get *atoum*'s version number, then the problem is coming from your PHP configuration.  
-In most cases, the cause would be within extensions, that might be incompatible with the PHAR format, or that would prevent executing PHAR archives as a security measure.  
+If you get *atoum*'s version number, then the problem is coming from your PHP configuration.
+In most cases, the cause would be within extensions, that might be incompatible with the PHAR format, or that would prevent executing PHAR archives as a security measure.
 The `ioncube` extension for instance seems incompatible with PHAR archives, and you must therefore deactivate it if you are using it, by commenting the following line out of your `php.ini`, by prefixing it with the `;` character :
 
 	zend_extension = /path/to/ioncube_loader*.*
@@ -197,22 +197,22 @@ The `suhosin` extension prevents executing PHAR archives, therefore its default 
 
 	suhosin.executor.include.whitelist="phar"
 
-Finally, if running *atoum* causes the screen to display characters looking like `???%`, this would be because the `detect_unicode` directive inside your `php.ini` file is set to 1.  
+Finally, if running *atoum* causes the screen to display characters looking like `???%`, this would be because the `detect_unicode` directive inside your `php.ini` file is set to 1.
 To fix the problem, you just need to set it to 0 by editing your `php.ini` file or by running *atoum* with the following command :
 
-	# php -d detect_unicode=0 mageekguy.atoum.phar [options]
+	# php -d detect_unicode=0 atoum.phar [options]
 
-If these three operations do not allow *atoum* to work, we suggest you send an e-mail to the address *support[AT]atoum(DOT)org*, describing in detail your configuration and your problem.  
+If these three operations do not allow *atoum* to work, we suggest you send an e-mail to the address *support[AT]atoum(DOT)org*, describing in detail your configuration and your problem.
 You can also ask for help from the *atoum* development staff on the IRC channel *##atoum* on the *freenode* network.
 
-### Error: Constant __COMPILER_HALT_OFFSET__ already defined /path/to/mageekguy.atoum.phar
+### Error: Constant __COMPILER_HALT_OFFSET__ already defined /path/to/atoum.phar
 
-This error comes from the fact the *atoum* PHAR archive is included in more than one place within your code using `include` or `require`.  
+This error comes from the fact the *atoum* PHAR archive is included in more than one place within your code using `include` or `require`.
 To fix this problem, you just need to include the archive by using only `include_once` or `require_once`, in order to ensure it is not included several times.
 
 ### APC seems not work with *atoum*
-[APC](http://fr.php.net/manual/en/apc.configuration.php)  is a free, open, and robust framework for caching and optimizing PHP intermediate code distributed under the form of a PHP extension.  
-When testing classes that use APC, you may get some failure message showing that `apc_fetch` function is unable to retrieve a value.  
+[APC](http://fr.php.net/manual/en/apc.configuration.php)  is a free, open, and robust framework for caching and optimizing PHP intermediate code distributed under the form of a PHP extension.
+When testing classes that use APC, you may get some failure message showing that `apc_fetch` function is unable to retrieve a value.
 As all PHP extension, APC has some configuration options to enable it :
 
 * `apc.enabled` whether to enable or disable APC ;
@@ -221,10 +221,10 @@ As all PHP extension, APC has some configuration options to enable it :
 In order to use [APC](http://fr.php.net/manual/en/apc.configuration.php) with *atoum*, you have to set `apc.enabled` and `apc.enable_cli` to `1`, otherwise, it won't be enabled for the PHP CLI version, which is used by *atoum*.
 
 ### Getting segfault when mocking objects
-When using *atoum* and mocking objects, you will sometime get segfaults coming from [PHP](http://www.php.net).  
+When using *atoum* and mocking objects, you will sometime get segfaults coming from [PHP](http://www.php.net).
 These segfaults are caused by [XDebug](http://xdebug.org/) in version less than 2.1.0 which has problem handling reflection in some cases.--
-To check the current version of [XDebug](http://xdebug.org/), you can run `php -v`.  
-To fix this issue, you have to update [XDebug](http://xdebug.org/) to the latest [stable version](http://xdebug.org/download.php).  
-If you can't update [XDebug](http://xdebug.org/) on your system, you can still disable the extension to avoid getting segfaults.  
-To be sure that [XDebug](http://xdebug.org/) has been succefully updated or disabled, you can run `php -v`.  
-When you are done updating or disabling [XDebug](http://xdebug.org/), run `php mageekguy.atoum.phar --test-it` to be sure that all the segfaults have gone and that *atoum* is working.
+To check the current version of [XDebug](http://xdebug.org/), you can run `php -v`.
+To fix this issue, you have to update [XDebug](http://xdebug.org/) to the latest [stable version](http://xdebug.org/download.php).
+If you can't update [XDebug](http://xdebug.org/) on your system, you can still disable the extension to avoid getting segfaults.
+To be sure that [XDebug](http://xdebug.org/) has been succefully updated or disabled, you can run `php -v`.
+When you are done updating or disabling [XDebug](http://xdebug.org/), run `php atoum.phar --test-it` to be sure that all the segfaults have gone and that *atoum* is working.

--- a/bin/atoum
+++ b/bin/atoum
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-define('mageekguy\atoum\scripts\runner', __FILE__);
+define('atoum\scripts\runner', __FILE__);
 
 require_once __DIR__ . '/../scripts/runner.php';
 

--- a/classes/adapter.php
+++ b/classes/adapter.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class adapter implements adapter\definition

--- a/classes/adapter/aggregator.php
+++ b/classes/adapter/aggregator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\adapter;
+namespace atoum\adapter;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 interface aggregator

--- a/classes/adapter/definition.php
+++ b/classes/adapter/definition.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\adapter;
+namespace atoum\adapter;
 
 interface definition
 {

--- a/classes/annotations/extractor.php
+++ b/classes/annotations/extractor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\annotations;
+namespace atoum\annotations;
 
 class extractor
 {

--- a/classes/asserter.php
+++ b/classes/asserter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\exceptions
 ;
 
 abstract class asserter

--- a/classes/asserter/exception.php
+++ b/classes/asserter/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\asserter;
+namespace atoum\asserter;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class exception extends \runtimeException {}

--- a/classes/asserter/generator.php
+++ b/classes/asserter/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserter;
+namespace atoum\asserter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class generator

--- a/classes/asserters/adapter.php
+++ b/classes/asserters/adapter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\arguments
+	atoum,
+	atoum\php,
+	atoum\asserter,
+	atoum\exceptions,
+	atoum\tools\arguments
 ;
 
 class adapter extends atoum\asserter
@@ -23,7 +23,7 @@ class adapter extends atoum\asserter
 	{
 		$this->adapter = $adapter;
 
-		if ($this->adapter instanceof \mageekguy\atoum\test\adapter === false)
+		if ($this->adapter instanceof \atoum\test\adapter === false)
 		{
 			$this->fail(sprintf($this->getLocale()->_('%s is not a test adapter'), $this->getTypeOf($this->adapter)));
 		}

--- a/classes/asserters/adapter/call/adapter.php
+++ b/classes/asserters/adapter/call/adapter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters\adapter\call;
+namespace atoum\asserters\adapter\call;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\test,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class adapter

--- a/classes/asserters/adapter/call/mock.php
+++ b/classes/asserters/adapter/call/mock.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters\adapter\call;
+namespace atoum\asserters\adapter\call;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class mock

--- a/classes/asserters/afterDestructionOf.php
+++ b/classes/asserters/afterDestructionOf.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class afterDestructionOf extends atoum\asserter

--- a/classes/asserters/boolean.php
+++ b/classes/asserters/boolean.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class boolean extends asserters\variable

--- a/classes/asserters/castToString.php
+++ b/classes/asserters/castToString.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters
+	atoum\asserters
 ;
 
 class castToString extends asserters\string

--- a/classes/asserters/dateTime.php
+++ b/classes/asserters/dateTime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class dateTime extends asserters\object

--- a/classes/asserters/error.php
+++ b/classes/asserters/error.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
-class error extends \mageekguy\atoum\asserter
+class error extends \atoum\asserter
 {
 	protected $score = null;
 	protected $message = null;

--- a/classes/asserters/exception.php
+++ b/classes/asserters/exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\diffs
+	atoum\asserters,
+	atoum\exceptions,
+	atoum\tools\diffs
 ;
 
 class exception extends asserters\object

--- a/classes/asserters/float.php
+++ b/classes/asserters/float.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
-class float extends \mageekguy\atoum\asserters\integer
+class float extends \atoum\asserters\integer
 {
 	public function setWith($value, $label = null)
 	{

--- a/classes/asserters/hash.php
+++ b/classes/asserters/hash.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class hash extends string

--- a/classes/asserters/integer.php
+++ b/classes/asserters/integer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class integer extends asserters\variable

--- a/classes/asserters/mock.php
+++ b/classes/asserters/mock.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\arguments
+	atoum,
+	atoum\php,
+	atoum\test,
+	atoum\asserter,
+	atoum\exceptions,
+	atoum\tools\arguments
 ;
 
 class mock extends atoum\asserter
@@ -39,7 +39,7 @@ class mock extends atoum\asserter
 	{
 		$this->mock = $mock;
 
-		if ($this->mock instanceof \mageekguy\atoum\mock\aggregator === false)
+		if ($this->mock instanceof \atoum\mock\aggregator === false)
 		{
 			$this->fail(sprintf($this->getLocale()->_('%s is not a mock'), $this->getTypeOf($this->mock)));
 		}

--- a/classes/asserters/mock/call/adapter.php
+++ b/classes/asserters/mock/call/adapter.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters\mock\call;
+namespace atoum\asserters\mock\call;
 
 use
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\php,
+	atoum\test,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class adapter extends php\call

--- a/classes/asserters/mock/call/mock.php
+++ b/classes/asserters/mock/call/mock.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters\mock\call;
+namespace atoum\asserters\mock\call;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\php,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class mock extends php\call

--- a/classes/asserters/mysqlDateTime.php
+++ b/classes/asserters/mysqlDateTime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class mysqlDateTime extends asserters\dateTime

--- a/classes/asserters/object.php
+++ b/classes/asserters/object.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class object extends asserters\variable

--- a/classes/asserters/output.php
+++ b/classes/asserters/output.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserters
 ;
 
 class output extends asserters\string

--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\diffs
+	atoum\asserters,
+	atoum\exceptions,
+	atoum\tools\diffs
 ;
 
 class phpArray extends asserters\variable

--- a/classes/asserters/phpClass.php
+++ b/classes/asserters/phpClass.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class phpClass extends atoum\asserter

--- a/classes/asserters/sizeOf.php
+++ b/classes/asserters/sizeOf.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
-class sizeOf extends \mageekguy\atoum\asserters\integer
+class sizeOf extends \atoum\asserters\integer
 {
 	public function setWith($value, $label = null)
 	{

--- a/classes/asserters/stream.php
+++ b/classes/asserters/stream.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class stream extends atoum\asserter

--- a/classes/asserters/string.php
+++ b/classes/asserters/string.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\exceptions
 ;
 
 class string extends variable

--- a/classes/asserters/testedClass.php
+++ b/classes/asserters/testedClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\exceptions
 ;
 
 class testedClass extends phpClass

--- a/classes/asserters/variable.php
+++ b/classes/asserters/variable.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\exceptions,
+	atoum\tools\diffs
 ;
 
 class variable extends atoum\asserter

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 require_once __DIR__ . '/../constants.php';
 

--- a/classes/cli.php
+++ b/classes/cli.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class cli

--- a/classes/cli/colorizer.php
+++ b/classes/cli/colorizer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\cli;
+namespace atoum\cli;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class colorizer

--- a/classes/cli/progressBar.php
+++ b/classes/cli/progressBar.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\cli;
+namespace atoum\cli;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class progressBar

--- a/classes/cli/prompt.php
+++ b/classes/cli/prompt.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\cli;
+namespace atoum\cli;
 
 class prompt
 {

--- a/classes/configurator.php
+++ b/classes/configurator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class configurator
 {

--- a/classes/dependencies.php
+++ b/classes/dependencies.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\dependencies
+	atoum\dependencies
 ;
 
 class dependencies implements \arrayAccess, \countable

--- a/classes/dependencies/exception.php
+++ b/classes/dependencies/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\dependencies;
+namespace atoum\dependencies;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class exception extends \exception implements atoum\exception {}

--- a/classes/exception.php
+++ b/classes/exception.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 interface exception {}

--- a/classes/exceptions/logic.php
+++ b/classes/exceptions/logic.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions;
+namespace atoum\exceptions;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class logic extends \logicException implements atoum\exception {}

--- a/classes/exceptions/logic/badMethodCall.php
+++ b/classes/exceptions/logic/badMethodCall.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\logic;
+namespace atoum\exceptions\logic;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class badMethodCall extends \badMethodCallException implements atoum\exception {}

--- a/classes/exceptions/logic/invalidArgument.php
+++ b/classes/exceptions/logic/invalidArgument.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\logic;
+namespace atoum\exceptions\logic;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class invalidArgument extends \invalidArgumentException implements atoum\exception {}

--- a/classes/exceptions/runtime.php
+++ b/classes/exceptions/runtime.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions;
+namespace atoum\exceptions;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class runtime extends \runtimeException implements atoum\exception {}

--- a/classes/exceptions/runtime/file.php
+++ b/classes/exceptions/runtime/file.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\runtime;
+namespace atoum\exceptions\runtime;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class file extends exceptions\runtime {}

--- a/classes/exceptions/runtime/unexpectedValue.php
+++ b/classes/exceptions/runtime/unexpectedValue.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\runtime;
+namespace atoum\exceptions\runtime;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class unexpectedValue extends \unexpectedValueException implements atoum\exception {}

--- a/classes/factory.php
+++ b/classes/factory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\factory
+	atoum\factory
 ;
 
 class factory implements \arrayAccess, \serializable

--- a/classes/factory/exception.php
+++ b/classes/factory/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\factory;
+namespace atoum\factory;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/includer.php
+++ b/classes/includer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\includer
+	atoum\includer
 ;
 
 class includer

--- a/classes/includer/exception.php
+++ b/classes/includer/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\includer;
+namespace atoum\includer;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/iterators/filters/recursives/closure.php
+++ b/classes/iterators/filters/recursives/closure.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives;
+namespace atoum\iterators\filters\recursives;
 
 class closure extends \recursiveFilterIterator
 {

--- a/classes/iterators/filters/recursives/dot.php
+++ b/classes/iterators/filters/recursives/dot.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives;
+namespace atoum\iterators\filters\recursives;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class dot extends \recursiveFilterIterator

--- a/classes/iterators/filters/recursives/extension.php
+++ b/classes/iterators/filters/recursives/extension.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives;
+namespace atoum\iterators\filters\recursives;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class extension extends \recursiveFilterIterator

--- a/classes/iterators/recursives/atoum/source.php
+++ b/classes/iterators/recursives/atoum/source.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\iterators\recursives\atoum;
+namespace atoum\iterators\recursives\atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators
+	atoum,
+	atoum\iterators
 ;
 
 class source implements \outerIterator

--- a/classes/iterators/recursives/directory.php
+++ b/classes/iterators/recursives/directory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\iterators\recursives;
+namespace atoum\iterators\recursives;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class directory implements \iteratorAggregate
@@ -62,12 +62,12 @@ class directory implements \iteratorAggregate
 
 		if ($this->acceptDots === false)
 		{
-			$iterator = $this->factory->build('mageekguy\atoum\iterators\filters\recursives\dot', array($iterator));
+			$iterator = $this->factory->build('atoum\iterators\filters\recursives\dot', array($iterator));
 		}
 
 		if (sizeof($this->acceptedExtensions) > 0)
 		{
-			$iterator = $this->factory->build('mageekguy\atoum\iterators\filters\recursives\extension', array($iterator, $this->acceptedExtensions));
+			$iterator = $this->factory->build('atoum\iterators\filters\recursives\extension', array($iterator, $this->acceptedExtensions));
 		}
 
 		return $iterator;

--- a/classes/locale.php
+++ b/classes/locale.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class locale
 {

--- a/classes/mailer.php
+++ b/classes/mailer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 abstract class mailer implements atoum\adapter\aggregator

--- a/classes/mailers/mail.php
+++ b/classes/mailers/mail.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mailers;
+namespace atoum\mailers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class mail extends atoum\mailer

--- a/classes/mock/aggregator.php
+++ b/classes/mock/aggregator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum\mock
+	atoum\mock
 ;
 
 interface aggregator

--- a/classes/mock/controller.php
+++ b/classes/mock/controller.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\mock,
+	atoum\test,
+	atoum\exceptions
 ;
 
 class controller extends test\adapter

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class generator
@@ -90,7 +90,7 @@ class generator
 				$mockClass = self::getClassName($class);
 			}
 
-			$adapter = $this->factory['mageekguy\atoum\adapter']();
+			$adapter = $this->factory['atoum\adapter']();
 
 			if ($adapter->class_exists($mockNamespace . '\\' . $mockClass, false) === true || $adapter->interface_exists($mockNamespace . '\\' . $mockClass, false) === true)
 			{
@@ -208,7 +208,7 @@ class generator
 						{
 							$methodCode .= "\t\t" . 'if ($mockController === null)' . PHP_EOL;
 							$methodCode .= "\t\t" . '{' . PHP_EOL;
-							$methodCode .= "\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL;
+							$methodCode .= "\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL;
 							$methodCode .= "\t\t" . '}' . PHP_EOL;
 							$methodCode .= "\t\t" . 'if ($mockController !== null)' . PHP_EOL;
 							$methodCode .= "\t\t" . '{' . PHP_EOL;
@@ -359,11 +359,11 @@ class generator
 			'final class ' . $mockClass . ' implements \\' . __NAMESPACE__ . '\\aggregator' . PHP_EOL .
 			'{' . PHP_EOL .
 			self::generateMockControllerMethod() .
-			"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+			"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 			"\t" . '{' . PHP_EOL .
 			"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
-			"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+			"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 			"\t\t" . '}' . PHP_EOL .
 			"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
@@ -426,7 +426,7 @@ class generator
 				{
 					$methodCode .= "\t\t" . 'if ($mockController === null)' . PHP_EOL;
 					$methodCode .= "\t\t" . '{' . PHP_EOL;
-					$methodCode .= "\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL;
+					$methodCode .= "\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL;
 					$methodCode .= "\t\t" . '}' . PHP_EOL;
 					$methodCode .= "\t\t" . 'if ($mockController !== null)' . PHP_EOL;
 					$methodCode .= "\t\t" . '{' . PHP_EOL;
@@ -472,7 +472,7 @@ class generator
 			. "\t" . '{' . PHP_EOL
 			. "\t\t" . 'if ($mockController === null)' . PHP_EOL
 			. "\t\t" . '{' . PHP_EOL
-			. "\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL
+			. "\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL
 			. "\t\t" . '}' . PHP_EOL
 			. "\t\t" . 'if ($mockController !== null)' . PHP_EOL
 			. "\t\t" . '{' . PHP_EOL

--- a/classes/mock/php/method.php
+++ b/classes/mock/php/method.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mock\php;
+namespace atoum\mock\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class method

--- a/classes/mock/php/method/argument.php
+++ b/classes/mock/php/method/argument.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\php\method;
+namespace atoum\mock\php\method;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class argument

--- a/classes/mock/stream.php
+++ b/classes/mock/stream.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\exceptions\logic,
-	mageekguy\atoum\exceptions\runtime
+	atoum\adapter,
+	atoum\exceptions\logic,
+	atoum\exceptions\runtime
 ;
 
 class stream

--- a/classes/mock/stream/controller.php
+++ b/classes/mock/stream/controller.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\mock\stream;
+namespace atoum\mock\stream;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\dependence,
-	mageekguy\atoum\dependencies
+	atoum\test,
+	atoum\exceptions,
+	atoum\dependence,
+	atoum\dependencies
 ;
 
 class controller extends test\adapter

--- a/classes/mock/stream/invoker.php
+++ b/classes/mock/stream/invoker.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\stream;
+namespace atoum\mock\stream;
 
 use
-	mageekguy\atoum\test\adapter
+	atoum\test\adapter
 ;
 
 class invoker extends adapter\invoker
@@ -22,7 +22,7 @@ class invoker extends adapter\invoker
 
 	public function offsetSet($call, $mixed)
 	{
-		if ($this->methodName == 'dir_readdir' && $mixed instanceof \mageekguy\atoum\mock\stream\controller)
+		if ($this->methodName == 'dir_readdir' && $mixed instanceof \atoum\mock\stream\controller)
 		{
 			$mixed = $mixed->getBasename();
 		}

--- a/classes/observable.php
+++ b/classes/observable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 interface observable
 {

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 interface observer
 {

--- a/classes/observers/runner.php
+++ b/classes/observers/runner.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\observers;
+namespace atoum\observers;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 interface runner extends atoum\observer

--- a/classes/observers/test.php
+++ b/classes/observers/test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\observers;
+namespace atoum\observers;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 interface test extends atoum\observer

--- a/classes/php/call.php
+++ b/classes/php/call.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\php;
+namespace atoum\php;
 
 class call
 {

--- a/classes/php/call/arguments/decorator.php
+++ b/classes/php/call/arguments/decorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\php\call\arguments;
+namespace atoum\php\call\arguments;
 
 class decorator
 {

--- a/classes/php/call/decorator.php
+++ b/classes/php/call/decorator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php\call;
+namespace atoum\php\call;
 
 use
-	mageekguy\atoum\php
+	atoum\php
 ;
 
 class decorator

--- a/classes/php/tokenizer.php
+++ b/classes/php/tokenizer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php;
+namespace atoum\php;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class tokenizer implements \iteratorAggregate

--- a/classes/php/tokenizer/iterator.php
+++ b/classes/php/tokenizer/iterator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer;
+namespace atoum\php\tokenizer;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer\iterator
+	atoum\exceptions,
+	atoum\php\tokenizer\iterator
 ;
 
 class iterator extends iterator\value

--- a/classes/php/tokenizer/iterator/value.php
+++ b/classes/php/tokenizer/iterator/value.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterator;
+namespace atoum\php\tokenizer\iterator;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 abstract class value implements \iterator, \countable

--- a/classes/php/tokenizer/iterators/phpArgument.php
+++ b/classes/php/tokenizer/iterators/phpArgument.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpArgument extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpClass.php
+++ b/classes/php/tokenizer/iterators/phpClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpClass extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpConstant.php
+++ b/classes/php/tokenizer/iterators/phpConstant.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\php\tokenizer
+	atoum\php\tokenizer
 ;
 
 class phpConstant extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpDefaultValue.php
+++ b/classes/php/tokenizer/iterators/phpDefaultValue.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpDefaultValue extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpFunction.php
+++ b/classes/php/tokenizer/iterators/phpFunction.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpFunction extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpImportation.php
+++ b/classes/php/tokenizer/iterators/phpImportation.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpImportation extends tokenizer\iterator {}

--- a/classes/php/tokenizer/iterators/phpMethod.php
+++ b/classes/php/tokenizer/iterators/phpMethod.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpMethod extends tokenizer\iterators\phpFunction {}

--- a/classes/php/tokenizer/iterators/phpNamespace.php
+++ b/classes/php/tokenizer/iterators/phpNamespace.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpNamespace extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpProperty.php
+++ b/classes/php/tokenizer/iterators/phpProperty.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpProperty extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpScript.php
+++ b/classes/php/tokenizer/iterators/phpScript.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpScript extends tokenizer\iterators\phpNamespace

--- a/classes/php/tokenizer/token.php
+++ b/classes/php/tokenizer/token.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer;
+namespace atoum\php\tokenizer;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer\iterator
+	atoum\exceptions,
+	atoum\php\tokenizer\iterator
 ;
 
 class token extends iterator\value

--- a/classes/report.php
+++ b/classes/report.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class report implements observer, adapter\aggregator
 {
@@ -16,8 +16,8 @@ class report implements observer, adapter\aggregator
 	{
 		$this
 			->setFactory($factory ?: new factory())
-			->setLocale($this->factory['mageekguy\atoum\locale']())
-			->setAdapter($this->factory['mageekguy\atoum\adapter']())
+			->setLocale($this->factory['atoum\locale']())
+			->setAdapter($this->factory['atoum\adapter']())
 		;
 	}
 

--- a/classes/report/field.php
+++ b/classes/report/field.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report;
+namespace atoum\report;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 abstract class field

--- a/classes/report/fields/event.php
+++ b/classes/report/fields/event.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields;
+namespace atoum\report\fields;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\test\cli,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\report,
+	atoum\test\cli,
+	atoum\exceptions
 ;
 
 abstract class event extends report\field

--- a/classes/report/fields/runner.php
+++ b/classes/report/fields/runner.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields;
+namespace atoum\report\fields;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 abstract class runner extends report\field

--- a/classes/report/fields/runner/atoum.php
+++ b/classes/report/fields/runner/atoum.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 require_once __DIR__ . '/../../../../constants.php';
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report
+	atoum\runner,
+	atoum\report
 ;
 
 abstract class atoum extends report\field
@@ -15,7 +15,7 @@ abstract class atoum extends report\field
 	protected $path = null;
 	protected $version = null;
 
-	public function __construct(\mageekguy\atoum\locale $locale = null)
+	public function __construct(\atoum\locale $locale = null)
 	{
 		parent::__construct(array(runner::runStart), $locale);
 	}
@@ -35,7 +35,7 @@ abstract class atoum extends report\field
 		return $this->path;
 	}
 
-	public function handleEvent($event, \mageekguy\atoum\observable $observable)
+	public function handleEvent($event, \atoum\observable $observable)
 	{
 		if (parent::handleEvent($event, $observable) === false)
 		{
@@ -43,7 +43,7 @@ abstract class atoum extends report\field
 		}
 		else
 		{
-			$this->author = \mageekguy\atoum\author;
+			$this->author = \atoum\author;
 			$this->path = $observable->getScore()->getAtoumPath();
 			$this->version = $observable->getScore()->getAtoumVersion();
 

--- a/classes/report/fields/runner/atoum/cli.php
+++ b/classes/report/fields/runner/atoum/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\atoum;
+namespace atoum\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\atoum

--- a/classes/report/fields/runner/atoum/phing.php
+++ b/classes/report/fields/runner/atoum/phing.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\atoum;
+namespace atoum\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class phing extends report\fields\runner\atoum\cli

--- a/classes/report/fields/runner/coverage.php
+++ b/classes/report/fields/runner/coverage.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report
+	atoum\runner,
+	atoum\report
 ;
 
 abstract class coverage extends report\field
 {
 	protected $coverage = null;
 
-	public function __construct(\mageekguy\atoum\locale $locale = null)
+	public function __construct(\atoum\locale $locale = null)
 	{
 		parent::__construct(array(runner::runStop), $locale);
 	}
@@ -21,7 +21,7 @@ abstract class coverage extends report\field
 		return $this->coverage;
 	}
 
-	public function handleEvent($event, \mageekguy\atoum\observable $observable)
+	public function handleEvent($event, \atoum\observable $observable)
 	{
 		if (parent::handleEvent($event, $observable) === false)
 		{

--- a/classes/report/fields/runner/coverage/cli.php
+++ b/classes/report/fields/runner/coverage/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\coverage;
+namespace atoum\report\fields\runner\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\coverage

--- a/classes/report/fields/runner/coverage/html.php
+++ b/classes/report/fields/runner/coverage/html.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\coverage;
+namespace atoum\report\fields\runner\coverage;
 
 require_once __DIR__ . '/../../../../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\template,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\locale,
+	atoum\report,
+	atoum\template,
+	atoum\exceptions,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class html extends report\fields\runner\coverage\cli

--- a/classes/report/fields/runner/duration.php
+++ b/classes/report/fields/runner/duration.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class duration extends report\field

--- a/classes/report/fields/runner/duration/cli.php
+++ b/classes/report/fields/runner/duration/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\duration;
+namespace atoum\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration
 ;
 
 class cli extends duration

--- a/classes/report/fields/runner/duration/phing.php
+++ b/classes/report/fields/runner/duration/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\duration;
+namespace atoum\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration
 ;
 
 class phing extends duration\cli

--- a/classes/report/fields/runner/errors.php
+++ b/classes/report/fields/runner/errors.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class errors extends report\field

--- a/classes/report/fields/runner/errors/cli.php
+++ b/classes/report/fields/runner/errors/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\errors;
+namespace atoum\report\fields\runner\errors;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\locale,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\errors

--- a/classes/report/fields/runner/event.php
+++ b/classes/report/fields/runner/event.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\test,
+	atoum\runner,
+	atoum\locale,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class event extends report\fields\event

--- a/classes/report/fields/runner/event/cli.php
+++ b/classes/report/fields/runner/event/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\event;
+namespace atoum\report\fields\runner\event;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\progressBar
+	atoum\test,
+	atoum\runner,
+	atoum\report,
+	atoum\exceptions,
+	atoum\cli\progressBar
 ;
 
 class cli extends report\fields\runner\event

--- a/classes/report/fields/runner/exceptions.php
+++ b/classes/report/fields/runner/exceptions.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class exceptions extends report\field

--- a/classes/report/fields/runner/exceptions/cli.php
+++ b/classes/report/fields/runner/exceptions/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\exceptions;
+namespace atoum\report\fields\runner\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\exceptions

--- a/classes/report/fields/runner/failures.php
+++ b/classes/report/fields/runner/failures.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class failures extends report\field

--- a/classes/report/fields/runner/failures/cli.php
+++ b/classes/report/fields/runner/failures/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures;
+namespace atoum\report\fields\runner\failures;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner
 ;
 
 class cli extends runner\failures

--- a/classes/report/fields/runner/outputs.php
+++ b/classes/report/fields/runner/outputs.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\observable,
-	mageekguy\atoum\report\field
+	atoum\runner,
+	atoum\locale,
+	atoum\observable,
+	atoum\report\field
 ;
 
 abstract class outputs extends field

--- a/classes/report/fields/runner/outputs/cli.php
+++ b/classes/report/fields/runner/outputs/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\outputs;
+namespace atoum\report\fields\runner\outputs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\outputs
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\outputs
 ;
 
 class cli extends outputs

--- a/classes/report/fields/runner/php/path.php
+++ b/classes/report/fields/runner/php/path.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php;
+namespace atoum\report\fields\runner\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class path extends report\field

--- a/classes/report/fields/runner/php/path/cli.php
+++ b/classes/report/fields/runner/php/path/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php\path;
+namespace atoum\report\fields\runner\php\path;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\php\path

--- a/classes/report/fields/runner/php/version.php
+++ b/classes/report/fields/runner/php/version.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php;
+namespace atoum\report\fields\runner\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class version extends report\field

--- a/classes/report/fields/runner/php/version/cli.php
+++ b/classes/report/fields/runner/php/version/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php\version;
+namespace atoum\report\fields\runner\php\version;
 
 use
-	mageekguy\atoum\report,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum\report,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\php\version

--- a/classes/report/fields/runner/result.php
+++ b/classes/report/fields/runner/result.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class result extends report\field

--- a/classes/report/fields/runner/result/cli.php
+++ b/classes/report/fields/runner/result/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result;
+namespace atoum\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields
 ;
 
 class cli extends fields\runner\result

--- a/classes/report/fields/runner/tests/coverage.php
+++ b/classes/report/fields/runner/tests/coverage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class coverage extends report\field

--- a/classes/report/fields/runner/tests/coverage/cli.php
+++ b/classes/report/fields/runner/tests/coverage/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\coverage;
+namespace atoum\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\tests\coverage

--- a/classes/report/fields/runner/tests/coverage/phing.php
+++ b/classes/report/fields/runner/tests/coverage/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\coverage;
+namespace atoum\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\runner\tests\coverage\cli

--- a/classes/report/fields/runner/tests/duration.php
+++ b/classes/report/fields/runner/tests/duration.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class duration extends report\field

--- a/classes/report/fields/runner/tests/duration/cli.php
+++ b/classes/report/fields/runner/tests/duration/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\duration;
+namespace atoum\report\fields\runner\tests\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\tests\duration

--- a/classes/report/fields/runner/tests/memory.php
+++ b/classes/report/fields/runner/tests/memory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class memory extends report\field

--- a/classes/report/fields/runner/tests/memory/cli.php
+++ b/classes/report/fields/runner/tests/memory/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\memory;
+namespace atoum\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\tests\memory

--- a/classes/report/fields/runner/tests/memory/phing.php
+++ b/classes/report/fields/runner/tests/memory/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\memory;
+namespace atoum\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\runner\tests\memory\cli

--- a/classes/report/fields/runner/tests/uncompleted.php
+++ b/classes/report/fields/runner/tests/uncompleted.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class uncompleted extends report\field

--- a/classes/report/fields/runner/tests/uncompleted/cli.php
+++ b/classes/report/fields/runner/tests/uncompleted/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\uncompleted;
+namespace atoum\report\fields\runner\tests\uncompleted;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\locale,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\tests\uncompleted

--- a/classes/report/fields/test/duration.php
+++ b/classes/report/fields/test/duration.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\test,
+	atoum\locale,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class duration extends report\field

--- a/classes/report/fields/test/duration/cli.php
+++ b/classes/report/fields/test/duration/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\duration;
+namespace atoum\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\test\duration

--- a/classes/report/fields/test/duration/phing.php
+++ b/classes/report/fields/test/duration/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\duration;
+namespace atoum\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\test\duration\cli

--- a/classes/report/fields/test/event.php
+++ b/classes/report/fields/test/event.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\test\cli,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\report,
+	atoum\test\cli,
+	atoum\exceptions
 ;
 
 abstract class event extends report\fields\event

--- a/classes/report/fields/test/event/cli.php
+++ b/classes/report/fields/test/event/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\event;
+namespace atoum\report\fields\test\event;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\progressBar
+	atoum\test,
+	atoum\report,
+	atoum\exceptions,
+	atoum\cli\progressBar
 ;
 
 class cli extends report\fields\test\event

--- a/classes/report/fields/test/event/phing.php
+++ b/classes/report/fields/test/event/phing.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\event;
+namespace atoum\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\report,
+	atoum\exceptions
 ;
 
 class phing extends report\fields\test\event\cli

--- a/classes/report/fields/test/memory.php
+++ b/classes/report/fields/test/memory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report
+	atoum,
+	atoum\test,
+	atoum\report
 ;
 
 abstract class memory extends report\field

--- a/classes/report/fields/test/memory/cli.php
+++ b/classes/report/fields/test/memory/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\memory;
+namespace atoum\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\test\memory

--- a/classes/report/fields/test/memory/phing.php
+++ b/classes/report/fields/test/memory/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\memory;
+namespace atoum\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\test\memory\cli

--- a/classes/report/fields/test/run.php
+++ b/classes/report/fields/test/run.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report
+	atoum,
+	atoum\test,
+	atoum\report
 ;
 
 abstract class run extends report\field

--- a/classes/report/fields/test/run/cli.php
+++ b/classes/report/fields/test/run/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\run;
+namespace atoum\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\test\run

--- a/classes/report/fields/test/run/phing.php
+++ b/classes/report/fields/test/run/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\run;
+namespace atoum\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\test\run\cli

--- a/classes/report/writers/asynchronous.php
+++ b/classes/report/writers/asynchronous.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report\writers;
+namespace atoum\report\writers;
 
 use
-	mageekguy\atoum\reports
+	atoum\reports
 ;
 
 interface asynchronous

--- a/classes/report/writers/realtime.php
+++ b/classes/report/writers/realtime.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report\writers;
+namespace atoum\report\writers;
 
 use
-	mageekguy\atoum\reports
+	atoum\reports
 ;
 
 interface realtime

--- a/classes/reports/asynchronous.php
+++ b/classes/reports/asynchronous.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\reports;
+namespace atoum\reports;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 abstract class asynchronous extends atoum\report

--- a/classes/reports/asynchronous/builder.php
+++ b/classes/reports/asynchronous/builder.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\exceptions,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class builder extends atoum\reports\asynchronous

--- a/classes/reports/asynchronous/vim.php
+++ b/classes/reports/asynchronous/vim.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class vim extends reports\asynchronous

--- a/classes/reports/asynchronous/xunit.php
+++ b/classes/reports/asynchronous/xunit.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\exceptions,
+	atoum\report\fields
 ;
 
 class xunit extends atoum\reports\asynchronous

--- a/classes/reports/realtime.php
+++ b/classes/reports/realtime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\reports;
+namespace atoum\reports;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 abstract class realtime extends atoum\report

--- a/classes/reports/realtime/cli.php
+++ b/classes/reports/realtime/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime;
+namespace atoum\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports\realtime,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class cli extends realtime

--- a/classes/reports/realtime/cli/light.php
+++ b/classes/reports/realtime/cli/light.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime\cli;
+namespace atoum\reports\realtime\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports\realtime,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class light extends realtime

--- a/classes/reports/realtime/phing.php
+++ b/classes/reports/realtime/phing.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime;
+namespace atoum\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports\realtime,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class phing extends realtime

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\iterators,
+	atoum\exceptions
 ;
 
 class runner implements observable, adapter\aggregator
 {
-	const atoumVersionConstant = 'mageekguy\atoum\version';
-	const atoumDirectoryConstant = 'mageekguy\atoum\directory';
+	const atoumVersionConstant = 'atoum\version';
+	const atoumDirectoryConstant = 'atoum\directory';
 
 	const runStart = 'runnerStart';
 	const runStop = 'runnerStop';
@@ -41,16 +41,16 @@ class runner implements observable, adapter\aggregator
 	{
 		$this
 			->setFactory($factory ?: new factory())
-			->setAdapter($this->factory['mageekguy\atoum\adapter']())
-			->setLocale($this->factory['mageekguy\atoum\locale']())
-			->setIncluder($this->factory['mageekguy\atoum\includer']())
-			->setScore($this->factory['mageekguy\atoum\score']($this->factory))
-			->setTestDirectoryIterator($this->factory['mageekguy\atoum\iterators\recursives\directory']())
+			->setAdapter($this->factory['atoum\adapter']())
+			->setLocale($this->factory['atoum\locale']())
+			->setIncluder($this->factory['atoum\includer']())
+			->setScore($this->factory['atoum\score']($this->factory))
+			->setTestDirectoryIterator($this->factory['atoum\iterators\recursives\directory']())
 		;
 
-		$this->factory['mageekguy\atoum\adapter'] = $this->adapter;
-		$this->factory['mageekguy\atoum\locale'] = $this->locale;
-		$this->factory['mageekguy\atoum\includer'] = $this->includer;
+		$this->factory['atoum\adapter'] = $this->adapter;
+		$this->factory['atoum\locale'] = $this->locale;
+		$this->factory['atoum\includer'] = $this->includer;
 
 		$runnerClass = $this->factory['reflectionClass']($this);
 

--- a/classes/score.php
+++ b/classes/score.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\exceptions
 ;
 
 class score
@@ -36,7 +36,7 @@ class score
 	{
 		$this
 			->setFactory($factory ?: new factory())
-			->setCoverage($this->factory['mageekguy\atoum\score\coverage']($this->factory))
+			->setCoverage($this->factory['atoum\score\coverage']($this->factory))
 		;
 	}
 

--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\score;
+namespace atoum\score;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\score,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\score,
+	atoum\exceptions
 ;
 
 class coverage implements \countable

--- a/classes/script.php
+++ b/classes/script.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\script,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\script,
+	atoum\exceptions
 ;
 
 abstract class script implements atoum\adapter\aggregator
@@ -46,7 +46,7 @@ abstract class script implements atoum\adapter\aggregator
 
 	public function setFactory(atoum\factory $factory)
 	{
-		$this->factory = $factory->import('mageekguy\atoum');
+		$this->factory = $factory->import('atoum');
 
 		return $this;
 	}

--- a/classes/script/arguments/parser.php
+++ b/classes/script/arguments/parser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\script\arguments;
+namespace atoum\script\arguments;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class parser implements \iteratorAggregate

--- a/classes/scripts/builder.php
+++ b/classes/scripts/builder.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\phar,
-	mageekguy\atoum\scripts\builder
+	atoum,
+	atoum\exceptions,
+	atoum\scripts\phar,
+	atoum\scripts\builder
 ;
 
 class builder extends atoum\script

--- a/classes/scripts/builder/vcs.php
+++ b/classes/scripts/builder/vcs.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\scripts\builder;
+namespace atoum\scripts\builder;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 abstract class vcs implements atoum\adapter\aggregator

--- a/classes/scripts/builder/vcs/svn.php
+++ b/classes/scripts/builder/vcs/svn.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts\builder\vcs;
+namespace atoum\scripts\builder\vcs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\builder
+	atoum,
+	atoum\exceptions,
+	atoum\scripts\builder
 ;
 
 class svn extends builder\vcs implements atoum\adapter\aggregator

--- a/classes/scripts/phar/generator.php
+++ b/classes/scripts/phar/generator.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace mageekguy\atoum\scripts\phar;
+namespace atoum\scripts\phar;
 
 require_once __DIR__ . '/../../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\iterators,
+	atoum\exceptions
 ;
 
 class generator extends atoum\script
 {
-	const phar = 'mageekguy.atoum.phar';
+	const phar = 'atoum.phar';
 
 	protected $generate = true;
 	protected $originDirectory = null;

--- a/classes/scripts/phar/stub.php
+++ b/classes/scripts/phar/stub.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts\phar;
+namespace atoum\scripts\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\scripts,
+	atoum\exceptions
 ;
 
 class stub extends scripts\runner

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 require_once __DIR__ . '/../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\system,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\system,
+	atoum\exceptions
 ;
 
 class runner extends atoum\script
@@ -107,8 +107,8 @@ class runner extends atoum\script
 				{
 					if ($this->runner->hasReports() === false)
 					{
-						$report = $this->factory['mageekguy\atoum\reports\realtime\cli']($this->factory);
-						$report->addWriter($this->factory['mageekguy\atoum\writers\std\out']());
+						$report = $this->factory['atoum\reports\realtime\cli']($this->factory);
+						$report->addWriter($this->factory['atoum\writers\std\out']());
 
 						$this->runner->addReport($report);
 					}
@@ -641,7 +641,7 @@ class runner extends atoum\script
 								throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
 							}
 
-							\mageekguy\atoum\cli::forceTerminal();
+							\atoum\cli::forceTerminal();
 						},
 						array('-ft', '--force-terminal'),
 						null,
@@ -668,8 +668,8 @@ class runner extends atoum\script
 								throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
 							}
 
-							$report = $script->getFactory()->build('mageekguy\atoum\reports\realtime\cli\light', array($script->getFactory()));
-							$report->addWriter($script->getFactory()->build('mageekguy\atoum\writers\std\out'));
+							$report = $script->getFactory()->build('atoum\reports\realtime\cli\light', array($script->getFactory()));
+							$report->addWriter($script->getFactory()->build('atoum\writers\std\out'));
 
 							$script->getRunner()->addReport($report);
 						},
@@ -692,7 +692,7 @@ class runner extends atoum\script
 	{
 		$arguments = ' --disable-loop-mode';
 
-		$cli = $this->factory['mageekguy\atoum\cli']();
+		$cli = $this->factory['atoum\cli']();
 
 		if ($cli->isTerminal() === true)
 		{

--- a/classes/scripts/tagger.php
+++ b/classes/scripts/tagger.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\tagger
+	atoum,
+	atoum\exceptions,
+	atoum\scripts\tagger
 ;
 
 class tagger extends atoum\script

--- a/classes/scripts/tagger/engine.php
+++ b/classes/scripts/tagger/engine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts\tagger;
+namespace atoum\scripts\tagger;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\adapter,
+	atoum\exceptions
 ;
 
 class engine implements adapter\aggregator

--- a/classes/superglobals.php
+++ b/classes/superglobals.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class superglobals

--- a/classes/template.php
+++ b/classes/template.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\template,
-	mageekguy\atoum\exceptions
+	atoum\template,
+	atoum\exceptions
 ;
 
 class template extends template\data

--- a/classes/template/data.php
+++ b/classes/template/data.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class data

--- a/classes/template/iterator.php
+++ b/classes/template/iterator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class iterator implements \iterator, \countable

--- a/classes/template/parser.php
+++ b/classes/template/parser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\template\parser
+	atoum,
+	atoum\exceptions,
+	atoum\template\parser
 ;
 
 class parser implements atoum\adapter\aggregator

--- a/classes/template/parser/exception.php
+++ b/classes/template/parser/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\template\parser;
+namespace atoum\template\parser;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime

--- a/classes/template/tag.php
+++ b/classes/template/tag.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class tag extends atoum\template

--- a/classes/test.php
+++ b/classes/test.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\annotations
+	atoum\test,
+	atoum\mock,
+	atoum\asserter,
+	atoum\exceptions,
+	atoum\annotations
 ;
 
 abstract class test implements observable, adapter\aggregator, \countable
@@ -30,7 +30,7 @@ abstract class test implements observable, adapter\aggregator, \countable
 	const afterTearDown = 'afterTestTearDown';
 	const runStop = 'testRunStop';
 	const defaultEngine = 'concurrent';
-	const enginesNamespace = '\mageekguy\atoum\test\engines';
+	const enginesNamespace = '\atoum\test\engines';
 
 	private $phpPath = null;
 	private $path = '';
@@ -68,11 +68,11 @@ abstract class test implements observable, adapter\aggregator, \countable
 	{
 		$this
 			->setFactory($factory ?: new factory())
-			->setScore($this->factory['mageekguy\atoum\score']($this->factory))
-			->setLocale($this->factory['mageekguy\atoum\locale']())
-			->setAdapter($this->factory['mageekguy\atoum\adapter']())
-			->setSuperglobals($this->factory['mageekguy\atoum\superglobals']())
-			->setIncluder($this->factory['mageekguy\atoum\includer']())
+			->setScore($this->factory['atoum\score']($this->factory))
+			->setLocale($this->factory['atoum\locale']())
+			->setAdapter($this->factory['atoum\adapter']())
+			->setSuperglobals($this->factory['atoum\superglobals']())
+			->setIncluder($this->factory['atoum\includer']())
 			->enableCodeCoverage()
 		;
 
@@ -82,7 +82,7 @@ abstract class test implements observable, adapter\aggregator, \countable
 		$this->class = $class->getName();
 		$this->classNamespace = $class->getNamespaceName();
 
-		$annotationExtractor = $this->factory['mageekguy\atoum\annotations\extractor']();
+		$annotationExtractor = $this->factory['atoum\annotations\extractor']();
 
 		$test = $this;
 
@@ -136,7 +136,7 @@ abstract class test implements observable, adapter\aggregator, \countable
 				->setAlias('class', 'phpClass')
 		;
 
-		$this->setAssertionManager($this->factory['mageekguy\atoum\test\assertion\manager']());
+		$this->setAssertionManager($this->factory['atoum\test\assertion\manager']());
 	}
 
 	public function __toString()
@@ -301,7 +301,7 @@ abstract class test implements observable, adapter\aggregator, \countable
 
 	public function getMockGenerator()
 	{
-		return $this->mockGenerator ?: $this->setMockGenerator($this->factory['mageekguy\atoum\test\mock\generator']($this))->mockGenerator;
+		return $this->mockGenerator ?: $this->setMockGenerator($this->factory['atoum\test\mock\generator']($this))->mockGenerator;
 	}
 
 	public function setAsserterGenerator(test\asserter\generator $generator)
@@ -315,7 +315,7 @@ abstract class test implements observable, adapter\aggregator, \countable
 	{
 		test\adapter::resetCallsForAllInstances();
 
-		return $this->asserterGenerator ?: $this->setAsserterGenerator($this->factory['mageekguy\atoum\test\asserter\generator']($this))->asserterGenerator;
+		return $this->asserterGenerator ?: $this->setAsserterGenerator($this->factory['atoum\test\asserter\generator']($this))->asserterGenerator;
 	}
 
 	public function setTestNamespace($testNamespace)

--- a/classes/test/adapter.php
+++ b/classes/test/adapter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\test;
+namespace atoum\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\dependence,
-	mageekguy\atoum\dependencies,
-	mageekguy\atoum\test\adapter\invoker
+	atoum,
+	atoum\exceptions,
+	atoum\dependence,
+	atoum\dependencies,
+	atoum\test\adapter\invoker
 ;
 
 class adapter extends atoum\adapter

--- a/classes/test/adapter/invoker.php
+++ b/classes/test/adapter/invoker.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\adapter;
+namespace atoum\test\adapter;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class invoker implements \arrayAccess

--- a/classes/test/asserter/generator.php
+++ b/classes/test/asserter/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\asserter;
+namespace atoum\test\asserter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter
+	atoum,
+	atoum\asserter
 ;
 
 class generator extends asserter\generator

--- a/classes/test/assertion/manager.php
+++ b/classes/test/assertion/manager.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\assertion;
+namespace atoum\test\assertion;
 
 use
-	mageekguy\atoum\test\assertion
+	atoum\test\assertion
 ;
 
 class manager

--- a/classes/test/assertion/manager/exception.php
+++ b/classes/test/assertion/manager/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\assertion\manager;
+namespace atoum\test\assertion\manager;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/test/engine.php
+++ b/classes/test/engine.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test;
+namespace atoum\test;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 abstract class engine

--- a/classes/test/engines/concurrent.php
+++ b/classes/test/engines/concurrent.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\test\engines;
+namespace atoum\test\engines;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\exceptions
 ;
 
 class concurrent extends test\engine
@@ -24,7 +24,7 @@ class concurrent extends test\engine
 	{
 		parent::__construct($factory);
 
-		$this->adapter = $this->factory['mageekguy\atoum\adapter']();
+		$this->adapter = $this->factory['atoum\adapter']();
 	}
 
 	public function isRunning()
@@ -60,7 +60,7 @@ class concurrent extends test\engine
 			$phpCode =
 				'<?php ' .
 				'ob_start();' .
-				'define(\'mageekguy\atoum\autorun\', false);' .
+				'define(\'atoum\autorun\', false);' .
 				'require \'' . atoum\directory . '/scripts/runner.php\';'
 			;
 
@@ -70,9 +70,9 @@ class concurrent extends test\engine
 			{
 				$phpCode .=
 					'require \'' . atoum\directory . '/classes/includer.php\';' .
-					'$includer = new mageekguy\atoum\includer();' .
+					'$includer = new atoum\includer();' .
 					'try { $includer->includePath(\'' . $bootstrapFile . '\'); }' .
-					'catch (mageekguy\atoum\includer\exception $exception)' .
+					'catch (atoum\includer\exception $exception)' .
 					'{ die(\'Unable to include bootstrap file \\\'' . $bootstrapFile . '\\\'\'); }'
 				;
 			}
@@ -154,7 +154,7 @@ class concurrent extends test\engine
 
 				if ($score instanceof atoum\score === false)
 				{
-					$score = $this->factory['mageekguy\atoum\score']($this->factory);
+					$score = $this->factory['atoum\score']($this->factory);
 					$score->addUncompletedMethod($this->test->getClass(), $this->method, $phpStatus['exitcode'], $this->stdOut);
 				}
 

--- a/classes/test/engines/inline.php
+++ b/classes/test/engines/inline.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\engines;
+namespace atoum\test\engines;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test
+	atoum,
+	atoum\test
 ;
 
 class inline extends test\engine
@@ -20,7 +20,7 @@ class inline extends test\engine
 	{
 		parent::__construct($factory);
 
-		$this->score = $this->factory['mageekguy\atoum\score']();
+		$this->score = $this->factory['atoum\score']();
 	}
 
 	public function run(atoum\test $test)

--- a/classes/test/engines/isolate.php
+++ b/classes/test/engines/isolate.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\engines;
+namespace atoum\test\engines;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\engines
+	atoum,
+	atoum\test\engines
 ;
 
 class isolate extends engines\concurrent
@@ -15,7 +15,7 @@ class isolate extends engines\concurrent
 	{
 		parent::__construct($factory);
 
-		$this->score = $this->factory['mageekguy\atoum\score']();
+		$this->score = $this->factory['atoum\score']();
 	}
 
 	public function run(atoum\test $test)

--- a/classes/test/exceptions/runtime.php
+++ b/classes/test/exceptions/runtime.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\exceptions;
+namespace atoum\test\exceptions;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class runtime extends exceptions\runtime {}

--- a/classes/test/mock/generator.php
+++ b/classes/test/mock/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\mock;
+namespace atoum\test\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\mock
 ;
 
 class generator extends mock\generator

--- a/classes/tools/diff.php
+++ b/classes/tools/diff.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\tools;
+namespace atoum\tools;
 
 class diff
 {

--- a/classes/tools/diffs/variable.php
+++ b/classes/tools/diffs/variable.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tools\diffs;
+namespace atoum\tools\diffs;
 
 use
-	mageekguy\atoum\tools,
-	mageekguy\atoum\exceptions
+	atoum\tools,
+	atoum\exceptions
 ;
 
 class variable extends tools\diff

--- a/classes/writer.php
+++ b/classes/writer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 abstract class writer implements adapter\aggregator
 {

--- a/classes/writers/file.php
+++ b/classes/writers/file.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\report\writers
+	atoum,
+	atoum\reports,
+	atoum\report\writers
 ;
 
 class file extends atoum\writer implements writers\realtime, writers\asynchronous

--- a/classes/writers/mail.php
+++ b/classes/writers/mail.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\reports
+	atoum,
+	atoum\report,
+	atoum\reports
 ;
 
 class mail extends atoum\writer implements report\writers\asynchronous

--- a/classes/writers/std.php
+++ b/classes/writers/std.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\writers
+	atoum,
+	atoum\reports,
+	atoum\exceptions,
+	atoum\report\writers
 ;
 
 abstract class std extends atoum\writer implements writers\realtime, writers\asynchronous

--- a/classes/writers/std/err.php
+++ b/classes/writers/std/err.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\writers\std;
+namespace atoum\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers
+	atoum,
+	atoum\writers
 ;
 
 class err extends writers\std

--- a/classes/writers/std/out.php
+++ b/classes/writers/std/out.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\writers\std;
+namespace atoum\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers
+	atoum,
+	atoum\writers
 ;
 
 class out extends writers\std

--- a/constants.php
+++ b/constants.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 if (defined(__NAMESPACE__ . '\running') === false)
 {

--- a/resources/configurations/builder/config.php.dist
+++ b/resources/configurations/builder/config.php.dist
@@ -1,6 +1,6 @@
 <?php
 
-use \mageekguy\atoum;
+use \atoum;
 
 $builder
 	->setWorkingDirectory('/path/to/working/directory')

--- a/resources/configurations/runner/builder.php.dist
+++ b/resources/configurations/runner/builder.php.dist
@@ -4,7 +4,7 @@
 Sample atoum configuration file to use with builder.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 $mailer = new atoum\mailers\mail();
 $mailer

--- a/resources/configurations/runner/cli.php.dist
+++ b/resources/configurations/runner/cli.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file.
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 Write all on stdout.

--- a/resources/configurations/runner/coverage.php.dist
+++ b/resources/configurations/runner/coverage.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file to have code coverage in html format.
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 $stdOutWriter = new atoum\writers\std\out();
 

--- a/resources/configurations/runner/vim.php.dist
+++ b/resources/configurations/runner/vim.php.dist
@@ -4,7 +4,7 @@
 Sample atoum configuration file for using atoum with vim.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 Write all on stdout.

--- a/resources/phing/AtoumTask.php
+++ b/resources/phing/AtoumTask.php
@@ -92,14 +92,14 @@ class AtoumTask extends Task
             require_once $this->bootstrap;
         }
 
-        define('mageekguy\\atoum\\autorun', false);
+        define('\atoum\\autorun', false);
         if (!empty($this->atoumpharpath)) {
             require_once($this->atoumpharpath);
         } elseif (!empty($this->atoumautoloaderpath)) {
             require_once($this->atoumautoloaderpath);
         } else {
-            if (!class_exists('mageekguy\atoum\scripts\runner', false)) {
-                throw new Exception("Unknown class mageekguy\\atoum\\scripts\\runner.\n\rConsider setting atoumpharpath parameter");
+            if (!class_exists('atoum\scripts\runner', false)) {
+                throw new Exception("Unknown class \atoum\\scripts\\runner.\n\rConsider setting atoumpharpath parameter");
             }
         }
 
@@ -113,8 +113,8 @@ class AtoumTask extends Task
     public function execute()
     {
         if ($this->runner === false) {
-            $this->runner = new \mageekguy\atoum\runner();
-            $report = new \mageekguy\atoum\reports\realtime\phing(
+            $this->runner = new \atoum\runner();
+            $report = new \atoum\reports\realtime\phing(
                 $this->showprogress,
                 $this->showcodecoverage,
                 $this->showmissingcodecoverage,
@@ -123,7 +123,7 @@ class AtoumTask extends Task
                 $this->codecoveragereportpath,
                 $this->codecoveragereporturl
             );
-            $writer = new \mageekguy\atoum\writers\std\out();
+            $writer = new \atoum\writers\std\out();
 
             $report->addWriter($writer);
             $this->runner->addReport($report);
@@ -140,9 +140,9 @@ class AtoumTask extends Task
                 $this->runner->setMaxChildrenNumber($this->maxchildren);
             }
             if ($this->codecoveragexunitpath !== false) {
-                $xUnit = new \mageekguy\atoum\reports\asynchronous\xunit();
+                $xUnit = new \atoum\reports\asynchronous\xunit();
                 $this->runner->addReport($xUnit);
-                $file = new \mageekguy\atoum\writers\file($this->codecoveragexunitpath);
+                $file = new \atoum\writers\file($this->codecoveragexunitpath);
                 $xUnit->addWriter($file);
             }
         }

--- a/resources/vim/atoum.vmb
+++ b/resources/vim/atoum.vmb
@@ -217,8 +217,8 @@ Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/ru
 */
 
 use
-  \mageekguy\atoum,
-  \mageekguy\atoum\cli\prompt
+  \atoum,
+  \atoum\cli\prompt
 ;
 
 /*

--- a/scripts/builder.php
+++ b/scripts/builder.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\scripts\svn\builder;
+namespace atoum\scripts\svn\builder;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../classes/autoloader.php';

--- a/scripts/phar/generator.php
+++ b/scripts/phar/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\phar;
+namespace atoum\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../../classes/autoloader.php';

--- a/scripts/phar/resources/stub.php
+++ b/scripts/phar/resources/stub.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\phar
+	atoum,
+	atoum\scripts\phar
 ;
 
 if (extension_loaded('phar') === false)
@@ -12,7 +12,7 @@ if (extension_loaded('phar') === false)
 	throw new \runtimeException('Phar extension is mandatory to use this PHAR');
 }
 
-define(__NAMESPACE__ . '\phar\name', 'mageekguy.atoum.phar');
+define(__NAMESPACE__ . '\phar\name', 'atoum.phar');
 
 \phar::mapPhar(atoum\phar\name);
 

--- a/scripts/runner.php
+++ b/scripts/runner.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../classes/autoloader.php';

--- a/scripts/tagger.php
+++ b/scripts/tagger.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\scripts\tagger;
+namespace atoum\scripts\tagger;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../classes/autoloader.php';

--- a/tests/units/asserters/template/parser/exception.php
+++ b/tests/units/asserters/template/parser/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\template\parser;
+namespace atoum\tests\units\asserters\template\parser;
 
 use
-	mageekguy\atoum\asserters
+	atoum\asserters
 ;
 
 class exception extends asserters\exception

--- a/tests/units/classes/adapter.php
+++ b/tests/units/classes/adapter.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -13,7 +13,7 @@ class adapter extends atoum\test
 	public function test__construct()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserter($generator = new atoum\asserter\generator()))
+			->if($asserter = new \mock\atoum\asserter($generator = new atoum\asserter\generator()))
 			->then
 				->object($asserter->getGenerator())->isIdenticalTo($generator)
 		;

--- a/tests/units/classes/annotations/extractor.php
+++ b/tests/units/classes/annotations/extractor.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\annotations;
+namespace atoum\tests\units\annotations;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\annotations
+	atoum,
+	atoum\annotations
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/asserter.php
+++ b/tests/units/classes/asserter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 require __DIR__ . '/../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class asserter extends atoum\test
@@ -13,7 +13,7 @@ class asserter extends atoum\test
 	public function testSetWithTest()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserter(new atoum\asserter\generator()))
+			->if($asserter = new \mock\atoum\asserter(new atoum\asserter\generator()))
 			->then
 				->object($asserter->setWithTest($this))->isIdenticalTo($asserter)
 		;
@@ -22,7 +22,7 @@ class asserter extends atoum\test
 	public function testSetWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserter(new atoum\asserter\generator()))
+			->if($asserter = new \mock\atoum\asserter(new atoum\asserter\generator()))
 			->then
 				->object($asserter->setWithArguments(array()))->isIdenticalTo($asserter)
 				->mock($asserter)->call('setWith')->never()

--- a/tests/units/classes/asserter/generator.php
+++ b/tests/units/classes/asserter/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserter;
+namespace atoum\tests\units\asserter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter
+	atoum,
+	atoum\asserter
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -29,9 +29,9 @@ class generator extends atoum\test
 			->if($generator = new asserter\generator())
 			->then
 				->exception(function() use ($generator, & $asserter) { $generator->{$asserter = uniqid()}; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Asserter \'' . $asserter . '\' does not exist')
-				->object($generator->variable)->isInstanceOf('mageekguy\atoum\asserters\variable')
+				->object($generator->variable)->isInstanceOf('atoum\asserters\variable')
 		;
 	}
 
@@ -53,9 +53,9 @@ class generator extends atoum\test
 			->if($generator = new asserter\generator())
 			->then
 				->exception(function() use ($generator, & $asserter) { $generator->{$asserter = uniqid()}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Asserter \'' . $asserter . '\' does not exist')
-				->object($generator->variable(uniqid()))->isInstanceOf('mageekguy\atoum\asserters\variable')
+				->object($generator->variable(uniqid()))->isInstanceOf('atoum\asserters\variable')
 		;
 	}
 

--- a/tests/units/classes/asserters/adapter.php
+++ b/tests/units/classes/asserters/adapter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\php,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -16,7 +16,7 @@ class adapter extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -42,7 +42,7 @@ class adapter extends atoum\test
 			->then
 				->assert('Set the asserter with something else than an adapter throw an exception')
 					->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not a test adapter'), $asserter->getTypeOf($value)))
 					->string($asserter->getAdapter())->isEqualTo($value)
 				->assert('It is possible to set the asserter with an adapter')
@@ -79,11 +79,11 @@ class adapter extends atoum\test
 	public function testCall()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->and($asserter->getMockController()->atLeastOnce = function() {})
 			->then
 				->exception(function() use ($asserter) { $asserter->call(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -100,16 +100,16 @@ class adapter extends atoum\test
 	public function testWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->and($asserter->getMockController()->atLeastOnce = function() {})
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -125,16 +125,16 @@ class adapter extends atoum\test
 	public function testWithAnyArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->and($asserter->getMockController()->atLeastOnce = function() {})
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -156,7 +156,7 @@ class adapter extends atoum\test
 			->and($asserter = new asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, $mock) { $asserter->beforeMethodCall(uniqid(), $mock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -196,7 +196,7 @@ class adapter extends atoum\test
 			->and($asserter = new asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, $mock) { $asserter->afterMethodCall(uniqid(), $mock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 				->if($asserter->setWith($adapter = new test\adapter()))
 				->then
@@ -239,7 +239,7 @@ class adapter extends atoum\test
 			->and($asserter = new asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -282,7 +282,7 @@ class adapter extends atoum\test
 			->and($asserter = new asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -321,16 +321,16 @@ class adapter extends atoum\test
 			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($firstArgument = uniqid()))
@@ -339,7 +339,7 @@ class adapter extends atoum\test
 			->if($adapter->md5($secondArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
@@ -349,7 +349,7 @@ class adapter extends atoum\test
 			->if($asserter->withArguments(uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -360,17 +360,17 @@ class adapter extends atoum\test
 			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
 			->if($adapter->md5(uniqid()))
 			->then
@@ -382,7 +382,7 @@ class adapter extends atoum\test
 			->and($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($arg))
@@ -391,7 +391,7 @@ class adapter extends atoum\test
 			->if($asserter->withArguments(uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -402,23 +402,23 @@ class adapter extends atoum\test
 			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($arg = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($adapter->md5($otherArg = uniqid()))
 			->then
@@ -426,23 +426,23 @@ class adapter extends atoum\test
 			->if($adapter->md5($anOtherArg = uniqid()))
 			->then
 				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($anOtherArg)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($adapter->md5($usedArg = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($adapter->md5($arg))
 			->then
@@ -450,7 +450,7 @@ class adapter extends atoum\test
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $anAnotherLine, $asserter) { $anAnotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg))  . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -461,12 +461,12 @@ class adapter extends atoum\test
 			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($call = new php\call('md5'))
 			->and($asserter->call('md5'))
@@ -475,7 +475,7 @@ class adapter extends atoum\test
 			->if($adapter->md5($usedArg = uniqid()))
 			->then
 					->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
@@ -484,12 +484,12 @@ class adapter extends atoum\test
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($asserter->withArguments(uniqid()))
 			->then

--- a/tests/units/classes/asserters/adapter/call/adapter.php
+++ b/tests/units/classes/asserters/adapter/call/adapter.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\adapter\call;
+namespace atoum\tests\units\asserters\adapter\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\adapter\call
+	atoum,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\adapter\call
 ;
 
 class adapter extends atoum\test
@@ -35,7 +35,7 @@ class adapter extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\adapter($adapterAsserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), new test\adapter(), uniqid()))
+			->if($call = new call\adapter($adapterAsserter = new \mock\atoum\asserters\adapter(new asserter\generator()), new test\adapter(), uniqid()))
 			->and($adapterAsserter->getMockController()->call = $adapterAsserter)
 			->then
 				->object($call->call($arg = uniqid()))->isIdenticalTo($adapterAsserter)
@@ -44,7 +44,7 @@ class adapter extends atoum\test
 			->if($unknownFunction = uniqid())
 			->then
 				->exception(function() use ($call, $unknownFunction) { $call->{$unknownFunction}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Method ' . get_class($adapterAsserter) . '::' . $unknownFunction . '() does not exist')
 		;
 	}

--- a/tests/units/classes/asserters/adapter/call/mock.php
+++ b/tests/units/classes/asserters/adapter/call/mock.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\adapter\call;
+namespace atoum\tests\units\asserters\adapter\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\adapter\call
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\adapter\call
 ;
 
 class mock extends atoum\test
@@ -34,7 +34,7 @@ class mock extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\mock($adapterAsserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), new \mock\dummy(), uniqid()))
+			->if($call = new call\mock($adapterAsserter = new \mock\atoum\asserters\adapter(new asserter\generator()), new \mock\dummy(), uniqid()))
 			->and($adapterAsserter->getMockController()->call = $adapterAsserter)
 			->then
 				->object($call->call($arg = uniqid()))->isIdenticalTo($adapterAsserter)
@@ -43,7 +43,7 @@ class mock extends atoum\test
 			->if($unknownMethod = uniqid())
 			->then
 				->exception(function() use ($call, $unknownMethod) { $call->{$unknownMethod}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Method ' . get_class($adapterAsserter) . '::' . $unknownMethod . '() does not exist')
 		;
 	}

--- a/tests/units/classes/asserters/afterDestructionOf.php
+++ b/tests/units/classes/asserters/afterDestructionOf.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -21,7 +21,7 @@ class afterDestructionOf extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -41,15 +41,15 @@ class afterDestructionOf extends atoum\test
 			->and($value = uniqid())
 			->then
 				->exception(function() use (& $line, $asserter, $value) { $line = __LINE__; $asserter->setWith($value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an object'), $asserter->getTypeOf($value)))
-			->object($asserter->setWith($objectWithDestructor = new \mock\mageekguy\atoum\tests\units\asserters\classWithDestructor()))->isIdenticalTo($asserter)
+			->object($asserter->setWith($objectWithDestructor = new \mock\atoum\tests\units\asserters\classWithDestructor()))->isIdenticalTo($asserter)
 				->mock($objectWithDestructor)
 						->call('__destruct')->once()
 			->if($objectWithoutDestructor = new classWithoutDestructor())
 			->then
 				->exception(function() use (& $otherLine, $asserter, $objectWithoutDestructor) { $otherLine = __LINE__; $asserter->setWith($objectWithoutDestructor); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Destructor of class %s is undefined'), get_class($objectWithoutDestructor)))
 		;
 	}

--- a/tests/units/classes/asserters/boolean.php
+++ b/tests/units/classes/asserters/boolean.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class boolean extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -45,7 +45,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isTrue(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not true'), $asserter) . PHP_EOL . $diff->setReference(true)->setData(false))
 			->if($asserter->setWith(true))
 			->then
@@ -54,7 +54,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isTrue; })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not true'), $asserter) . PHP_EOL . $diff->setReference(true)->setData(false))
 		;
 	}
@@ -74,7 +74,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isFalse(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not false'), $asserter) . PHP_EOL . $diff->setReference(false)->setData(true))
 			->if($asserter->setWith(false))
 			->then
@@ -83,7 +83,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isFalse; })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not false'), $asserter) . PHP_EOL . $diff->setReference(false)->setData(true))
 		;
 	}
@@ -95,7 +95,7 @@ class boolean extends atoum\test
 			->then
 				->assert('Set the asserter with something else than a boolean throw an exception')
 					->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not a boolean'), $asserter->getTypeOf($value)))
 				->assert('The asserter was returned when it set with a boolean')
 					->string($asserter->getValue())->isEqualTo($value)

--- a/tests/units/classes/asserters/castToString.php
+++ b/tests/units/classes/asserters/castToString.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class castToString extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\string');
+		$this->testedClass->isSubclassOf('atoum\asserters\string');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class castToString extends atoum\test
 			->then
 				->assert('Set the asserter with something else than an object throw an exception')
 					->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not an object'), $asserter->getTypeOf($value)))
 					->integer($asserter->getValue())->isEqualTo($value)
 					->variable($asserter->getCharlist())->isNull()

--- a/tests/units/classes/asserters/dateTime.php
+++ b/tests/units/classes/asserters/dateTime.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class dateTime extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\object');
+		$this->testedClass->isSubclassOf('atoum\asserters\object');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class dateTime extends atoum\test
 			->if($asserter = new asserters\dateTime($generator = new asserter\generator()))
 			->assert('Set the asserter with something else than a date time trown an exception')
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of \\dateTime'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->assert('The asserter was returned when it set with a date time')
@@ -52,12 +52,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new asserters\dateTime($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \dateTime('now', $timezone = new \dateTimezone('Europe/Paris'))))
 			->then
 				->exception(function() use (& $line, & $requiredTimezone, $asserter) { $line = __LINE__; $asserter->hasTimezone($requiredTimezone = new \DateTimezone('Europe/London')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Timezone is %s instead of %s'), $timezone->getName(), $requiredTimezone->getName()))
 				->object($asserter->hasTimezone($dateTime->getTimezone()))->isIdenticalTo($asserter);
 		;
@@ -68,15 +68,15 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new asserters\dateTime($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->isInYear(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \dateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->isInYear(2011); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Year is %s instead of %s'), 2011, 1976))
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->isInYear(76); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Year is %s instead of %s'), 76, 1976))
 				->object($asserter->isInYear(1976))->isIdenticalTo($asserter)
 		;
@@ -87,12 +87,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new asserters\dateTime($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->isInMonth(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \dateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->isInMonth(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Month is %s instead of %s'), 1, 10))
 				->object($asserter->isInMonth(10))->isIdenticalTo($asserter)
 			->if($asserter->setWith($dateTime = new \dateTime('1980-08-14')))
@@ -108,12 +108,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new asserters\dateTime($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->isInDay(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \dateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->isInDay(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Day is %s instead of %s'), 1, 6))
 				->object($asserter->isInDay('06'))->isIdenticalTo($asserter)
 				->object($asserter->isInDay('6'))->isIdenticalTo($asserter)
@@ -127,12 +127,12 @@ class dateTime extends atoum\test
 			->if($asserter = new asserters\dateTime($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasDate(1976, 10, 6); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \dateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasDate(1980, 8, 14); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Date is %s instead of %s'), '1980-08-14', '1976-10-06'))
 				->object($asserter->hasDate(1976, 10, 6))->isIdenticalTo($asserter)
 				->object($asserter->hasDate('1976', '10', '6'))->isIdenticalTo($asserter)

--- a/tests/units/classes/asserters/error.php
+++ b/tests/units/classes/asserters/error.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class error extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function testInitWithTest()
@@ -85,7 +85,7 @@ class error extends atoum\test
 			->if($asserter = new asserters\error($generator = new asserter\generator()))
 			->then
 				->exception(function() use (& $line, $asserter) { $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('error does not exist'))
 			->if($asserter->getScore()->addError(uniqid(), rand(1, PHP_INT_MAX), uniqid(), uniqid(), rand(0, PHP_INT_MAX), uniqid(), uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -94,7 +94,7 @@ class error extends atoum\test
 			->if($asserter->setWith($message = uniqid(), null))
 			->then
 				->exception(function() use (& $line, $asserter) { $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('error with message \'%s\' does not exist'), $message))
 			->if($asserter->getScore()->addError(uniqid(), rand(1, PHP_INT_MAX), uniqid(), uniqid(), rand(0, PHP_INT_MAX), $message, uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -103,7 +103,7 @@ class error extends atoum\test
 			->if($asserter->setWith($message = uniqid(), $type = E_USER_ERROR))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('error of type %s with message \'%s\' does not exist'), asserters\error::getAsString($type), $message))
 			->if($asserter->getScore()->addError(uniqid(), rand(1, PHP_INT_MAX), uniqid(), uniqid(), $type, $message, uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -112,7 +112,7 @@ class error extends atoum\test
 			->if($asserter->setWith(null, $type = E_USER_ERROR))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('error of type %s does not exist'), asserters\error::getAsString($type)))
 			->if($asserter->getScore()->addError(uniqid(), rand(1, PHP_INT_MAX), uniqid(), uniqid(), $type, uniqid(), uniqid(), rand(1, PHP_INT_MAX)))
 			->then

--- a/tests/units/classes/asserters/exception.php
+++ b/tests/units/classes/asserters/exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class exception extends atoum\test
 			->then
 				->assert('It is impossible to set asserter with something else than an exception')
 					->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not an exception'), $asserter->getTypeOf($value)))
 					->string($asserter->getValue())->isEqualTo($value)
 				->assert('The asserter was returned when it set with an exception')
@@ -51,7 +51,7 @@ class exception extends atoum\test
 			->if($asserter = new asserters\exception($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Exception is undefined')
 			->if($asserter->setWith(new \exception()))
 			->then
@@ -60,11 +60,11 @@ class exception extends atoum\test
 				->object($asserter->isInstanceOf('\exception'))->isIdenticalTo($asserter)
 				->object($asserter->isInstanceOf('exception'))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->isInstanceOf(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
-					->hasMessage('Argument of mageekguy\atoum\asserters\exception::isInstanceOf() must be a \exception instance or an exception class name')
-				->exception(function() use ($asserter) { $asserter->isInstanceOf('mageekguy\atoum\exceptions\runtime'); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of mageekguy\atoum\exceptions\runtime'), $asserter))
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
+					->hasMessage('Argument of atoum\asserters\exception::isInstanceOf() must be a \exception instance or an exception class name')
+				->exception(function() use ($asserter) { $asserter->isInstanceOf('atoum\exceptions\runtime'); })
+					->isInstanceOf('atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of atoum\exceptions\runtime'), $asserter))
 		;
 	}
 
@@ -80,7 +80,7 @@ class exception extends atoum\test
 			->if($asserter->setWith(new atoum\exceptions\runtime(uniqid(), $code = rand(2, PHP_INT_MAX))))
 			->then
 				->exception(function() use ($asserter, & $otherCode) { $asserter->hasCode($otherCode = 1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('code is %d instead of %d'), $code, $otherCode))
 			->object($asserter->hasCode($code))->isIdenticalTo($asserter)
 		;
@@ -98,7 +98,7 @@ class exception extends atoum\test
 			->if($asserter->setWith(new atoum\exceptions\runtime($message = uniqid())))
 			->then
 				->exception(function() use ($asserter, & $otherMessage) { $asserter->hasMessage($otherMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('message \'%s\' is not identical to \'%s\''), $message, $otherMessage))
 				->object($asserter->hasMessage($message))->isIdenticalTo($asserter)
 		;
@@ -116,17 +116,17 @@ class exception extends atoum\test
 			->if($asserter->setWith(new atoum\exceptions\runtime('', 0)))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasNestedException(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('exception does not contain any nested exception'))
 				->exception(function() use ($asserter) { $asserter->hasNestedException(new \exception()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('exception does not contain this nested exception'))
 			->if($asserter->setWith(new atoum\exceptions\runtime('', 0, $nestedException = new \exception())))
 			->then
 				->object($asserter->hasNestedException())->isIdenticalTo($asserter)
 				->object($asserter->hasNestedException($nestedException))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->hasNestedException(new \exception()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('exception does not contain this nested exception'))
 		;
 	}

--- a/tests/units/classes/asserters/float.php
+++ b/tests/units/classes/asserters/float.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class float extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\integer');
+		$this->testedClass->isSubclassOf('atoum\asserters\integer');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class float extends atoum\test
 		$this
 			->if($asserter = new asserters\float($generator = new asserter\generator()))
 			->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = uniqid()); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
+				->isInstanceOf('atoum\asserter\exception')
 				->hasMessage(sprintf($generator->getLocale()->_('%s is not a float'), $asserter->getTypeOf($value)))
 			->string($asserter->getValue())->isEqualTo($value)
 			->object($asserter->setWith($value = (float) rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($asserter)
@@ -54,7 +54,7 @@ class float extends atoum\test
 			->and($diff->setReference(- $value)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isEqualTo(- $value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf(- $value)) . PHP_EOL . $diff)
 		;
 	}

--- a/tests/units/classes/asserters/hash.php
+++ b/tests/units/classes/asserters/hash.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class hash extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\string');
+		$this->testedClass->isSubclassOf('atoum\asserters\string');
 	}
 
 	public function testIsSha1()
@@ -30,14 +30,14 @@ class hash extends atoum\test
 			->and($diff->setReference( $newvalue )->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha1(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setReference($newvalue)->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha1(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
@@ -54,14 +54,14 @@ class hash extends atoum\test
 			->and($diff->setReference( $newvalue )->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha256(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setReference($newvalue)->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha256(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
@@ -78,14 +78,14 @@ class hash extends atoum\test
 			->and($diff->setReference( $newvalue )->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha512(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setReference($newvalue)->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha512(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
@@ -102,14 +102,14 @@ class hash extends atoum\test
 			->and($diff->setReference( $newvalue )->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isMd5(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setReference($newvalue)->setData($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isMd5(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}

--- a/tests/units/classes/asserters/integer.php
+++ b/tests/units/classes/asserters/integer.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class integer extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class integer extends atoum\test
 			->if($asserter = new asserters\integer($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an integer'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->object($asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($asserter)
@@ -55,7 +55,7 @@ class integer extends atoum\test
 			->and($diff->setReference(- $value)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isEqualTo(- $value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf(- $value)) . PHP_EOL . $diff)
 		;
 	}
@@ -71,13 +71,13 @@ class integer extends atoum\test
 			->and($diff->setReference(PHP_INT_MAX)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isGreaterThan(PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than %s'), $asserter, $asserter->getTypeOf(PHP_INT_MAX)))
 			->if($diff = new diffs\variable())
 			->and($diff->setReference($value)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isGreaterThan($value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -93,13 +93,13 @@ class integer extends atoum\test
 			->and($diff->setReference(- PHP_INT_MAX)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLowerThan(- PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not lower than %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 			->if($diff = new diffs\variable())
 			->and($diff->setReference($value)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLowerThan($value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not lower than %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -115,13 +115,13 @@ class integer extends atoum\test
 			->and($diff->setReference(- PHP_INT_MAX)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLessThan(- PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not lower than %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 			->if($diff = new diffs\variable())
 			->and($diff->setReference($value)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLessThan($value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not lower than %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -138,7 +138,7 @@ class integer extends atoum\test
 			->and($diff->setReference(PHP_INT_MAX)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $line = __LINE__; $asserter->isGreaterThanOrEqualTo(PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than or equal to %s'), $asserter, $asserter->getTypeOf(PHP_INT_MAX)))
 		;
 	}
@@ -155,7 +155,7 @@ class integer extends atoum\test
 			->and($diff->setReference(- PHP_INT_MAX)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLowerThanOrEqualTo(- PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not lower than or equal to %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 		;
 	}
@@ -172,7 +172,7 @@ class integer extends atoum\test
 			->and($diff->setReference(- PHP_INT_MAX)->setData($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLessThanOrEqualTo(- PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not lower than or equal to %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 		;
 	}

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\php,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -22,7 +22,7 @@ class mock extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -42,13 +42,13 @@ class mock extends atoum\test
 	public function testReset()
 	{
 		$this
-			->if($mockController = new \mock\mageekguy\atoum\mock\controller())
+			->if($mockController = new \mock\atoum\mock\controller())
 			->and($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->variable($asserter->getMock())->isNull()
 				->object($asserter->reset())->isIdenticalTo($asserter)
 				->variable($asserter->getMock())->isNull()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\score()))
+			->if($asserter->setWith($mock = new \mock\atoum\score()))
 			->and($mock->setMockController($mockController))
 			->then
 				->object($asserter->getMock())->isIdenticalTo($mock)
@@ -65,9 +65,9 @@ class mock extends atoum\test
 			->and($adapter->class_exists = true)
 			->then
 				->exception(function() use ($asserter, & $mock) { $asserter->setWith($mock = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a mock'), $asserter->getTypeOf($mock)))
-				->object($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\mock(null, null, $adapter)))->isIdenticalTo($asserter)
+				->object($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\mock(null, null, $adapter)))->isIdenticalTo($asserter)
 				->object($asserter->getMock())->isIdenticalTo($mock)
 		;
 	}
@@ -78,18 +78,18 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 				->then
 					->exception(function() use ($asserter) { $asserter->wasCalled(); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic')
+						->isInstanceOf('atoum\exceptions\logic')
 						->hasMessage('Mock is undefined')
 				->if($adapter = new atoum\test\adapter())
 				->and($adapter->class_exists = true)
-				->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\mock(null, null, $adapter)))
+				->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\mock(null, null, $adapter)))
 				->and($mock->getMockController()->resetCalls())
 				->then
 					->exception(function() use ($asserter) { $asserter->wasCalled(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not called'), get_class($mock)))
 					->exception(function() use ($asserter, & $failMessage) { $asserter->wasCalled($failMessage = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($failMessage)
 				->if($mock->getMockController()->{$method = __FUNCTION__} = function() {})
 				->and($mock->{$method}())
@@ -104,11 +104,11 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->wasNotCalled(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\mock(null, null, $adapter)))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\mock(null, null, $adapter)))
 			->and($mock->getMockController()->resetCalls())
 			->then
 				->object($asserter->wasNotCalled())->isIdenticalTo($asserter)
@@ -116,7 +116,7 @@ class mock extends atoum\test
 			->and($mock->{$method}())
 			->then
 				->exception(function() use ($asserter, & $failMessage) { $asserter->wasNotCalled($failMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage)
 		;
 	}
@@ -127,9 +127,9 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeMethodCall(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->object($asserter->beforeMethodCall('foo'))->isEqualTo($beforeMethodCall = new asserters\mock\call\mock($asserter, $mock, 'foo'))
 				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
@@ -146,7 +146,7 @@ class mock extends atoum\test
 				->array($asserter->getBeforeMethodCalls())->isEmpty()
 				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
 				->array($asserter->getBeforeMethodCalls())->isEmpty()
-			->if($asserter->setWith(new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith(new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall(uniqid()))
 			->then
 				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
@@ -169,9 +169,9 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterMethodCall(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->object($asserter->afterMethodCall('foo'))->isEqualTo($afterMethodCall = new asserters\mock\call\mock($asserter, $mock, 'foo'))
 				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
@@ -188,7 +188,7 @@ class mock extends atoum\test
 				->array($asserter->getAfterMethodCalls())->isEmpty()
 				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
 				->array($asserter->getAfterMethodCalls())->isEmpty()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->afterMethodCall($function = uniqid()))
 			->then
 				->array($asserter->getAfterMethodCalls())->isNotEmpty()
@@ -211,9 +211,9 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->then
 				->object($asserter->beforeFunctionCall('foo', $adapter))->isEqualTo($beforeFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'foo'))
@@ -231,7 +231,7 @@ class mock extends atoum\test
 				->array($asserter->getBeforeFunctionCalls())->isEmpty()
 				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
 				->array($asserter->getBeforeFunctionCalls())->isEmpty()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->and($asserter->beforeFunctionCall($function = uniqid(), $adapter))
 			->then
@@ -255,9 +255,9 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->then
 				->object($asserter->afterFunctionCall('foo', $adapter))->isEqualTo($afterFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'foo'))
@@ -275,7 +275,7 @@ class mock extends atoum\test
 				->array($asserter->getAfterFunctionCalls())->isEmpty()
 				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
 				->array($asserter->getAfterFunctionCalls())->isEmpty()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->and($asserter->afterFunctionCall($function = uniqid(), $adapter))
 			->then
@@ -296,12 +296,12 @@ class mock extends atoum\test
 	public function testCall()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->call(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter)
 			->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
@@ -316,15 +316,15 @@ class mock extends atoum\test
 	public function testWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -340,15 +340,15 @@ class mock extends atoum\test
 	public function testWithAnyArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -369,17 +369,17 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->and($mock->foo($usedArg = uniqid()))
@@ -388,7 +388,7 @@ class mock extends atoum\test
 			->if($mock->foo($otherUsedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($usedArg = uniqid()))
@@ -398,26 +398,26 @@ class mock extends atoum\test
 			->if($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			/*
 			->if($mock->foo(uniqid()))
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->bar(uniqid()))
 			->and($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called before method %s'), $asserter->getCall(), current($asserter->getBeforeMethodCalls())))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->foo(uniqid()))
@@ -425,23 +425,23 @@ class mock extends atoum\test
 			->then
 				->object($asserter->once())->isIdenticalTo($asserter)
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->afterMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getAfterMethodCalls())))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->foo(uniqid()))
 			->and($mock->bar(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called after method %s'), $asserter->getCall(), current($asserter->getAfterMethodCalls())))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->bar(uniqid()))
@@ -449,12 +449,12 @@ class mock extends atoum\test
 			->then
 				->object($asserter->once())->isIdenticalTo($asserter)
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-				->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+				->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 				->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
 				->and($mock->foo(uniqid()))
 				->then
 					->exception(function() use ($asserter) { $asserter->once(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
 		*/
 		;
@@ -467,17 +467,17 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
 			->if($mock->foo(uniqid()))
 			->then
@@ -489,7 +489,7 @@ class mock extends atoum\test
 			->and($asserter->withArguments($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->if( $mock->foo($usedArg))
@@ -498,7 +498,7 @@ class mock extends atoum\test
 			->if($asserter->withArguments($otherArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 		;
 	}
@@ -509,23 +509,23 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($otherUsedArg = uniqid()))
 			->then
@@ -533,23 +533,23 @@ class mock extends atoum\test
 			->if($mock->foo($anOtherUsedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($anOtherUsedArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($mock->foo($arg))
 			->then
@@ -557,7 +557,7 @@ class mock extends atoum\test
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg)) . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -568,12 +568,12 @@ class mock extends atoum\test
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
@@ -582,7 +582,7 @@ class mock extends atoum\test
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
@@ -591,17 +591,17 @@ class mock extends atoum\test
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter, & $message) { $asserter->never($message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 			->if($asserter->withArguments(uniqid()))
 			->then

--- a/tests/units/classes/asserters/mock/call/adapter.php
+++ b/tests/units/classes/asserters/mock/call/adapter.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\mock\call;
+namespace atoum\tests\units\asserters\mock\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\mock\call
+	atoum,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\mock\call
 ;
 
 class adapter extends atoum\test
@@ -35,7 +35,7 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($call = new call\adapter(
-					$mockAsserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()),
+					$mockAsserter = new \mock\atoum\asserters\mock(new asserter\generator()),
 					new test\adapter(),
 					uniqid()
 				)
@@ -51,7 +51,7 @@ class adapter extends atoum\test
 							$call->{$unknownFunction}();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method ' . get_class($mockAsserter) . '::' . $unknownFunction . '() does not exist')
 		;
 	}

--- a/tests/units/classes/asserters/mock/call/mock.php
+++ b/tests/units/classes/asserters/mock/call/mock.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\mock\call;
+namespace atoum\tests\units\asserters\mock\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\mock\call
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\mock\call
 ;
 
 class dummy
@@ -23,7 +23,7 @@ class mock extends atoum\test
 		$this
 			->if($call = new call\mock(
 					$mockAsserter = new asserters\mock(new asserter\generator()),
-					$mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mockAggregator = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					$function = uniqid()
 				)
 			)
@@ -39,8 +39,8 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new call\mock(
-					$mockAsserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mockAsserter = new \mock\atoum\asserters\mock(new asserter\generator()),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
@@ -55,7 +55,7 @@ class mock extends atoum\test
 							$call->{$unknownMethod}();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method ' . get_class($mockAsserter) . '::' . $unknownMethod . '() does not exist')
 		;
 	}
@@ -65,7 +65,7 @@ class mock extends atoum\test
 		$this
 			->if($call = new call\mock(
 					new asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
@@ -82,11 +82,11 @@ class mock extends atoum\test
 		$this
 			->if($call = new call\mock(
 					new asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
-			->and($mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy())
+			->and($mockAggregator = new \mock\atoum\tests\units\asserters\mock\call\dummy())
 			->then
 				->object($call->on($mockAggregator))->isIdenticalTo($call)
 				->object($call->getObject())->isIdenticalTo($mockAggregator)
@@ -98,13 +98,13 @@ class mock extends atoum\test
 		$this
 			->if($call = new call\mock(
 					new asserters\mock(new asserter\generator()),
-					$mock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mock = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					'foo'
 				)
 			)
 			->then
 				->variable($call->getFirstCall())->isNull()
-			->if($otherMock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy())
+			->if($otherMock = new \mock\atoum\tests\units\asserters\mock\call\dummy())
 			->and($otherMock->foo())
 			->then
 				->variable($call->getFirstCall())->isNull()
@@ -120,13 +120,13 @@ class mock extends atoum\test
 		$this
 			->if($call = new call\mock(
 					new asserters\mock(new asserter\generator()),
-					$mock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mock = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					'foo'
 				)
 			)
 			->then
 				->variable($call->getLastCall())->isNull()
-			->if($otherMock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy())
+			->if($otherMock = new \mock\atoum\tests\units\asserters\mock\call\dummy())
 			->and($otherMock->foo())
 			->then
 				->variable($call->getLastCall())->isNull()

--- a/tests/units/classes/asserters/mysqlDateTime.php
+++ b/tests/units/classes/asserters/mysqlDateTime.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class mysqlDateTime extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\dateTime');
+		$this->testedClass->isSubclassOf('atoum\asserters\dateTime');
 	}
 
 	public function testSetWith()
@@ -23,7 +23,7 @@ class mysqlDateTime extends atoum\test
 			->if($asserter = new asserters\mysqlDateTime($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not in format Y-m-d H:i:s'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->object($asserter->setWith($value = '1976-10-06 14:05:54'))->isIdenticalTo($asserter)

--- a/tests/units/classes/asserters/object.php
+++ b/tests/units/classes/asserters/object.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class object extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -35,14 +35,14 @@ class object extends atoum\test
 			->if($asserter = new asserters\object($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->toString; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 				->exception(function() use ($asserter, & $property) { $asserter->{$property = uniqid()}; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Asserter \'' . $property . '\' does not exist')
 			->if($asserter->setWith($this))
 			->then
-				->object($asserter->toString)->isInstanceOf('mageekguy\atoum\asserters\castToString')
+				->object($asserter->toString)->isInstanceOf('atoum\asserters\castToString')
 		;
 	}
 
@@ -52,7 +52,7 @@ class object extends atoum\test
 			->if($asserter = new asserters\object($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an object'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 				->object($asserter->setWith($value = $this))->isIdenticalTo($asserter)
@@ -68,12 +68,12 @@ class object extends atoum\test
 			->if($asserter = new asserters\object($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($this))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has not size %d'), $asserter, 0))
 				->object($asserter->hasSize(sizeof($this)))->isIdenticalTo($asserter);
 		;
@@ -85,12 +85,12 @@ class object extends atoum\test
 			->if($asserter = new asserters\object($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($this))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has size %d'), $asserter, sizeof($this)))
 			->if($asserter->setWith(new \arrayIterator()))
 			->then
@@ -104,11 +104,11 @@ class object extends atoum\test
 			->if($asserter = new asserters\object($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->toString(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($this))
 			->then
-				->object($asserter->toString())->isInstanceOf('mageekguy\atoum\asserters\castToString')
+				->object($asserter->toString())->isInstanceOf('atoum\asserters\castToString')
 		;
 	}
 }

--- a/tests/units/classes/asserters/output.php
+++ b/tests/units/classes/asserters/output.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class output extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\string');
+		$this->testedClass->isSubclassOf('atoum\asserters\string');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/asserters/phpArray.php
+++ b/tests/units/classes/asserters/phpArray.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class phpArray extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class phpArray extends atoum\test
 			->if($asserter = new asserters\phpArray($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an array'), $asserter->getTypeOf($value)))
 				->object($asserter->setWith($value = array()))->isIdenticalTo($asserter)
 				->array($asserter->getValue())->isEqualTo($value)
@@ -49,12 +49,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->exception(function() use ($asserter, & $size) { $asserter->hasSize($size = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has not size %d'), $asserter, $size))
 				->object($asserter->hasSize(0))->isIdenticalTo($asserter)
 		;
@@ -67,12 +67,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not empty'), $asserter))
 			->if($asserter->setWith(array()))
 			->then
@@ -87,12 +87,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array()))
 				->then
 					->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is empty'), $asserter))
 				->if($asserter->setWith(array(uniqid())))
 				->then
@@ -107,12 +107,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-                ->isInstanceOf('mageekguy\atoum\exceptions\logic')
+                ->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid(), uniqid(), $value = rand(1, PHP_INT_MAX), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter, & $notInArray) { $asserter->contains($notInArray = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not contain %s'), $asserter, $asserter->getTypeOf($notInArray)))
 				->object($asserter->contains($value))->isIdenticalTo($asserter)
 				->object($asserter->contains((string) $value))->isIdenticalTo($asserter)
@@ -126,15 +126,15 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 				->then
 					->exception(function() use ($asserter) { $asserter->containsValues(array(6)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array(6))))
 					->exception(function() use ($asserter) { $asserter->containsValues(array('6')); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array('6'))))
 					->object($asserter->containsValues(array(1)))->isIdenticalTo($asserter)
 					->object($asserter->containsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
@@ -149,15 +149,15 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 			->then
 				->exception(function() use ($asserter) { $asserter->notContainsValues(array(1, 6)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1))))
 				->exception(function() use ($asserter) { $asserter->notContainsValues(array('1', '6')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array('1'))))
 				->object($asserter->containsValues(array(1)))->isIdenticalTo($asserter)
 				->object($asserter->containsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
@@ -172,23 +172,23 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 				->then
 					->exception(function() use ($asserter) { $asserter->strictlyContainsValues(array(6)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(6))))
             ->exception(function() use ($asserter) { $asserter->strictlyContainsValues(array('6')); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
+                ->isInstanceOf('atoum\asserter\exception')
                 ->hasMessage(sprintf($generator->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array('6'))))
             ->exception(function() use ($asserter) { $asserter->strictlyContainsValues(array('1')); })
-                ->isInstanceOf('mageekguy\atoum\asserter\exception')
+                ->isInstanceOf('atoum\asserter\exception')
                 ->hasMessage(sprintf($generator->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array('1'))))
             ->object($asserter->strictlyContainsValues(array(1)))->isIdenticalTo($asserter)
             ->object($asserter->strictlyContainsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
 				 ->exception(function() use ($asserter) { $asserter->strictlyContainsValues(array('1', 2, '4')); })
-					  ->isInstanceOf('mageekguy\atoum\asserter\exception')
+					  ->isInstanceOf('atoum\asserter\exception')
 					  ->hasMessage(sprintf($generator->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array('1', '4'))))
 		;
 	}
@@ -200,15 +200,15 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 				->then
 					->exception(function() use ($asserter) { $asserter->strictlyNotContainsValues(array(1)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1))))
 					->exception(function() use ($asserter) { $asserter->strictlyNotContainsValues(array(1, '2', 3)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1, 3))))
 					->object($asserter->strictlyNotContainsValues(array('1')))->isIdenticalTo($asserter)
 					->object($asserter->strictlyNotContainsValues(array(6, 7, '2', 8)))->isIdenticalTo($asserter)
@@ -222,12 +222,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->and($asserter->setWith(array(1)))
 			->then
 				->exception(function() use ($asserter) {$asserter->strictlyContains('1'); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not strictly contain %s'), $asserter, $asserter->getTypeOf('1')))
 				->object($asserter->strictlyContains(1))->isIdenticalTo($asserter)
 		;
@@ -240,12 +240,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(1)))
 			->then
 				->exception(function() use ($asserter) {$asserter->strictlyNotContains(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains strictly %s'), $asserter, $asserter->getTypeOf(1)))
 				->object($asserter->strictlyNotContains('1'))->isIdenticalTo($asserter)
 		;
@@ -258,16 +258,16 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->notContains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid(), uniqid(), $inArray = uniqid(), uniqid(), uniqid())))
 			->then
 				->object($asserter->notContains(uniqid()))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $inArray) { $asserter->notContains($inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s'), $asserter, $asserter->getTypeOf($inArray)))
 				->exception(function() use($asserter, $inArray){ $asserter->notContains((string) $inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s'), $asserter, $asserter->getTypeOf((string) $inArray)))
         ;
 	}
@@ -279,12 +279,12 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->exception(function() use ($asserter, & $key) { $asserter->hasKey($key = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key)))
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
@@ -294,7 +294,7 @@ class phpArray extends atoum\test
 				->object($asserter->hasKey(3))->isIdenticalTo($asserter)
 				->object($asserter->hasKey(4))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->hasKey(5); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf(5)))
 		;
 	}
@@ -306,7 +306,7 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
@@ -314,7 +314,7 @@ class phpArray extends atoum\test
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->notHasKey(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has a key %s'), $asserter, $asserter->getTypeOf(0)))
 				->object($asserter->notHasKey(5))->isIdenticalTo($asserter)
 		;
@@ -327,7 +327,7 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
@@ -336,7 +336,7 @@ class phpArray extends atoum\test
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->notHasKeys(array(0, 'premier', 2)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should not have keys %s'), $asserter, $asserter->getTypeOf(array(0, 2))))
 				->object($asserter->notHasKeys(array(5, '6')))->isIdenticalTo($asserter)
 		;
@@ -349,17 +349,17 @@ class phpArray extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasKeys(array(0)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array(0))))
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasKeys(array(0, 'first', 2, 'second')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array('first', 'second'))))
 			->object($asserter->hasKeys(array(0, 2, 4)))->isIdenticalTo($asserter)
 		;

--- a/tests/units/classes/asserters/phpClass.php
+++ b/tests/units/classes/asserters/phpClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -21,7 +21,7 @@ class phpClass extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -54,7 +54,7 @@ class phpClass extends atoum\test
 				->object($asserter->setReflectionClassInjector(function($class) use (& $reflectionClass) { return ($reflectionClass = new \mock\reflectionClass($class)); }))->isIdenticalTo($asserter)
 				->object($asserter->getReflectionClass($class = uniqid()))->isIdenticalTo($reflectionClass)
 				->exception(function() use ($asserter) { $asserter->setReflectionClassInjector(function() {}); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Reflection class injector must take one argument')
 		;
 	}
@@ -73,7 +73,7 @@ class phpClass extends atoum\test
 			->if($asserter->setReflectionClassInjector(function($class) use (& $reflectionClass) { return uniqid(); }))
 			->then
 				->exception(function() use ($asserter) { $asserter->getReflectionClass(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Reflection class injector must return a \reflectionClass instance')
 		;
 	}
@@ -88,7 +88,7 @@ class phpClass extends atoum\test
 			->and($class = uniqid())
 			->then
 				->exception(function() use ($asserter, $class) { $asserter->setWith($class); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class \'%s\' does not exist'), $class))
 			->if($asserter = new asserters\phpClass($generator = new asserter\generator()))
 			->then
@@ -118,7 +118,7 @@ class phpClass extends atoum\test
 			->and($mockController->getParentClass = function() use ($parent, $parentMockController) { return new \mock\reflectionClass($parent, $parentMockController); })
 			->then
 				->exception(function() use ($asserter, $parent) { $asserter->hasParent($parent); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not the parent of class %s'), $parent, $class))
 			->if($parentMockController->getName = function() use ($parent) { return $parent; })
 			->then
@@ -149,7 +149,7 @@ class phpClass extends atoum\test
 			->and($reflectionClass->getMockController()->getParentClass = function() use ($parentClass) { return $parentClass; })
 			->then
 				->exception(function() use ($asserter) { $asserter->hasNoParent(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('class %s has parent %s'), $className, $parentClass))
 		;
 	}
@@ -174,7 +174,7 @@ class phpClass extends atoum\test
 			->and($mockController->isSubclassOf = false)
 			->then
 				->exception(function() use ($asserter, $parentClass) { $asserter->isSubclassOf($parentClass); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s is not a sub-class of %s'), $class, $parentClass))
 			->if($mockController->isSubclassOf = true)
 			->then
@@ -202,7 +202,7 @@ class phpClass extends atoum\test
 			->and($mockController->implementsInterface = false)
 			->then
 				->exception(function() use ($asserter, $interface) { $asserter->hasInterface($interface); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s does not implement interface %s'), $class, $interface))
 			->if($mockController->implementsInterface = true)
 			->then
@@ -229,7 +229,7 @@ class phpClass extends atoum\test
 			->and($mockController->isAbstract = false)
 			->then
 				->exception(function() use ($asserter) { $asserter->isAbstract(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s is not abstract'), $class))
 			->if($mockController->isAbstract = true)
 			->then
@@ -257,7 +257,7 @@ class phpClass extends atoum\test
 			)
 			->then
 				->exception(function() use ($asserter, $method) { $asserter->hasMethod($method); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Method %s::%s() does not exist'), $class, $method))
 			->if($reflectionClassController->hasMethod = true)
 			->then

--- a/tests/units/classes/asserters/sizeOf.php
+++ b/tests/units/classes/asserters/sizeOf.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class sizeOf extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\integer');
+		$this->testedClass->isSubclassOf('atoum\asserters\integer');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/asserters/stream.php
+++ b/tests/units/classes/asserters/stream.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class stream extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -51,14 +51,14 @@ class stream extends atoum\test
 			->if($asserter = new asserters\stream($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isRead(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Stream is undefined')
 			->if($streamController = atoum\mock\stream::get($streamName = uniqid()))
 			->and($streamController->file_get_contents = uniqid())
 			->and($asserter->setWith($streamName))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->isRead(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage = sprintf($generator->getLocale()->_('stream %s is not read'), $streamName))
 				->when(function() use ($streamName) { file_get_contents('atoum://' . $streamName); })
 					->object($asserter->isRead())->isIdenticalTo($asserter)
@@ -71,14 +71,14 @@ class stream extends atoum\test
 			->if($asserter = new asserters\stream($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isWrited(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Stream is undefined')
 			->if($streamController = atoum\mock\stream::get($streamName = uniqid()))
 			->and($streamController->file_put_contents = strlen($contents = uniqid()))
 			->and($asserter->setWith($streamName))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->isWrited(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage = sprintf($generator->getLocale()->_('stream %s is not writed'), $streamName))
 				->when(function() use ($streamName, $contents) { file_put_contents('atoum://' . $streamName, $contents); })
 					->object($asserter->isWrited())->isIdenticalTo($asserter)

--- a/tests/units/classes/asserters/string.php
+++ b/tests/units/classes/asserters/string.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class string extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -50,7 +50,7 @@ class string extends atoum\test
 			->if($asserter = new asserters\string($generator = new asserter\generator()))
 			->then
 				->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a string'), $asserter->getTypeOf($value)))
 				->integer($asserter->getValue())->isEqualTo($value)
 				->variable($asserter->getCharlist())->isNull()
@@ -70,13 +70,13 @@ class string extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEqualTo(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($firstString = uniqid()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $secondString) { $asserter->isEqualTo($secondString = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('strings are not equals') . PHP_EOL . $diff->setReference($secondString)->setData($firstString))
 			->object($asserter->isEqualTo($firstString))->isIdenticalTo($asserter)
 		;
@@ -89,19 +89,19 @@ class string extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEqualToContentsOfFile(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($firstString = uniqid()))
 			->and($adapter->file_get_contents = false)
 			->then
 				->exception(function() use ($asserter, & $path) { $asserter->isEqualToContentsOfFile($path = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Unable to get contents of file %s'), $path))
 			->if($adapter->file_get_contents = $fileContents = uniqid())
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $path) { $asserter->isEqualToContentsOfFile($path); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('string is not equals to contents of file %s'), $path) . PHP_EOL . $diff->setReference($fileContents)->setData($firstString))
 			->if($adapter->file_get_contents = $firstString)
 			->then
@@ -115,13 +115,13 @@ class string extends atoum\test
 			->if($asserter = new asserters\string($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = uniqid()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('strings are not equals') . PHP_EOL . $diff->setReference('')->setData($string))
 			->if($asserter->setWith(''))
 			->then
@@ -135,13 +135,13 @@ class string extends atoum\test
 			->if($asserter = new asserters\string($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('string is empty'))
 			->if($asserter->setWith($string = uniqid()))
 			->then
@@ -155,13 +155,13 @@ class string extends atoum\test
 			->if($asserter = new asserters\string($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLength(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $requiredLength) { $asserter->hasLength($requiredLength = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not %d'), $asserter->getTypeOf(''), $requiredLength))
 				->object($asserter->hasLength(0))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = uniqid()))
@@ -176,20 +176,20 @@ class string extends atoum\test
 			->if($asserter = new asserters\string($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = uniqid()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $fragment) { $asserter->contains($fragment = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
 				->object($asserter->contains($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith(uniqid() . $string . uniqid()))
 			->then
 				->object($asserter->contains($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->contains($fragment = strtoupper($string)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
 		;
 	}

--- a/tests/units/classes/asserters/testedClass.php
+++ b/tests/units/classes/asserters/testedClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class testedClass extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\phpClass');
+		$this->testedClass->isSubclassOf('atoum\asserters\phpClass');
 	}
 
 	public function testSetWith()
@@ -23,7 +23,7 @@ class testedClass extends atoum\test
 			->if($asserter = new asserters\testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->setWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\badMethodCall')
+					->isInstanceOf('atoum\exceptions\logic\badMethodCall')
 					->hasMessage('Unable to call method ' . get_class($asserter) . '::setWith()')
 		;
 	}

--- a/tests/units/classes/asserters/variable.php
+++ b/tests/units/classes/asserters/variable.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\tools\diffs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class variable extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -119,14 +119,14 @@ class variable extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use (& $line, $asserter, & $notEqualValue) { $line = __LINE__; $asserter->isEqualTo($notEqualValue = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf($notEqualValue)) . PHP_EOL . $diff->setReference($notEqualValue)->setData($asserter->getValue()))
 			->if($asserter->setWith(1))
 			->and($otherDiff = new diffs\variable())
 			->then
 				->object($asserter->isEqualTo('1'))->isIdenticalTo($asserter)
 				->exception(function() use (& $otherLine, $asserter, & $otherNotEqualValue, & $otherFailMessage) { $otherLine = __LINE__; $asserter->isEqualTo($otherNotEqualValue = uniqid(), $otherFailMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($otherFailMessage . PHP_EOL . $otherDiff->setReference($otherNotEqualValue)->setData($asserter->getValue()))
 		;
 	}
@@ -144,10 +144,10 @@ class variable extends atoum\test
 				->then
 					->object($asserter->isNotEqualTo(uniqid()))->isIdenticalTo($asserter)
 					->exception(function() use ($asserter, $value) { $asserter->isNotEqualTo($value); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is equal to %s'), $asserter, $asserter->getTypeOf($value)))
 					->exception(function() use ($asserter, $value, & $failMessage) { $asserter->isNotEqualTo($value, $failMessage = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($failMessage)
 		;
 	}
@@ -167,10 +167,10 @@ class variable extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $notIdenticalValue, $value) { $asserter->isIdenticalTo($notIdenticalValue = (string) $value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not identical to %s'), $asserter, $asserter->getTypeOf($notIdenticalValue)) . PHP_EOL . $diff->setReference($notIdenticalValue)->setData($asserter->getValue()))
 				->exception(function() use ($asserter, $notIdenticalValue, & $failMessage) { $asserter->isIdenticalTo($notIdenticalValue, $failMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage . PHP_EOL . $diff->setReference($notIdenticalValue)->setData($asserter->getValue()))
 		;
 	}
@@ -188,7 +188,7 @@ class variable extends atoum\test
 			->then
 			->object($asserter->isNotIdenticalTo(uniqid()))->isIdenticalTo($asserter)
 			->exception(function() use ($asserter, & $notIdenticalValue, $value) { $asserter->isNotIdenticalTo($value); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
+				->isInstanceOf('atoum\asserter\exception')
 				->hasMessage(sprintf($generator->getLocale()->_('%s is identical to %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -208,22 +208,22 @@ class variable extends atoum\test
 			->if($asserter->setWith(''))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 			->if($asserter->setWith(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 			->if($asserter->setWith(0))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 			->if($asserter->setWith(false))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 		;
 	}
@@ -243,7 +243,7 @@ class variable extends atoum\test
 			->if($asserter->setWith(null))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is null'), $asserter))
 		;
 	}
@@ -273,7 +273,7 @@ class variable extends atoum\test
 			->if($notReference = uniqid())
 			->then
 				->exception(function() use ($asserter, $notReference) { $asserter->isReferenceTo($notReference); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a reference to %s'), $asserter, $asserter->getTypeOf($notReference)))
 			->if($value = new \exception())
 			->and($reference = $value)
@@ -285,7 +285,7 @@ class variable extends atoum\test
 			->if($notReference = new \exception())
 			->then
 				->exception(function() use ($asserter, $notReference) { $asserter->isReferenceTo($notReference); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a reference to %s'), $asserter, $asserter->getTypeOf($notReference)))
 		;
 	}

--- a/tests/units/classes/autoloader.php
+++ b/tests/units/classes/autoloader.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -15,7 +15,7 @@ class autoloader extends atoum\test
 		$autoloader = new atoum\autoloader();
 
 		$this->assert
-            ->array($directories = $autoloader->getDirectories())->hasKey('mageekguy\atoum')
-            ->array($directories['mageekguy\atoum'])->isEqualTo(array(atoum\directory . (\phar::running() ? '/' : DIRECTORY_SEPARATOR) . 'classes'));
+            ->array($directories = $autoloader->getDirectories())->hasKey('atoum')
+            ->array($directories['atoum'])->isEqualTo(array(atoum\directory . (\phar::running() ? '/' : DIRECTORY_SEPARATOR) . 'classes'));
 	}
 }

--- a/tests/units/classes/cli.php
+++ b/tests/units/classes/cli.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -82,7 +82,7 @@ class cli extends atoum\test
 			->boolean($otherCli->isTerminal())->isFalse()
 		;
 
-		\mageekguy\atoum\cli::forceTerminal();
+		\atoum\cli::forceTerminal();
 
 		$this->assert
 			->boolean($cli->isTerminal())->isTrue()
@@ -92,7 +92,7 @@ class cli extends atoum\test
 
 	public function testIsTerminalWhenForceTerminalWasUsedBeforeFirstCallToConstructor()
 	{
-		\mageekguy\atoum\cli::forceTerminal();
+		\atoum\cli::forceTerminal();
 
 		$adapter = new atoum\test\adapter();
 		$adapter->defined = false;

--- a/tests/units/classes/cli/colorizer.php
+++ b/tests/units/classes/cli/colorizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\cli;
+namespace atoum\tests\units\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli
+	atoum,
+	atoum\cli
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -106,7 +106,7 @@ class colorizer extends atoum\test
 
 	public function testColorize()
 	{
-		$colorizer = new cli\colorizer(null, null, $cli = new \mock\mageekguy\atoum\cli());
+		$colorizer = new cli\colorizer(null, null, $cli = new \mock\atoum\cli());
 
 		$cli->getMockController()->isTerminal = true;
 

--- a/tests/units/classes/cli/progressBar.php
+++ b/tests/units/classes/cli/progressBar.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\cli;
+namespace atoum\tests\units\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\cli,
+	atoum\mock
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -61,7 +61,7 @@ class progressBar extends atoum\test
 
 	public function testRefresh()
 	{
-		$cli = new \mock\mageekguy\atoum\cli();
+		$cli = new \mock\atoum\cli();
 		$cli->getMockController()->isTerminal = true;
 
 		$progressBar = new cli\progressBar(0, $cli);

--- a/tests/units/classes/cli/prompt.php
+++ b/tests/units/classes/cli/prompt.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\cli;
+namespace atoum\tests\units\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli
+	atoum,
+	atoum\cli
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -17,7 +17,7 @@ class prompt extends atoum\test
 
 		$this->assert
 			->string($prompt->getValue())->isEmpty()
-			->object($prompt->getColorizer())->isInstanceOf('mageekguy\atoum\cli\colorizer')
+			->object($prompt->getColorizer())->isInstanceOf('atoum\cli\colorizer')
 			->variable($prompt->getColorizer()->getForeground())->isNull()
 			->variable($prompt->getColorizer()->getBackground())->isNull()
 		;
@@ -26,7 +26,7 @@ class prompt extends atoum\test
 
 		$this->assert
 			->string($prompt->getValue())->isEqualTo($value)
-			->object($prompt->getColorizer())->isInstanceOf('mageekguy\atoum\cli\colorizer')
+			->object($prompt->getColorizer())->isInstanceOf('atoum\cli\colorizer')
 			->variable($prompt->getColorizer()->getForeground())->isNull()
 			->variable($prompt->getColorizer()->getBackground())->isNull()
 		;

--- a/tests/units/classes/configurator.php
+++ b/tests/units/classes/configurator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -25,9 +25,9 @@ class configurator extends atoum\test
 	{
 		$this
 			->assert
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($runner->getMockController()->setBootstrapFile = function() {})
-				->and($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+				->and($script = new \mock\atoum\scripts\runner(uniqid()))
 				->and($script->setRunner($runner))
 				->and($configurator = new atoum\configurator($script))
 				->then
@@ -38,10 +38,10 @@ class configurator extends atoum\test
 					->object($configurator->bootstrapFile($bootstrapFile = uniqid()))->isIdenticalTo($configurator)
 					->mock($runner)->call('setBootstrapFile')->withArguments($bootstrapFile)->once()
 				->exception(function() use ($configurator, & $method) { $configurator->{$method = uniqid()}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Method \'' . $method . '\' is unavailable')
 				->exception(function() use ($configurator) { $configurator->setPhpPath(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Method \'setPhpPath\' is unavailable')
 		;
 	}

--- a/tests/units/classes/dependencies.php
+++ b/tests/units/classes/dependencies.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 require_once __DIR__ . '/../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\dependencies as testedClass
+	atoum,
+	atoum\dependencies as testedClass
 ;
 
 class dependencies extends atoum\test
@@ -69,7 +69,7 @@ class dependencies extends atoum\test
 			->if($dependencies = new testedClass())
 			->then
 				->exception(function() use ($dependencies, & $argument) { $dependencies->{$argument = uniqid()}; })
-					->isInstanceOf('mageekguy\atoum\dependencies\exception')
+					->isInstanceOf('atoum\dependencies\exception')
 					->hasMessage('Argument \'' . $argument . '\' is undefined')
 			->if($dependencies->setArgument($name = uniqid(), $value = uniqid()))
 			->then
@@ -218,7 +218,7 @@ class dependencies extends atoum\test
 			->if($dependencies = new testedClass())
 			->then
 				->exception(function() use ($dependencies, & $argument) { $dependencies->getArgument($argument = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\dependencies\exception')
+					->isInstanceOf('atoum\dependencies\exception')
 					->hasMessage('Argument \'' . $argument . '\' is undefined')
 			->if($dependencies->setArgument($name = uniqid(), $value = uniqid()))
 			->then

--- a/tests/units/classes/exceptions/logic.php
+++ b/tests/units/classes/exceptions/logic.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions;
+namespace atoum\tests\units\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,7 +18,7 @@ class logic extends atoum\test
 		$this->assert
 			->object($logicExcepion)
 				->isInstanceOf('logicException')
-				->isInstanceOf('mageekguy\atoum\exception')
+				->isInstanceOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/logic/badMethodCall.php
+++ b/tests/units/classes/exceptions/logic/badMethodCall.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions\logic;
+namespace atoum\tests\units\exceptions\logic;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\logic
+	atoum,
+	atoum\exceptions\logic
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class badMethodCall extends atoum\test
 			->testedClass
 				->isSubclassOf('logicException')
 				->isSubclassOf('badMethodCallException')
-				->isSubclassOf('mageekguy\atoum\exception')
+				->isSubclassOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/logic/invalidArgument.php
+++ b/tests/units/classes/exceptions/logic/invalidArgument.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions\logic;
+namespace atoum\tests\units\exceptions\logic;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\logic
+	atoum,
+	atoum\exceptions\logic
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class invalidArgument extends atoum\test
 			->testedClass
 				->isSubclassOf('logicException')
 				->isSubclassOf('invalidArgumentException')
-				->isSubclassOf('mageekguy\atoum\exception')
+				->isSubclassOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/runtime.php
+++ b/tests/units/classes/exceptions/runtime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions;
+namespace atoum\tests\units\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,7 +18,7 @@ class runtime extends atoum\test
 		$this->assert
 			->object($runtimeExcepion)
 				->isInstanceOf('runtimeException')
-				->isInstanceOf('mageekguy\atoum\exception')
+				->isInstanceOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/runtime/unexpectedValue.php
+++ b/tests/units/classes/exceptions/runtime/unexpectedValue.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions\runtime;
+namespace atoum\tests\units\exceptions\runtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\runtime
+	atoum,
+	atoum\exceptions\runtime
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -19,7 +19,7 @@ class unexpectedValue extends atoum\test
 			->object($unexpectedValueException)
 				->isInstanceOf('runtimeException')
 				->isInstanceOf('unexpectedValueException')
-				->isInstanceOf('mageekguy\atoum\exception')
+				->isInstanceOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/factory.php
+++ b/tests/units/classes/factory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require __DIR__ . '/../runner.php';
@@ -68,7 +68,7 @@ class factory extends atoum\test
 				->object($arrayIterator = $factory->build('arrayIterator', array(array())))->isEqualTo(new \arrayIterator())
 				->object($arrayIterator = $factory->build('arrayIterator', array($data = array(uniqid(), uniqid(), uniqid()))))->isEqualTo(new \arrayIterator($data))
 				->exception(function() use ($factory, & $class) { $factory->build($class = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\factory\exception')
+					->isInstanceOf('atoum\factory\exception')
 					->hasMessage('Class \'' . $class . '\' does not exist')
 			->if($factory->setBuilder('arrayIterator', function() use (& $return) { return ($return = new \arrayIterator); }))
 				->object($arrayIterator = $factory->build('arrayIterator'))->isIdenticalTo($return)
@@ -78,16 +78,16 @@ class factory extends atoum\test
 			->if($factory->setBuilder('arrayIterator', function() use (& $return) { return ($return = uniqid()); }))
 			->then
 				->string($factory->build('arrayIterator'))->isEqualTo($return)
-			->if($factory->import('mageekguy\atoum'))
+			->if($factory->import('atoum'))
 			->then
 				->object($factory->build('atoum\adapter'))->isEqualTo(new atoum\adapter())
-			->if($factory->import('mageekguy\atoum', 'foo'))
+			->if($factory->import('atoum', 'foo'))
 			->then
 				->object($factory->build('foo\adapter'))->isEqualTo(new atoum\adapter())
-			->if($factory->import('mageekguy\atoum\adapter'))
+			->if($factory->import('atoum\adapter'))
 			->then
 				->object($factory->build('adapter'))->isEqualTo(new atoum\adapter())
-			->if($factory->import('mageekguy\atoum\adapter', 'bar'))
+			->if($factory->import('atoum\adapter', 'bar'))
 			->then
 				->object($factory->build('bar'))->isEqualTo(new atoum\adapter())
 		;
@@ -225,7 +225,7 @@ class factory extends atoum\test
 				->object($factory->import('foo\bar\toto', 'tutu'))->isIdenticalTo($factory)
 				->array($factory->getImportations())->isEqualTo(array('foo' => 'foo', 'bar' => 'foo', 'truc' => 'foo\bar', 'tutu' => 'foo\bar\toto'))
 				->exception(function() use ($factory) { $factory->import('foo\bar\tutu'); })
-					->isInstanceOf('mageekguy\atoum\factory\exception')
+					->isInstanceOf('atoum\factory\exception')
 					->hasMessage('Unable to use \'foo\bar\tutu\' as \'tutu\' because the name is already in use')
 		;
 	}

--- a/tests/units/classes/factory/exception.php
+++ b/tests/units/classes/factory/exception.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\factory;
+namespace atoum\tests\units\factory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 require __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class exception extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\exceptions\runtime')
+			->testedClass->isSubclassOf('atoum\exceptions\runtime')
 		;
 	}
 }

--- a/tests/units/classes/includer.php
+++ b/tests/units/classes/includer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\stream
+	atoum,
+	atoum\mock\stream
 ;
 
 require __DIR__ . '/../runner.php';
@@ -18,7 +18,7 @@ class includer extends atoum\test
 			->and($unknownFile = stream::get())
 			->then
 				->exception(function() use ($includer, $unknownFile) { $includer->includePath($unknownFile); })
-					->isInstanceOf('mageekguy\atoum\includer\exception')
+					->isInstanceOf('atoum\includer\exception')
 					->hasMessage('Unable to include \'' . $unknownFile . '\'')
 			->if($file = stream::get())
 			->and($file->file_get_contents = $fileContents = uniqid())

--- a/tests/units/classes/iterators/filters/recursives/dot.php
+++ b/tests/units/classes/iterators/filters/recursives/dot.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\filters\recursives;
+namespace atoum\tests\units\iterators\filters\recursives;
 
 require __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\iterators\filters\recursives
+	atoum,
+	atoum\mock,
+	atoum\iterators\filters\recursives
 ;
 
 class dot extends atoum\test
@@ -29,7 +29,7 @@ class dot extends atoum\test
 			->and($factory->setBuilder('recursiveDirectoryIterator', function($path) use (& $innerIterator) { return ($innerIterator = new \mock\recursiveDirectoryIterator($path)); }))
 			->and($filterController = new mock\controller())
 			->and($filterController->createFactory = $factory)
-			->and($filter = new \mock\mageekguy\atoum\iterators\filters\recursives\dot($path = uniqid()))
+			->and($filter = new \mock\atoum\iterators\filters\recursives\dot($path = uniqid()))
 			->then
 				->object($filter->getInnerIterator())->isIdenticalTo($innerIterator)
 				->mock($filter->getInnerIterator())->call('__construct')->withArguments($path)->once()
@@ -60,7 +60,7 @@ class dot extends atoum\test
 		$this
 			->if($filter = new recursives\dot(new \mock\recursiveIterator()))
 			->then
-				->object($filter->createFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($filter->createFactory())->isInstanceOf('atoum\factory')
 		;
 	}
 }

--- a/tests/units/classes/iterators/filters/recursives/extension.php
+++ b/tests/units/classes/iterators/filters/recursives/extension.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\filters\recursives;
+namespace atoum\tests\units\iterators\filters\recursives;
 
 require __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\iterators\filters\recursives
+	atoum,
+	atoum\mock,
+	atoum\iterators\filters\recursives
 ;
 
 class extension extends atoum\test
@@ -30,7 +30,7 @@ class extension extends atoum\test
 			->and($factory->setBuilder('recursiveDirectoryIterator', function($path) use (& $innerIterator) { return ($innerIterator = new \mock\recursiveDirectoryIterator($path)); }))
 			->and($filterController = new mock\controller())
 			->and($filterController->createFactory = $factory)
-			->and($filter = new \mock\mageekguy\atoum\iterators\filters\recursives\extension($path = uniqid(), $acceptedExtensions = array('php')))
+			->and($filter = new \mock\atoum\iterators\filters\recursives\extension($path = uniqid(), $acceptedExtensions = array('php')))
 			->then
 				->object($filter->getInnerIterator())->isIdenticalTo($innerIterator)
 				->mock($filter->getInnerIterator())->call('__construct')->withArguments($path)->once()

--- a/tests/units/classes/iterators/recursives/atoum/source.php
+++ b/tests/units/classes/iterators/recursives/atoum/source.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\recursives\atoum;
+namespace atoum\tests\units\iterators\recursives\atoum;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\mock\stream
+	atoum,
+	atoum\iterators,
+	atoum\mock\stream
 ;
 
 class source extends atoum\test

--- a/tests/units/classes/iterators/recursives/directory.php
+++ b/tests/units/classes/iterators/recursives/directory.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\recursives;
+namespace atoum\tests\units\iterators\recursives;
 
 require_once __DIR__ . '/../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators\filters,
-	mageekguy\atoum\iterators\recursives
+	atoum,
+	atoum\iterators\filters,
+	atoum\iterators\recursives
 ;
 
 class directory extends atoum\test
@@ -118,36 +118,36 @@ class directory extends atoum\test
 	public function testGetIterator()
 	{
 		$this
-			->if($iterator = new \mock\mageekguy\atoum\iterators\recursives\directory())
+			->if($iterator = new \mock\atoum\iterators\recursives\directory())
 			->then
 				->exception(function() use ($iterator) {
 						$iterator->getIterator();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path is undefined')
-			->if($factory = new \mock\mageekguy\atoum\factory())
+			->if($factory = new \mock\atoum\factory())
 			->and($factory->setBuilder('recursiveDirectoryIterator', function($path) use (& $recursiveDirectoryIterator) { return ($recursiveDirectoryIterator = new \mock\recursiveDirectoryIterator($path)); }))
 			->and($iterator = new recursives\directory($path = uniqid(), $factory))
 			->then
-				->object($filterIterator = $iterator->getIterator())->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\extension')
-				->object($filterIterator->getInnerIterator())->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\dot')
+				->object($filterIterator = $iterator->getIterator())->isInstanceOf('atoum\iterators\filters\recursives\extension')
+				->object($filterIterator->getInnerIterator())->isInstanceOf('atoum\iterators\filters\recursives\dot')
 				->object($filterIterator->getInnerIterator()->getInnerIterator())->isIdenticalTo($recursiveDirectoryIterator)
 				->mock($factory)->call('build')
 					->withArguments('recursiveDirectoryIterator', array($path))->once()
-					->withArguments('mageekguy\atoum\iterators\filters\recursives\dot', array($recursiveDirectoryIterator))->once()
-					->withArguments('mageekguy\atoum\iterators\filters\recursives\extension', array(new atoum\iterators\filters\recursives\dot($recursiveDirectoryIterator), array('php')))->once()
+					->withArguments('atoum\iterators\filters\recursives\dot', array($recursiveDirectoryIterator))->once()
+					->withArguments('atoum\iterators\filters\recursives\extension', array(new atoum\iterators\filters\recursives\dot($recursiveDirectoryIterator), array('php')))->once()
 			->if($iterator->acceptDots())
 			->then
-				->object($filterIterator = $iterator->getIterator())->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\extension')
+				->object($filterIterator = $iterator->getIterator())->isInstanceOf('atoum\iterators\filters\recursives\extension')
 				->object($filterIterator->getInnerIterator())->isIdenticalTo($recursiveDirectoryIterator)
 				->mock($factory)->call('build')
 					->withArguments('recursiveDirectoryIterator', array($path))->exactly(2)
-					->withArguments('mageekguy\atoum\iterators\filters\recursives\extension', array($recursiveDirectoryIterator, array('php')))->once()
+					->withArguments('atoum\iterators\filters\recursives\extension', array($recursiveDirectoryIterator, array('php')))->once()
 			->if($iterator->refuseDots())
 			->and($iterator->acceptExtensions(array()))
 			->then
-				->object($filterIterator = $iterator->getIterator())->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\dot')
+				->object($filterIterator = $iterator->getIterator())->isInstanceOf('atoum\iterators\filters\recursives\dot')
 				->object($filterIterator->getInnerIterator())->isIdenticalTo($recursiveDirectoryIterator)
 				->mock($factory)->call('build')
 					->withArguments('recursiveDirectoryIterator', array($path))->exactly(3)
@@ -159,24 +159,24 @@ class directory extends atoum\test
 					->withArguments('recursiveDirectoryIterator', array($path))->exactly(4)
 			->if($iterator = new recursives\directory(null, $factory))
 			->then
-				->object($filterIterator = $iterator->getIterator($path = uniqid()))->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\extension')
-				->object($filterIterator->getInnerIterator())->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\dot')
+				->object($filterIterator = $iterator->getIterator($path = uniqid()))->isInstanceOf('atoum\iterators\filters\recursives\extension')
+				->object($filterIterator->getInnerIterator())->isInstanceOf('atoum\iterators\filters\recursives\dot')
 				->object($filterIterator->getInnerIterator()->getInnerIterator())->isIdenticalTo($recursiveDirectoryIterator)
 				->mock($factory)->call('build')
 					->withArguments('recursiveDirectoryIterator', array($path))->once()
-					->withArguments('mageekguy\atoum\iterators\filters\recursives\dot', array($recursiveDirectoryIterator))->once()
-					->withArguments('mageekguy\atoum\iterators\filters\recursives\extension', array(new atoum\iterators\filters\recursives\dot($recursiveDirectoryIterator), array('php')))->exactly(2)
+					->withArguments('atoum\iterators\filters\recursives\dot', array($recursiveDirectoryIterator))->once()
+					->withArguments('atoum\iterators\filters\recursives\extension', array(new atoum\iterators\filters\recursives\dot($recursiveDirectoryIterator), array('php')))->exactly(2)
 			->if($iterator->acceptDots())
 			->then
-				->object($filterIterator = $iterator->getIterator($path = uniqid()))->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\extension')
+				->object($filterIterator = $iterator->getIterator($path = uniqid()))->isInstanceOf('atoum\iterators\filters\recursives\extension')
 				->object($filterIterator->getInnerIterator())->isIdenticalTo($recursiveDirectoryIterator)
 				->mock($factory)->call('build')
 					->withArguments('recursiveDirectoryIterator', array($path))->once()
-					->withArguments('mageekguy\atoum\iterators\filters\recursives\extension', array($recursiveDirectoryIterator, array('php')))->once()
+					->withArguments('atoum\iterators\filters\recursives\extension', array($recursiveDirectoryIterator, array('php')))->once()
 			->if($iterator->refuseDots())
 			->and($iterator->acceptExtensions(array()))
 			->then
-				->object($filterIterator = $iterator->getIterator($path = uniqid()))->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\dot')
+				->object($filterIterator = $iterator->getIterator($path = uniqid()))->isInstanceOf('atoum\iterators\filters\recursives\dot')
 				->object($filterIterator->getInnerIterator())->isIdenticalTo($recursiveDirectoryIterator)
 				->mock($factory)->call('build')
 					->withArguments('recursiveDirectoryIterator', array($path))->once()

--- a/tests/units/classes/locale.php
+++ b/tests/units/classes/locale.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';

--- a/tests/units/classes/mailers/mail.php
+++ b/tests/units/classes/mailers/mail.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mailers;
+namespace atoum\tests\units\mailers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mailers
+	atoum,
+	atoum\mailers
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,8 +15,8 @@ class mail extends atoum\test
 	{
 		$this->assert
 			->class($this->getTestedClassName())
-				->isSubClassOf('mageekguy\atoum\mailer')
-				->hasInterface('mageekguy\atoum\adapter\aggregator')
+				->isSubClassOf('atoum\mailer')
+				->hasInterface('atoum\adapter\aggregator')
 			->string(mailers\mail::eol)->isEqualTo("\r\n")
 		;
 	}
@@ -31,7 +31,7 @@ class mail extends atoum\test
 			->variable($mail->getSubject())->isNull()
 			->variable($mail->getReplyTo())->isNull()
 			->variable($mail->getXMailer())->isNull()
-			->object($mail)->isInstanceOf('mageekguy\atoum\adapter\aggregator')
+			->object($mail)->isInstanceOf('atoum\adapter\aggregator')
 		;
 
 		$adapter = new atoum\test\adapter();
@@ -147,7 +147,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('To is undefined')
 		;
 
@@ -155,7 +155,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Subject is undefined')
 		;
 
@@ -163,7 +163,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('From is undefined')
 		;
 
@@ -171,7 +171,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Reply to is undefined')
 		;
 
@@ -179,7 +179,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('X-mailer is undefined')
 		;
 

--- a/tests/units/classes/mock/controller.php
+++ b/tests/units/classes/mock/controller.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock;
+namespace atoum\tests\units\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\mock
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -13,7 +13,7 @@ class controller extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\test\adapter');
+		$this->testedClass->isSubclassOf('atoum\test\adapter');
 	}
 
 	public function test__construct()
@@ -21,11 +21,11 @@ class controller extends atoum\test
 		$this
 			->if($mockController = new mock\controller())
 			->then
-				->object($mockController->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($mockController->getFactory())->isInstanceOf('atoum\factory')
 				->variable($mockController->getMockClass())->isNull()
 				->array($mockController->getInvokers())->isEmpty()
 				->array($mockController->getCalls())->isEmpty()
-				->object($mockController->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($mockController->getFactory())->isInstanceOf('atoum\factory')
 		;
 	}
 
@@ -65,15 +65,15 @@ class controller extends atoum\test
 		$this
 			->if($mockController = new mock\controller())
 			->then
-				->object($mockController->{uniqid()})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($mockController->{uniqid()})->isInstanceOf('atoum\test\adapter\invoker')
 			->if($mockController->{$method = uniqid()} = $function = function() {})
 			->then
-				->object($mockController->{uniqid()})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($mockController->{uniqid()})->isInstanceOf('atoum\test\adapter\invoker')
 				->object($mockController->{$method}->getClosure())->isIdenticalTo($function)
 				->object($mockController->{strtoupper($method)}->getClosure())->isIdenticalTo($function)
 			->if($mockController->{$otherMethod = uniqid()} = $return = uniqid())
 			->then
-				->object($mockController->{uniqid()})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($mockController->{uniqid()})->isInstanceOf('atoum\test\adapter\invoker')
 				->object($mockController->{$method}->getClosure())->isIdenticalTo($function)
 				->object($mockController->{strtoupper($method)}->getClosure())->isIdenticalTo($function)
 				->object($mockController->{$otherMethod}->getClosure())->isInstanceOf('closure')
@@ -120,7 +120,7 @@ class controller extends atoum\test
 	{
 		$mockAggregatorController = new mock\controller();
 		$mockAggregatorController->__construct = function() {};
-		$mockAggregatorController->getName = function() { return 'mageekguy\atoum\mock\aggregator'; };
+		$mockAggregatorController->getName = function() { return 'atoum\mock\aggregator'; };
 		$mockAggregator = new \mock\reflectionClass(uniqid(), $mockAggregatorController);
 
 		$methods = array(
@@ -252,7 +252,7 @@ class controller extends atoum\test
 						$mockController->invoke($method, array());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Method ' . $method . '() is not under control')
 			->if($return = uniqid())
 			->and($mockController->test = function() use ($return) { return $return; })
@@ -431,7 +431,7 @@ class controller extends atoum\test
 				->array($mockController->getCalls())->isEmpty()
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\controller(null, null, $adapter))
+			->and($mock = new \mock\atoum\tests\units\mock\controller(null, null, $adapter))
 			->and($mockController->control($mock))
 			->and($mockController->{$method = __FUNCTION__} = function() {})
 			->and($mockController->invoke($method, array()))

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock;
+namespace atoum\tests\units\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\mock
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -16,7 +16,7 @@ class generator extends atoum\test
 		$this
 			->if($generator = new mock\generator())
 			->then
-				->object($generator->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($generator->getFactory())->isInstanceOf('atoum\factory')
 			->if($factory = new atoum\factory())
 			->and($generator = new mock\generator($factory))
 			->then
@@ -68,23 +68,23 @@ class generator extends atoum\test
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = false)
 			->and($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->then
 				->string($generator->getMockedClassCode($unknownClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $unknownClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $unknownClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -102,11 +102,11 @@ class generator extends atoum\test
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -170,23 +170,23 @@ class generator extends atoum\test
 			->and($adapter->class_exists = function($class) use (& $realClass) { return ($class == '\\' . $realClass); })
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $reflectionClass)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -204,12 +204,12 @@ class generator extends atoum\test
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -259,24 +259,24 @@ class generator extends atoum\test
 			->and($overloadedMethod->addArgument($argument = new mock\php\method\argument(uniqid())))
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $reflectionClass)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->and($generator->overload($overloadedMethod))
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -299,7 +299,7 @@ class generator extends atoum\test
 					"\t\t" . '$arguments = array_merge(array(' . $argument . '), array_slice(func_get_args(), 1, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -348,23 +348,23 @@ class generator extends atoum\test
 			->and($adapter->class_exists = function($class) use ($realClass) { return ($class == '\\' . $realClass); })
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $reflectionClass)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -382,12 +382,12 @@ class generator extends atoum\test
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -431,24 +431,24 @@ class generator extends atoum\test
 			->and($adapter->class_exists = function($class) use ($realClass) { return ($class == '\\' . $realClass); })
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $reflectionClass)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->and($generator->shunt('__construct'))
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -466,12 +466,12 @@ class generator extends atoum\test
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -511,23 +511,23 @@ class generator extends atoum\test
 			->and($adapter->class_exists = function($class) use (& $realClass) { return ($class == '\\' . $realClass); })
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $reflectionClass)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' implements \\' . $realClass . ', \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' implements \\' . $realClass . ', \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -545,11 +545,11 @@ class generator extends atoum\test
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -593,23 +593,23 @@ class generator extends atoum\test
 			->and($adapter->class_exists = function($class) use (& $realClass) { return ($class == '\\' . $realClass); })
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $reflectionClass)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -640,11 +640,11 @@ class generator extends atoum\test
 					"\t\t\t" . 'return call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -699,23 +699,23 @@ class generator extends atoum\test
 			->and($adapter->class_exists = function($class) use ($className) { return ($class == '\\' . $className); })
 			->and($factory = new atoum\factory())
 			->and($factory['reflectionClass'] = $class)
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->then
 				->string($generator->getMockedClassCode($className))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $className . ' extends \\' . $className . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $className . ' extends \\' . $className . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					"\t" . 'private $mockController = null;' . PHP_EOL .
 					"\t" . 'public function getMockController()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$this->setMockController(new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController(new \atoum\mock\controller());' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->mockController;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+					"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($this->mockController !== $controller)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -743,11 +743,11 @@ class generator extends atoum\test
 					"\t\t" . 'return $this->mockController->invoke(\'' . $publicMethodName . '\', $arguments);' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'protected function ' . $protectedMethodName . '() {}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -770,17 +770,17 @@ class generator extends atoum\test
 			->if($generator = new mock\generator())
 			->then
 				->exception(function() use ($generator) { $generator->generate(''); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Class name \'\' is invalid')
 				->exception(function() use ($generator) { $generator->generate('\\'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Class name \'\\\' is invalid')
 				->exception(function() use ($generator, & $class) { $generator->generate($class = ('\\' . uniqid() . '\\')); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Class name \'' . $class . '\' is invalid')
 			->if($adapter = new atoum\test\adapter())
 			->and($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter)
+			->and($factory['atoum\adapter'] = $adapter)
 			->and($generator = new mock\generator($factory))
 			->and($adapter->class_exists = false)
 			->and($adapter->interface_exists = false)
@@ -789,13 +789,13 @@ class generator extends atoum\test
 				->object($generator->generate($class))->isIdenticalTo($generator)
 				->class('\mock\\' . $class)
 					->hasNoParent()
-					->hasInterface('mageekguy\atoum\mock\aggregator')
+					->hasInterface('atoum\mock\aggregator')
 			->if($class = '\\' . uniqid('unknownClass'))
 			->then
 				->object($generator->generate($class))->isIdenticalTo($generator)
 				->class('\mock' . $class)
 					->hasNoParent()
-					->hasInterface('mageekguy\atoum\mock\aggregator')
+					->hasInterface('atoum\mock\aggregator')
 			->if($adapter->class_exists = true)
 			->and($class = uniqid())
 			->then
@@ -803,7 +803,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'\mock\\' . $class . '\' already exists')
 			->if($class = '\\' . uniqid())
 			->then
@@ -811,7 +811,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'\mock' . $class . '\' already exists')
 			->if($class = uniqid())
 			->and($adapter->class_exists = function($arg) use ($class) { return $arg === '\\' . $class; })
@@ -826,7 +826,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'\\' . $class . '\' is final, unable to mock it')
 			->if($class = '\\' . uniqid())
 			->and($adapter->class_exists = function($arg) use ($class) { return $arg === $class; })
@@ -835,7 +835,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'' . $class . '\' is final, unable to mock it')
 			->if($reflectionClassController->isFinal = false)
 			->and($generator = new mock\generator())
@@ -843,7 +843,7 @@ class generator extends atoum\test
 				->object($generator->generate(__CLASS__))->isIdenticalTo($generator)
 				->class('\mock\\' . __CLASS__)
 					->hasParent(__CLASS__)
-					->hasInterface('mageekguy\atoum\mock\aggregator')
+					->hasInterface('atoum\mock\aggregator')
 			->if($generator = new mock\generator())
 			->and($generator->shunt('__construct'))
 			->then

--- a/tests/units/classes/mock/php/method.php
+++ b/tests/units/classes/mock/php/method.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\php;
+namespace atoum\tests\units\mock\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\php
+	atoum,
+	atoum\mock\php
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -35,7 +35,7 @@ class method extends atoum\test
 						$method->returnReference();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Constructor can not return a reference')
 		;
 	}

--- a/tests/units/classes/mock/php/method/argument.php
+++ b/tests/units/classes/mock/php/method/argument.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\php\method;
+namespace atoum\tests\units\mock\php\method;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\php
+	atoum,
+	atoum\mock\php
 ;
 
 require_once __DIR__ . '/../../../../runner.php';

--- a/tests/units/classes/mock/stream.php
+++ b/tests/units/classes/mock/stream.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock;
+namespace atoum\tests\units\mock;
 
 use
-	mageekguy\atoum\mock,
-	mageekguy\atoum\test,
-	mageekguy\atoum\adapter
+	atoum\mock,
+	atoum\test,
+	atoum\adapter
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -37,33 +37,33 @@ class stream extends test
 			->and($adapter->stream_get_wrappers = array())
 			->and($adapter->stream_wrapper_register = true)
 			->then
-				->object($streamController = mock\stream::get($stream = uniqid()))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($streamController = mock\stream::get($stream = uniqid()))->isInstanceOf('atoum\mock\stream\controller')
 				->string($streamController->getStream())->isEqualTo(mock\stream::defaultProtocol . '://' . mock\stream::setDirectorySeparator($stream))
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments(mock\stream::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments(mock\stream::defaultProtocol, 'atoum\mock\stream')->once()
 			->if($adapter->stream_get_wrappers = array(mock\stream::defaultProtocol))
 			->then
-				->object($streamController = mock\stream::get())->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($streamController = mock\stream::get())->isInstanceOf('atoum\mock\stream\controller')
 				->string($streamController->getStream())->match('#^' . mock\stream::defaultProtocol . '://\w+$#')
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments(mock\stream::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments(mock\stream::defaultProtocol, 'atoum\mock\stream')->once()
 				->object(mock\stream::get($stream))->isIdenticalTo($streamController = mock\stream::get($stream))
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments(mock\stream::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments(mock\stream::defaultProtocol, 'atoum\mock\stream')->once()
 				->object(mock\stream::get($otherStream = ($protocol = uniqid()) . '://' . uniqid()))->isNotIdenticalTo($streamController)
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments($protocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments($protocol, 'atoum\mock\stream')->once()
 			->if($adapter->stream_get_wrappers = array(mock\stream::defaultProtocol, $protocol))
 			->then
 				->object(mock\stream::get($otherStream))->isIdenticalTo(mock\stream::get($otherStream))
 				->object(mock\stream::get($otherStream))->isIdenticalTo(mock\stream::get($otherStream))
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments($protocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments($protocol, 'atoum\mock\stream')->once()
 			->if($adapter->stream_get_wrappers = array())
 			->and($adapter->stream_wrapper_register = false)
 			->then
 				->exception(function() use ($protocol) { mock\stream::get($protocol . '://' . uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to register ' . $protocol . ' stream')
 		;
 	}
@@ -76,9 +76,9 @@ class stream extends test
 			->and($adapter->stream_wrapper_register = true)
 			->and($stream = mock\stream::get())
 			->then
-				->object($subStream = mock\stream::getSubStream($stream))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($subStream = mock\stream::getSubStream($stream))->isInstanceOf('atoum\mock\stream\controller')
 				->castToString($subStream)->match('#^' . $stream . DIRECTORY_SEPARATOR . '[^' . DIRECTORY_SEPARATOR . ']+$#')
-				->object($subStream = mock\stream::getSubStream($stream, $basename = uniqid()))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($subStream = mock\stream::getSubStream($stream, $basename = uniqid()))->isInstanceOf('atoum\mock\stream\controller')
 				->castToString($subStream)->match('#^' . $stream . DIRECTORY_SEPARATOR . $basename . '$#')
 		;
 	}

--- a/tests/units/classes/mock/stream/controller.php
+++ b/tests/units/classes/mock/stream/controller.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\stream;
+namespace atoum\tests\units\mock\stream;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\dependence,
-	mageekguy\atoum\dependencies,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\mock\stream\controller as testedClass
+	atoum,
+	atoum\test,
+	atoum\dependence,
+	atoum\dependencies,
+	atoum\mock\stream,
+	atoum\mock\stream\controller as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -18,7 +18,7 @@ class controller extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\test\adapter')
+			->testedClass->isSubclassOf('atoum\test\adapter')
 		;
 	}
 
@@ -51,7 +51,7 @@ class controller extends atoum\test
 				->variable($streamController->invoke('stream_write'))->isNull()
 				->variable($streamController->invoke('unlink'))->isNull()
 				->variable($streamController->invoke('url_stat'))->isNull()
-				->object($dependencies = $streamController->getDependencies())->isInstanceOf('mageekguy\atoum\dependencies')
+				->object($dependencies = $streamController->getDependencies())->isInstanceOf('atoum\dependencies')
 				->object($dependencies['invoker']->setArgument('method', $method = uniqid())->__invoke())->isEqualTo(new stream\invoker($method))
 			->if($streamController = new testedClass($stream = uniqid(), $dependencies = new dependencies()))
 			->then
@@ -144,7 +144,7 @@ class controller extends atoum\test
 							$streamController->{$method};
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -304,7 +304,7 @@ class controller extends atoum\test
 							$streamController->{$method} = uniqid();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -450,7 +450,7 @@ class controller extends atoum\test
 							isset($streamController->{$method});
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -706,7 +706,7 @@ class controller extends atoum\test
 						unset($streamController->{$method});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -765,7 +765,7 @@ class controller extends atoum\test
 							$streamController->invoke($method);
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}

--- a/tests/units/classes/mock/stream/invoker.php
+++ b/tests/units/classes/mock/stream/invoker.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\stream;
+namespace atoum\tests\units\mock\stream;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\mock\stream
+	atoum\test,
+	atoum\mock\stream
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -13,7 +13,7 @@ class invoker extends test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\test\adapter\invoker');
+		$this->testedClass->isSubclassOf('atoum\test\adapter\invoker');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/php/call.php
+++ b/tests/units/classes/php/call.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php;
+namespace atoum\tests\units\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php
+	atoum,
+	atoum\php
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/php/call/arguments/decorator.php
+++ b/tests/units/classes/php/call/arguments/decorator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\call\arguments;
+namespace atoum\tests\units\php\call\arguments;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\php\call\arguments
+	atoum,
+	atoum\mock\stream,
+	atoum\php\call\arguments
 ;
 
 require_once __DIR__ . '/../../../runner.php';

--- a/tests/units/classes/php/call/decorator.php
+++ b/tests/units/classes/php/call/decorator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\call;
+namespace atoum\tests\units\php\call;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\call
+	atoum,
+	atoum\php\call
 ;
 
 require_once __DIR__ . '/../../../runner.php';

--- a/tests/units/classes/php/tokenizer.php
+++ b/tests/units/classes/php/tokenizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php;
+namespace atoum\tests\units\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php
+	atoum,
+	atoum\php
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -23,7 +23,7 @@ class tokenizer extends atoum\test
 		$tokenizer = new php\tokenizer();
 
 		$this->assert
-			->object($iterator = $tokenizer->getIterator())->isInstanceOf('mageekguy\atoum\php\tokenizer\iterator')
+			->object($iterator = $tokenizer->getIterator())->isInstanceOf('atoum\php\tokenizer\iterator')
 			->sizeOf($iterator)->isZero()
 		;
 	}
@@ -65,7 +65,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 		;
@@ -73,7 +73,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php ?><?php ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 		;
@@ -81,7 +81,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php ?>foo<?php ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 		;
@@ -91,11 +91,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 		;
@@ -103,11 +103,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo ; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo ')
 		;
@@ -115,11 +115,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 		;
@@ -128,7 +128,7 @@ class tokenizer extends atoum\test
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo ?>'))->isIdenticalTo($tokenizer)
 			->castToString($tokenizer->getIterator())->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo ')
 		;
@@ -136,15 +136,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo; namespace bar; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar')
 		;
@@ -152,15 +152,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo?><?php namespace bar?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar')
 		;
@@ -168,15 +168,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo ?><?php namespace bar ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo ')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar ')
 		;
@@ -184,11 +184,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo {} ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo {}')
 		;
@@ -196,15 +196,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo {} namespace bar {} ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo {}')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar {}')
 		;
@@ -214,11 +214,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\'; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 		;
@@ -226,11 +226,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\'?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 		;
@@ -238,11 +238,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\''))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 		;
@@ -250,11 +250,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\', bar = \'bar\'; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\', bar = \'bar\'')
 		;
@@ -262,15 +262,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\'?><?php const bar = \'bar\'; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 			->object($tokenizer->getIterator()->getConstant(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const bar = \'bar\'')
 		;
@@ -280,11 +280,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar')
 		;
@@ -292,11 +292,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString->
 					isEqualTo('use foo\bar')
 		;
@@ -304,11 +304,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar')
 		;
@@ -316,15 +316,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar; use bar\foo; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar')
 			->object($tokenizer->getIterator()->getImportation(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use bar\foo')
 		;
@@ -332,11 +332,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar, bar\foo; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar, bar\foo')
 		;
@@ -346,11 +346,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar as bar; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar as bar')
 		;
@@ -360,7 +360,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php function foo() {} ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->castToString($tokenizer->getIterator()->getFunction(0))

--- a/tests/units/classes/php/tokenizer/iterator.php
+++ b/tests/units/classes/php/tokenizer/iterator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer;
+namespace atoum\tests\units\php\tokenizer;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer
+	atoum,
+	atoum\php\tokenizer
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -702,7 +702,7 @@ class iterator extends atoum\test
 					$iterator->append($innerIterator);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to append value because it has already a parent')
 		;
 

--- a/tests/units/classes/php/tokenizer/iterators/phpArgument.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpArgument.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpArgument extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpClass.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpClass extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpConstant.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpConstant.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpConstant extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpFunction.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpFunction.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpFunction extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpImportation.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpImportation.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpImportation extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpMethod.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpMethod.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpMethod extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterators\phpFunction')
+				->isSubClassOf('atoum\php\tokenizer\iterators\phpFunction')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpNamespace.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpNamespace.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpNamespace extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpProperty.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpProperty.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpProperty extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpScript.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpScript.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpScript extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isSubClassOf('atoum\php\tokenizer\iterators\phpNamespace')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/token.php
+++ b/tests/units/classes/php/tokenizer/token.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer;
+namespace atoum\tests\units\php\tokenizer;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer
+	atoum,
+	atoum\php\tokenizer
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -14,7 +14,7 @@ class token extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\php\tokenizer\iterator\value')
+			->testedClass->isSubclassOf('atoum\php\tokenizer\iterator\value')
 		;
 	}
 
@@ -145,7 +145,7 @@ class token extends atoum\test
 						$token->setParent(new tokenizer\iterator());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Parent is already set')
 			;
 		;
@@ -160,7 +160,7 @@ class token extends atoum\test
 						$token->append(new tokenizer\token(uniqid(), uniqid(), rand(1, PHP_INT_MAX)));
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage($this->getTestedClassName() . '::append() is unavailable')
 		;
 	}

--- a/tests/units/classes/report.php
+++ b/tests/units/classes/report.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -13,8 +13,8 @@ class report extends atoum\test
 	public function testTestedClass()
 	{
 		$this->testedClass
-			->isSubclassOf('mageekguy\atoum\observer')
-			->isSubclassOf('mageekguy\atoum\adapter\aggregator')
+			->isSubclassOf('atoum\observer')
+			->isSubclassOf('atoum\adapter\aggregator')
 		;
 	}
 
@@ -24,21 +24,21 @@ class report extends atoum\test
 			->if($report = new atoum\report())
 			->then
 				->variable($report->getTitle())->isNull()
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEmpty()
 				->array($report->getWriters())->isEmpty()
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
 			->and($report = new atoum\report($factory))
 			->then
 				->variable($report->getTitle())->isNull()
 				->object($report->getLocale())->isIdenticalTo($locale)
 				->object($report->getAdapter())->isIdenticalTo($adapter)
-				->object($report->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($locale)
-				->object($report->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($adapter)
+				->object($report->getFactory()->build('atoum\locale'))->isIdenticalTo($locale)
+				->object($report->getFactory()->build('atoum\adapter'))->isIdenticalTo($adapter)
 				->array($report->getFields())->isEmpty()
 				->array($report->getWriters())->isEmpty()
 		;
@@ -72,9 +72,9 @@ class report extends atoum\test
 		$this
 			->if($report = new atoum\report())
 			->then
-				->object($report->addField($field = new \mock\mageekguy\atoum\report\field))->isIdenticalTo($report)
+				->object($report->addField($field = new \mock\atoum\report\field))->isIdenticalTo($report)
 				->array($report->getFields())->isIdenticalTo(array($field))
-				->object($report->addField($otherField = new \mock\mageekguy\atoum\report\field()))->isIdenticalTo($report)
+				->object($report->addField($otherField = new \mock\atoum\report\field()))->isIdenticalTo($report)
 				->array($report->getFields())->isIdenticalTo(array($field, $otherField))
 		;
 	}

--- a/tests/units/classes/report/field.php
+++ b/tests/units/classes/report/field.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report;
+namespace atoum\tests\units\report;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,11 +15,11 @@ class field extends atoum\test
 	{
 		$this
 			->assert
-			->if($field = new \mock\mageekguy\atoum\report\field())
+			->if($field = new \mock\atoum\report\field())
 			->then
 				->variable($field->getEvents())->isNull()
-				->object($field->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-			->if($field = new \mock\mageekguy\atoum\report\field($events = array(uniqid(), uniqid(), uniqid()), $locale = new atoum\locale()))
+				->object($field->getLocale())->isInstanceOf('atoum\locale')
+			->if($field = new \mock\atoum\report\field($events = array(uniqid(), uniqid(), uniqid()), $locale = new atoum\locale()))
 			->then
 				->array($field->getEvents())->isEqualTo($events)
 				->object($field->getLocale())->isIdenticalTo($locale)

--- a/tests/units/classes/report/fields/runner/atoum/cli.php
+++ b/tests/units/classes/report/fields/runner/atoum/cli.php
@@ -1,25 +1,25 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\atoum;
+namespace atoum\tests\units\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum\score,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\atoum
+	atoum\score,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\atoum
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
 
-class cli extends \mageekguy\atoum\test
+class cli extends \atoum\test
 {
 	public function testClass()
 	{
 		$this->assert
-			->class($this->getTestedClassName())->isSubclassOf('mageekguy\atoum\report\field')
+			->class($this->getTestedClassName())->isSubclassOf('atoum\report\field')
 		;
 	}
 
@@ -85,7 +85,7 @@ class cli extends \mageekguy\atoum\test
 			->variable($field->getPath())->isNull()
 			->variable($field->getVersion())->isNull()
 			->boolean($field->handleEvent(runner::runStart, $runner))->isTrue()
-			->string($field->getAuthor())->isEqualTo(\mageekguy\atoum\author)
+			->string($field->getAuthor())->isEqualTo(\atoum\author)
 			->string($field->getPath())->isEqualTo($atoumPath)
 			->string($field->getVersion())->isEqualTo($atoumVersion)
 		;
@@ -109,14 +109,14 @@ class cli extends \mageekguy\atoum\test
 				->castToString($field)->isEmpty()
 			->if($field->handleEvent(runner::runStart, $runner))
 			->then
-				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_('atoum version %s by %s (%s)'), $atoumVersion, \mageekguy\atoum\author, $atoumPath)) . PHP_EOL)
+				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_('atoum version %s by %s (%s)'), $atoumVersion, \atoum\author, $atoumPath)) . PHP_EOL)
 			->if($field = new atoum\cli($prompt = new prompt(uniqid()), $colorizer = new colorizer(uniqid(), uniqid()), null, $locale = new locale()))
 			->and($field->handleEvent(runner::runStop, $runner))
 			->then
 				->castToString($field)->isEmpty()
 			->if($field->handleEvent(runner::runStart, $runner))
 			->then
-				->castToString($field)->isEqualTo($field->getPrompt() . $colorizer->colorize(sprintf($field->getLocale()->_('atoum version %s by %s (%s)'), $atoumVersion, \mageekguy\atoum\author, $atoumPath)) . PHP_EOL)
+				->castToString($field)->isEqualTo($field->getPrompt() . $colorizer->colorize(sprintf($field->getLocale()->_('atoum version %s by %s (%s)'), $atoumVersion, \atoum\author, $atoumPath)) . PHP_EOL)
 		;
 	}
 }

--- a/tests/units/classes/report/fields/runner/atoum/phing.php
+++ b/tests/units/classes/report/fields/runner/atoum/phing.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\atoum;
+namespace atoum\tests\units\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum\score,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\atoum
+	atoum\score,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\atoum
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
 
-class phing extends \mageekguy\atoum\test
+class phing extends \atoum\test
 {
 	public function testClass()
 	{
-		$this->assert->testedClass->isSubclassOf('mageekguy\atoum\report\field')
+		$this->assert->testedClass->isSubclassOf('atoum\report\field')
 		;
 	}
 
@@ -84,7 +84,7 @@ class phing extends \mageekguy\atoum\test
 			->variable($field->getPath())->isNull()
 			->variable($field->getVersion())->isNull()
 			->boolean($field->handleEvent(runner::runStart, $runner))->isTrue()
-			->string($field->getAuthor())->isEqualTo(\mageekguy\atoum\author)
+			->string($field->getAuthor())->isEqualTo(\atoum\author)
 			->string($field->getPath())->isEqualTo($atoumPath)
 			->string($field->getVersion())->isEqualTo($atoumVersion)
 		;
@@ -108,14 +108,14 @@ class phing extends \mageekguy\atoum\test
 				->castToString($field)->isEmpty()
 			->if($field->handleEvent(runner::runStart, $runner))
 			->then
-				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_("Atoum version: %s \nAtoum path: %s \nAtoum author: %s"), $atoumVersion, $atoumPath, \mageekguy\atoum\author)))
+				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_("Atoum version: %s \nAtoum path: %s \nAtoum author: %s"), $atoumVersion, $atoumPath, \atoum\author)))
 			->if($field = new atoum\phing($prompt = new prompt(uniqid()), $colorizer = new colorizer(uniqid(), uniqid()), null, $locale = new locale()))
 			->and($field->handleEvent(runner::runStop, $runner))
 			->then
 				->castToString($field)->isEmpty()
 			->if($field->handleEvent(runner::runStart, $runner))
 			->then
-				->castToString($field)->isEqualTo($field->getPrompt() . $colorizer->colorize(sprintf($field->getLocale()->_("Atoum version: %s \nAtoum path: %s \nAtoum author: %s"), $atoumVersion, $atoumPath, \mageekguy\atoum\author)))
+				->castToString($field)->isEqualTo($field->getPrompt() . $colorizer->colorize(sprintf($field->getLocale()->_("Atoum version: %s \nAtoum path: %s \nAtoum author: %s"), $atoumVersion, $atoumPath, \atoum\author)))
 		;
 	}
 }

--- a/tests/units/classes/report/fields/runner/coverage/html.php
+++ b/tests/units/classes/report/fields/runner/coverage/html.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\coverage;
+namespace atoum\tests\units\report\fields\runner\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\template,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\coverage
+	atoum,
+	atoum\test,
+	atoum\locale,
+	atoum\template,
+	atoum\mock,
+	atoum\mock\stream,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\coverage
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -20,7 +20,7 @@ class html extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\coverage\cli');
+		$this->testedClass->isSubclassOf('atoum\report\fields\runner\coverage\cli');
 	}
 
 	public function test__construct()
@@ -36,9 +36,9 @@ class html extends atoum\test
 				->object($field->getCoverageColorizer())->isEqualTo(new colorizer())
 				->object($field->getUrlPrompt())->isEqualTo(new prompt())
 				->object($field->getUrlColorizer())->isEqualTo(new colorizer())
-				->object($field->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($field->getAdapter())->isInstanceOf('atoum\adapter')
 				->object($field->getLocale())->isEqualTo(new locale())
-				->object($field->getTemplateParser())->isInstanceOf('mageekguy\atoum\template\parser')
+				->object($field->getTemplateParser())->isInstanceOf('atoum\template\parser')
 				->variable($field->getCoverage())->isNull()
 				->array($field->getSrcDirectories())->isEmpty()
 				->array($field->getEvents())->isEqualTo(array(atoum\runner::runStop))
@@ -214,7 +214,7 @@ class html extends atoum\test
 			->and($destinationDirectory->readdir[4] = $file = stream::getSubStream($destinationDirectory))
 			->and($file->unlink = true)
 			->and($destinationDirectory->readdir[5] = false)
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\coverage\html(uniqid(), (string) $destinationDirectory, uniqid(), null, null, null, null, null, null, $adapter = new test\adapter()))
+			->and($field = new \mock\atoum\report\fields\runner\coverage\html(uniqid(), (string) $destinationDirectory, uniqid(), null, null, null, null, null, null, $adapter = new test\adapter()))
 			->and($adapter->rmdir = function() {})
 			->and($adapter->unlink = function() {})
 			->then
@@ -293,7 +293,7 @@ class html extends atoum\test
 							$field->setReflectionClassInjector(function() {});
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Reflection class injector must take one argument')
 		;
 	}
@@ -311,7 +311,7 @@ class html extends atoum\test
 							$field->getReflectionClass(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Reflection class injector must return a \reflectionClass instance')
 		;
 	}
@@ -322,7 +322,7 @@ class html extends atoum\test
 			->if($field = new coverage\html(uniqid(), uniqid(), uniqid()))
 			->then
 				->castToString($field)->isEqualTo('Code coverage: unknown.' . PHP_EOL)
-			->if($coverage = new \mock\mageekguy\atoum\score\coverage())
+			->if($coverage = new \mock\atoum\score\coverage())
 			->and($coverageController = $coverage->getMockController())
 			->and($coverageController->count = rand(1, PHP_INT_MAX))
 			->and($coverageController->getClasses = array(
@@ -355,31 +355,31 @@ class html extends atoum\test
 			->and($coverageController->getValue = $coverageValue = rand(1, 10) / 10)
 			->and($coverageController->getValueForClass = $classCoverageValue = rand(1, 10) / 10)
 			->and($coverageController->getValueForMethod = $methodCoverageValue = rand(1, 10) / 10)
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getCoverage = $coverage)
-			->if($classCoverageTemplate = new \mock\mageekguy\atoum\template\tag('classCoverage'))
-			->and($classCoverageTemplate->addChild($classCoverageAvailableTemplate = new \mock\mageekguy\atoum\template\tag('classCoverageAvailable')))
-			->and($indexTemplate = new \mock\mageekguy\atoum\template())
+			->if($classCoverageTemplate = new \mock\atoum\template\tag('classCoverage'))
+			->and($classCoverageTemplate->addChild($classCoverageAvailableTemplate = new \mock\atoum\template\tag('classCoverageAvailable')))
+			->and($indexTemplate = new \mock\atoum\template())
 			->and($indexTemplate
-					->addChild($coverageAvailableTemplate = new \mock\mageekguy\atoum\template\tag('coverageAvailable'))
+					->addChild($coverageAvailableTemplate = new \mock\atoum\template\tag('coverageAvailable'))
 					->addChild($classCoverageTemplate)
 				)
 			->and($indexTemplateController = $indexTemplate->getMockController())
 			->and($indexTemplateController->__set = function() {})
 			->and($indexTemplateController->build = $buildOfIndexTemplate = uniqid())
-			->and($methodTemplate = new \mock\mageekguy\atoum\template())
+			->and($methodTemplate = new \mock\atoum\template())
 			->and($methodTemplateController = $methodTemplate->getMockController())
 			->and($methodTemplateController->__set = function() {})
-			->and($lineTemplate = new \mock\mageekguy\atoum\template\tag('line'))
+			->and($lineTemplate = new \mock\atoum\template\tag('line'))
 			->and($lineTemplateController = $lineTemplate->getMockController())
 			->and($lineTemplateController->__set = function() {})
-			->and($coveredLineTemplate = new \mock\mageekguy\atoum\template\tag('coveredLine'))
+			->and($coveredLineTemplate = new \mock\atoum\template\tag('coveredLine'))
 			->and($coveredLineTemplateController = $coveredLineTemplate->getMockController())
 			->and($coveredLineTemplateController->__set = function() {})
-			->and($notCoveredLineTemplate = new \mock\mageekguy\atoum\template\tag('notCoveredLine'))
+			->and($notCoveredLineTemplate = new \mock\atoum\template\tag('notCoveredLine'))
 			->and($notCoveredLineTemplateController = $notCoveredLineTemplate->getMockController())
 			->and($notCoveredLineTemplateController->__set = function() {})
-			->and($sourceFileTemplate = new \mock\mageekguy\atoum\template\tag('sourceFile'))
+			->and($sourceFileTemplate = new \mock\atoum\template\tag('sourceFile'))
 			->and($sourceFileTemplateController = $sourceFileTemplate->getMockController())
 			->and($sourceFileTemplateController->__set = function() {})
 			->and($sourceFileTemplate
@@ -387,12 +387,12 @@ class html extends atoum\test
 					->addChild($coveredLineTemplate)
 					->addChild($notCoveredLineTemplate)
 				)
-			->and($methodCoverageAvailableTemplate = new \mock\mageekguy\atoum\template\tag('methodCoverageAvailable'))
-			->and($methodTemplate = new \mock\mageekguy\atoum\template\tag('method'))
+			->and($methodCoverageAvailableTemplate = new \mock\atoum\template\tag('methodCoverageAvailable'))
+			->and($methodTemplate = new \mock\atoum\template\tag('method'))
 			->and($methodTemplate->addChild($methodCoverageAvailableTemplate))
-			->and($methodsTemplate = new \mock\mageekguy\atoum\template\tag('methods'))
+			->and($methodsTemplate = new \mock\atoum\template\tag('methods'))
 			->and($methodsTemplate->addChild($methodTemplate))
-			->and($classTemplate = new \mock\mageekguy\atoum\template())
+			->and($classTemplate = new \mock\atoum\template())
 			->and($classTemplateController = $classTemplate->getMockController())
 			->and($classTemplateController->__set = function() {})
 			->and($classTemplate
@@ -436,8 +436,8 @@ class html extends atoum\test
 			->and($reflectedMethod4Controller->getStartLine = 11)
 			->and($reflectedMethod4 = new \mock\reflectionMethod(uniqid(), uniqid(), $reflectedMethod4Controller))
 			->and($reflectedClassController->getMethods = array($reflectedMethod1, $reflectedMethod2, $reflectedMethod3, $reflectedMethod4))
-			->and($templateParser = new \mock\mageekguy\atoum\template\parser())
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\coverage\html($projectName = uniqid(), $destinationDirectory = uniqid(), $templatesDirectory = uniqid()))
+			->and($templateParser = new \mock\atoum\template\parser())
+			->and($field = new \mock\atoum\report\fields\runner\coverage\html($projectName = uniqid(), $destinationDirectory = uniqid(), $templatesDirectory = uniqid()))
 			->and($field
 					->setTemplateParser($templateParser)
 					->setAdapter($adapter = new test\adapter())
@@ -445,7 +445,7 @@ class html extends atoum\test
 			->and($fieldController = $field->getMockController())
 			->and($fieldController->cleanDestinationDirectory = function() {})
 			->and($fieldController->getReflectionClass = $reflectedClass)
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->getMockController()->getScore = $score)
 			->and($field->setRootUrl($rootUrl = uniqid()))
 			->and($templateParserController = $templateParser->getMockController())

--- a/tests/units/classes/report/fields/runner/duration/cli.php
+++ b/tests/units/classes/report/fields/runner/duration/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\duration;
+namespace atoum\tests\units\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\duration')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\duration')
 		;
 	}
 
@@ -103,7 +103,7 @@ class cli extends atoum\test
 				->then
 					->boolean($field->handleEvent(runner::runStart, new atoum\runner()))->isFalse()
 					->variable($field->getValue())->isNull()
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($runner->getMockController()->getRunningDuration = $runningDuration = rand(0, PHP_INT_MAX))
 				->then
 					->boolean($field->handleEvent(runner::runStop, $runner))->isTrue()
@@ -115,15 +115,15 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($runner->getMockController()->getRunningDuration = 1)
-				->and($prompt = new \mock\mageekguy\atoum\cli\prompt())
+				->and($prompt = new \mock\atoum\cli\prompt())
 				->and($prompt->getMockController()->__toString = $promptString = uniqid())
-				->and($titleColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+				->and($titleColorizer = new \mock\atoum\cli\colorizer())
 				->and($titleColorizer->getMockController()->colorize = $colorizedTitle = uniqid())
-				->and($durationColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+				->and($durationColorizer = new \mock\atoum\cli\colorizer())
 				->and($durationColorizer->getMockController()->colorize = $colorizedDuration = uniqid())
-				->and($locale = new \mock\mageekguy\atoum\locale())
+				->and($locale = new \mock\atoum\locale())
 				->and($locale->getMockController()->_ = function($string) { return $string; })
 				->and($field = new duration\cli($prompt, $titleColorizer, $durationColorizer, $locale))
 				->then

--- a/tests/units/classes/report/fields/runner/duration/phing.php
+++ b/tests/units/classes/report/fields/runner/duration/phing.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\duration;
+namespace atoum\tests\units\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->assert->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\duration\cli') ;
+		$this->assert->testedClass->isSubclassOf('atoum\report\fields\runner\duration\cli') ;
 	}
 
 	public function test__construct()
@@ -100,7 +100,7 @@ class phing extends atoum\test
 				->then
 					->boolean($field->handleEvent(runner::runStart, new atoum\runner()))->isFalse()
 					->variable($field->getValue())->isNull()
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($runner->getMockController()->getRunningDuration = $runningDuration = rand(0, PHP_INT_MAX))
 				->then
 					->boolean($field->handleEvent(runner::runStop, $runner))->isTrue()
@@ -112,15 +112,15 @@ class phing extends atoum\test
 	{
 		$this
 			->assert
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($runner->getMockController()->getRunningDuration = 1)
-				->and($prompt = new \mock\mageekguy\atoum\cli\prompt())
+				->and($prompt = new \mock\atoum\cli\prompt())
 				->and($prompt->getMockController()->__toString = $promptString = uniqid())
-				->and($titleColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+				->and($titleColorizer = new \mock\atoum\cli\colorizer())
 				->and($titleColorizer->getMockController()->colorize = $colorizedTitle = uniqid())
-				->and($durationColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+				->and($durationColorizer = new \mock\atoum\cli\colorizer())
 				->and($durationColorizer->getMockController()->colorize = $colorizedDuration = uniqid())
-				->and($locale = new \mock\mageekguy\atoum\locale())
+				->and($locale = new \mock\atoum\locale())
 				->and($locale->getMockController()->_ = function($string) { return $string; })
 				->and($field = new duration\phing($prompt, $titleColorizer, $durationColorizer, $locale))
 				->then

--- a/tests/units/classes/report/fields/runner/errors/cli.php
+++ b/tests/units/classes/report/fields/runner/errors/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\errors;
+namespace atoum\tests\units\report\fields\runner\errors;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner,
-	mock\mageekguy\atoum as mock
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\errors')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\errors')
 		;
 	}
 

--- a/tests/units/classes/report/fields/runner/event/cli.php
+++ b/tests/units/classes/report/fields/runner/event/cli.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\event;
+namespace atoum\tests\units\report\fields\runner\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\mock,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -15,7 +15,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\runner\event')
+			->testedClass->isSubClassOf('atoum\report\fields\runner\event')
 		;
 	}
 
@@ -36,7 +36,7 @@ class cli extends atoum\test
 			->assert
 				->if($testController = new atoum\mock\controller())
 				->and($testController->__construct = function() {})
-				->and($test = new \mock\mageekguy\atoum\test())
+				->and($test = new \mock\atoum\test())
 				->and($runner = new atoum\runner())
 				->and($field = new runner\event\cli())
 				->then
@@ -93,7 +93,7 @@ class cli extends atoum\test
 				->and($runnerController = new atoum\mock\controller())
 				->and($runnerController->__construct = function() {})
 				->and($runnerController->getTestMethodNumber = function() use ($testMethodNumber) { return $testMethodNumber; })
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($field = new runner\event\cli())
 				->and($progressBar = new atoum\cli\progressBar($runner->getTestMethodNumber()))
 				->then

--- a/tests/units/classes/report/fields/runner/exceptions/cli.php
+++ b/tests/units/classes/report/fields/runner/exceptions/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\exceptions;
+namespace atoum\tests\units\report\fields\runner\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\exceptions')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\exceptions')
 		;
 	}
 
@@ -165,7 +165,7 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getExceptions = array())
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/cli.php
+++ b/tests/units/classes/report/fields/runner/failures/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures;
+namespace atoum\tests\units\report\fields\runner\failures;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\failures')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\failures')
 		;
 	}
 
@@ -131,7 +131,7 @@ class cli extends atoum\test
 
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getErrors = array())
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/outputs/cli.php
+++ b/tests/units/classes/report/fields/runner/outputs/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\outputs;
+namespace atoum\tests\units\report\fields\runner\outputs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\outputs
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\outputs
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\outputs')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\outputs')
 		;
 	}
 
@@ -160,7 +160,7 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getOutputs = array())
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/php/path/cli.php
+++ b/tests/units/classes/report/fields/runner/php/path/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\php\path;
+namespace atoum\tests\units\report\fields\runner\php\path;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\php\path')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\php\path')
 		;
 	}
 
@@ -93,7 +93,7 @@ class cli extends atoum\test
 		$this
 			->assert
 				->if($field = new runner\php\path\cli())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getPhpPath = $phpPath = uniqid())
 				->then
 					->boolean($field->handleEvent(atoum\runner::runStop, $runner = new atoum\runner()))->isFalse()
@@ -108,7 +108,7 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getPhpPath = $phpPath = uniqid())
 				->and($defaultField = new runner\php\path\cli())
 				->then

--- a/tests/units/classes/report/fields/runner/php/version/cli.php
+++ b/tests/units/classes/report/fields/runner/php/version/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\php\version;
+namespace atoum\tests\units\report\fields\runner\php\version;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner,
-	mageekguy\atoum\mock\mageekguy\atoum as mock
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner,
+	atoum\mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -19,7 +19,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\php\version')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\php\version')
 		;
 	}
 
@@ -115,7 +115,7 @@ class cli extends atoum\test
 		$this
 			->assert
 				->if($field = new runner\php\version\cli())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getPhpVersion = $phpVersion = uniqid())
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))
@@ -131,7 +131,7 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getPhpVersion = $phpVersion = uniqid())
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/result/cli.php
+++ b/tests/units/classes/report/fields/runner/result/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result;
+namespace atoum\tests\units\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\field')
+			->testedClass->isSubClassOf('atoum\report\field')
 		;
 	}
 
@@ -111,12 +111,12 @@ class cli extends atoum\test
 
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getAssertionNumber = $assertionNumber = rand(1, PHP_INT_MAX))
 				->and($score->getMockController()->getFailNumber = $failNumber = rand(1, PHP_INT_MAX))
 				->and($score->getMockController()->getErrorNumber = $errorNumber = rand(1, PHP_INT_MAX))
 				->and($score->getMockController()->getExceptionNumber = $exceptionNumber = rand(1, PHP_INT_MAX))
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 				->and($runner->getMockController()->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
@@ -141,20 +141,20 @@ class cli extends atoum\test
 
 	public function test__toString()
 	{
-		$score = new \mock\mageekguy\atoum\score();
+		$score = new \mock\atoum\score();
 		$scoreController = $score->getMockController();
 		$scoreController->getAssertionNumber = 1;
 		$scoreController->getFailNumber = 0;
 		$scoreController->getErrorNumber = 0;
 		$scoreController->getExceptionNumber = 0;
 
-		$runner = new \mock\mageekguy\atoum\runner();
+		$runner = new \mock\atoum\runner();
 		$runnerController = $runner->getMockController();
 		$runnerController->getScore = $score;
 		$runnerController->getTestNumber = 1;
 		$runnerController->getTestMethodNumber = 1;
 
-		$locale = new \mock\mageekguy\atoum\locale();
+		$locale = new \mock\atoum\locale();
 		$localeController = $locale->getMockController();
 		$localeController->_ = function ($string) use (& $noTestRunningString, & $successString, & $failureString) {
 			switch ($string)
@@ -195,15 +195,15 @@ class cli extends atoum\test
 			}
 		};
 
-		$prompt = new \mock\mageekguy\atoum\cli\prompt();
+		$prompt = new \mock\atoum\cli\prompt();
 		$promptController = $prompt->getMockController();
 		$promptController->__toString = $promptString = uniqid();
 
-		$successColorizer = new \mock\mageekguy\atoum\cli\colorizer();
+		$successColorizer = new \mock\atoum\cli\colorizer();
 		$successColorizerController = $successColorizer->getMockController();
 		$successColorizerController->colorize = $colorizedSuccessString = uniqid();
 
-		$failureColorizer = new \mock\mageekguy\atoum\cli\colorizer();
+		$failureColorizer = new \mock\atoum\cli\colorizer();
 		$failureColorizerController = $failureColorizer->getMockController();
 		$failureColorizerController->colorize = $colorizedFailureString = uniqid();
 

--- a/tests/units/classes/report/fields/runner/tests/coverage/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/coverage/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\coverage;
+namespace atoum\tests\units\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\score,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\mock,
+	atoum\score,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -19,7 +19,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\tests\coverage')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\tests\coverage')
 		;
 	}
 
@@ -146,7 +146,7 @@ class cli extends atoum\test
 		$this
 			->assert
 				->if($scoreCoverage = new score\coverage($factory = new atoum\factory()))
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getCoverage = function() use ($scoreCoverage) { return $scoreCoverage; })
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/tests/coverage/phing.php
+++ b/tests/units/classes/report/fields/runner/tests/coverage/phing.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\coverage;
+namespace atoum\tests\units\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\score,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\mock,
+	atoum\score,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->assert->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\tests\coverage\cli');
+		$this->assert->testedClass->isSubclassOf('atoum\report\fields\runner\tests\coverage\cli');
 	}
 
 	public function test__construct()
@@ -159,7 +159,7 @@ class phing extends atoum\test
 		$this
 			->assert
 				->if($scoreCoverage = new score\coverage($factory = new atoum\factory()))
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getCoverage = function() use ($scoreCoverage) { return $scoreCoverage; })
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/tests/duration/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/duration/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\duration;
+namespace atoum\tests\units\report\fields\runner\tests\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\runner\tests\duration')
+			->testedClass->isSubClassOf('atoum\report\fields\runner\tests\duration')
 		;
 	}
 
@@ -111,9 +111,9 @@ class cli extends atoum\test
 					->boolean($field->handleEvent(atoum\runner::runStart, new atoum\runner()))->isFalse()
 					->variable($field->getValue())->isNull()
 					->variable($field->getTestNumber())->isNull()
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalDuration = $totalDuration = (float) rand(1, PHP_INT_MAX))
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = $testsNumber = rand(1, PHP_INT_MAX))
 				->then
@@ -127,9 +127,9 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalDuration = $totalDuration = (rand(1, 100) / 1000))
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = $testNumber = 1)
 				->and($defaultField = new tests\duration\cli())

--- a/tests/units/classes/report/fields/runner/tests/memory/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/memory/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\memory;
+namespace atoum\tests\units\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\memory
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\tests\units,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\memory
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -19,7 +19,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\runner\tests\memory')
+			->testedClass->isSubClassOf('atoum\report\fields\runner\tests\memory')
 		;
 	}
 
@@ -118,9 +118,9 @@ class cli extends atoum\test
 		$this
 			->assert
 				->if($field = new memory\cli())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = function () use (& $testNumber) { return $testNumber = rand(0, PHP_INT_MAX); })
 				->then
@@ -137,9 +137,9 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 				->and($defaultField = new memory\cli())

--- a/tests/units/classes/report/fields/runner/tests/memory/phing.php
+++ b/tests/units/classes/report/fields/runner/tests/memory/phing.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\memory;
+namespace atoum\tests\units\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\memory
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\tests\units,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\memory
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-	  $this->assert->testedClass->isSubClassOf('mageekguy\atoum\report\fields\runner\tests\memory\cli');
+	  $this->assert->testedClass->isSubClassOf('atoum\report\fields\runner\tests\memory\cli');
 	}
 
 	public function test__construct()
@@ -116,9 +116,9 @@ class phing extends atoum\test
 		$this
 			->assert
 				->if($field = new memory\phing())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = function () use (& $testNumber) { return $testNumber = rand(0, PHP_INT_MAX); })
 				->then
@@ -135,9 +135,9 @@ class phing extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-				->and($runner = new \mock\mageekguy\atoum\runner())
+				->and($runner = new \mock\atoum\runner())
 				->and($runner->setScore($score))
 				->and($runner->getMockController()->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 				->and($defaultField = new memory\phing())

--- a/tests/units/classes/report/fields/runner/tests/uncompleted/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/uncompleted/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\uncompleted;
+namespace atoum\tests\units\report\fields\runner\tests\uncompleted;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mock\mageekguy\atoum as mock,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	mock\atoum as mock,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -19,7 +19,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\tests\uncompleted')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\tests\uncompleted')
 		;
 	}
 
@@ -178,7 +178,7 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getUncompletedMethods = array())
 				->and($runner = new atoum\runner())
 				->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/test/duration/cli.php
+++ b/tests/units/classes/report/fields/test/duration/cli.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\duration;
+namespace atoum\tests\units\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\test\adapter,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -20,7 +20,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\duration')
+			->testedClass->isSubClassOf('atoum\report\fields\test\duration')
 		;
 	}
 
@@ -116,14 +116,14 @@ class cli extends atoum\test
 		$this
 			->assert
 				->if($field = new test\duration\cli())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalDuration = function() use (& $runningDuration) { return $runningDuration = rand(0, PHP_INT_MAX); })
 				->and($adapter = new adapter())
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
 				->and($testController->getScore = $score)
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->then
 					->boolean($field->handleEvent(atoum\runner::runStop, $test))->isFalse()
 					->variable($field->getValue())->isNull()
@@ -138,12 +138,12 @@ class cli extends atoum\test
 			->assert
 				->if($adapter = new adapter())
 				->and($adapter->class_exists = true)
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalDuration = $runningDuration = rand(1, 1000) / 1000)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
 				->and($testController->getScore = $score)
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($defaultField = new test\duration\cli())
 				->and($customField = new test\duration\cli($prompt = new prompt(), $titleColorizer = new colorizer(), $durationColorizer = new colorizer(), $locale = new locale()))
 				->then

--- a/tests/units/classes/report/fields/test/duration/phing.php
+++ b/tests/units/classes/report/fields/test/duration/phing.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\duration;
+namespace atoum\tests\units\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\test\adapter,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -19,7 +19,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-	  $this->assert->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\duration\cli');
+	  $this->assert->testedClass->isSubClassOf('atoum\report\fields\test\duration\cli');
 	}
 
 	public function test__construct()
@@ -114,14 +114,14 @@ class phing extends atoum\test
 		$this
 			->assert
 				->if($field = new test\duration\phing())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalDuration = function() use (& $runningDuration) { return $runningDuration = rand(0, PHP_INT_MAX); })
 				->and($adapter = new adapter())
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
 				->and($testController->getScore = $score)
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->then
 					->boolean($field->handleEvent(atoum\runner::runStop, $test))->isFalse()
 					->variable($field->getValue())->isNull()
@@ -136,12 +136,12 @@ class phing extends atoum\test
 			->assert
 				->if($adapter = new adapter())
 				->and($adapter->class_exists = true)
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalDuration = $runningDuration = rand(1, 1000) / 1000)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
 				->and($testController->getScore = $score)
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($defaultField = new test\duration\phing())
 				->and($customField = new test\duration\phing($prompt = new prompt(), $titleColorizer = new colorizer(), $durationColorizer = new colorizer(), $locale = new locale()))
 				->then

--- a/tests/units/classes/report/fields/test/event/cli.php
+++ b/tests/units/classes/report/fields/test/event/cli.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\event;
+namespace atoum\tests\units\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -15,7 +15,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\event')
+			->testedClass->isSubClassOf('atoum\report\fields\test\event')
 		;
 	}
 
@@ -38,7 +38,7 @@ class cli extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($field = new test\event\cli())
 				->then
 					->boolean($field->handleEvent(atoum\runner::runStart, $test))->isFalse()
@@ -94,7 +94,7 @@ class cli extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new atoum\mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($field = new test\event\cli())
 				->and($count = rand(1, PHP_INT_MAX))
 				->and($test->getMockController()->count = function() use ($count) { return $count; })

--- a/tests/units/classes/report/fields/test/event/phing.php
+++ b/tests/units/classes/report/fields/test/event/phing.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\event;
+namespace atoum\tests\units\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -14,7 +14,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-	  $this->assert->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\event\cli');
+	  $this->assert->testedClass->isSubClassOf('atoum\report\fields\test\event\cli');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class phing extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($field = new test\event\phing())
 				->then
 					->boolean($field->handleEvent(atoum\runner::runStart, $test))->isFalse()
@@ -92,7 +92,7 @@ class phing extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new atoum\mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($field = new test\event\phing())
 				->and($count = rand(1, PHP_INT_MAX))
 				->and($test->getMockController()->count = function() use ($count) { return $count; })

--- a/tests/units/classes/report/fields/test/memory/cli.php
+++ b/tests/units/classes/report/fields/test/memory/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\memory;
+namespace atoum\tests\units\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\memory')
+			->testedClass->isSubClassOf('atoum\report\fields\test\memory')
 		;
 	}
 
@@ -99,13 +99,13 @@ class cli extends atoum\test
 		$this
 			->assert
 				->if($field = new test\memory\cli())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 				->and($adapter = new atoum\test\adapter())
 				->and($adapter->class_exists = true)
 				->and($testController = new atoum\mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($test->getMockController()->getScore = $score)
 				->then
 					->boolean($field->handleEvent(atoum\test::runStart, $test))->isFalse()
@@ -119,13 +119,13 @@ class cli extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 				->and($adapter = new atoum\test\adapter())
 				->and($adapter->class_exists = true)
 				->and($testController = new atoum\mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($test->getMockController()->getScore = $score)
 				->and($defaultField = new test\memory\cli())
 				->and($customField = new test\memory\cli($prompt = new prompt(uniqid()), $titleColorizer = new colorizer(uniqid(), uniqid()), $memoryColorizer = new colorizer(uniqid(), uniqid()), $locale = new locale()))

--- a/tests/units/classes/report/fields/test/memory/phing.php
+++ b/tests/units/classes/report/fields/test/memory/phing.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\memory;
+namespace atoum\tests\units\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->assert->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\memory\cli');
+		$this->assert->testedClass->isSubClassOf('atoum\report\fields\test\memory\cli');
 	}
 
 	public function test__construct()
@@ -97,13 +97,13 @@ class phing extends atoum\test
 		$this
 			->assert
 				->if($field = new test\memory\phing())
-				->and($score = new \mock\mageekguy\atoum\score())
+				->and($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 				->and($adapter = new atoum\test\adapter())
 				->and($adapter->class_exists = true)
 				->and($testController = new atoum\mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($test->getMockController()->getScore = $score)
 				->then
 					->boolean($field->handleEvent(atoum\test::runStart, $test))->isFalse()
@@ -117,13 +117,13 @@ class phing extends atoum\test
 	{
 		$this
 			->assert
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 				->and($adapter = new atoum\test\adapter())
 				->and($adapter->class_exists = true)
 				->and($testController = new atoum\mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($test->getMockController()->getScore = $score)
 				->and($defaultField = new test\memory\phing())
 				->and($customField = new test\memory\phing($prompt = new prompt(uniqid()), $titleColorizer = new colorizer(uniqid(), uniqid()), $memoryColorizer = new colorizer(uniqid(), uniqid()), $locale = new locale()))

--- a/tests/units/classes/report/fields/test/run/cli.php
+++ b/tests/units/classes/report/fields/test/run/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\run;
+namespace atoum\tests\units\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -19,7 +19,7 @@ class cli extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\run')
+			->testedClass->isSubClassOf('atoum\report\fields\test\run')
 		;
 	}
 
@@ -77,7 +77,7 @@ class cli extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->then
 					->boolean($field->handleEvent(atoum\test::runStop, $test))->isFalse()
 					->variable($field->getTestClass())->isNull()
@@ -114,7 +114,7 @@ class cli extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($defaultField = new test\run\cli())
 				->then
 					->castToString($defaultField)->isEqualTo('There is currently no test running.' . PHP_EOL)

--- a/tests/units/classes/report/fields/test/run/phing.php
+++ b/tests/units/classes/report/fields/test/run/phing.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\run;
+namespace atoum\tests\units\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->assert->testedClass->isSubClassOf('mageekguy\atoum\report\fields\test\run\cli');
+		$this->assert->testedClass->isSubClassOf('atoum\report\fields\test\run\cli');
 	}
 
 	public function test__construct()
@@ -74,7 +74,7 @@ class phing extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->then
 					->boolean($field->handleEvent(atoum\test::runStop, $test))->isFalse()
 					->variable($field->getTestClass())->isNull()
@@ -111,7 +111,7 @@ class phing extends atoum\test
 				->and($adapter->class_exists = true)
 				->and($testController = new mock\controller())
 				->and($testController->getTestedClassName = uniqid())
-				->and($test = new \mock\mageekguy\atoum\test(null, null, $adapter, null, null, $testController))
+				->and($test = new \mock\atoum\test(null, null, $adapter, null, null, $testController))
 				->and($defaultField = new test\run\phing())
 				->then
 					->castToString($defaultField)->isEqualTo('There is currently no test running.')

--- a/tests/units/classes/reports/asynchronous.php
+++ b/tests/units/classes/reports/asynchronous.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports;
+namespace atoum\tests\units\reports;
 
 require __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class asynchronous extends atoum\test
@@ -14,8 +14,8 @@ class asynchronous extends atoum\test
 	{
 		$this
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\test\adapter())
-			->if($report = new \mock\mageekguy\atoum\reports\asynchronous($factory))
+			->and($factory['atoum\adapter'] = $adapter = new atoum\test\adapter())
+			->if($report = new \mock\atoum\reports\asynchronous($factory))
 			->then
 				->object($report->handleEvent(atoum\runner::runStop, new atoum\runner()))->isIdenticalTo($report)
 				->variable($report->getTitle())->isNull()

--- a/tests/units/classes/reports/asynchronous/builder.php
+++ b/tests/units/classes/reports/asynchronous/builder.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner,
-	mageekguy\atoum\reports\asynchronous as reports
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test,
+	atoum\report\fields\runner,
+	atoum\reports\asynchronous as reports
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class builder extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubClassOf('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->isSubClassOf('atoum\reports\asynchronous');
 	}
 
 	public function test__construct()
@@ -25,9 +25,9 @@ class builder extends atoum\test
 		$this
 			->if($report = new reports\builder())
 			->then
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEqualTo(array(
 						new runner\atoum\cli(),
 						new runner\php\path\cli(),
@@ -78,8 +78,8 @@ class builder extends atoum\test
 					)
 				)
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
 			->and($report = new reports\builder($factory))
 			->then
 				->object($report->getFactory())->isIdenticalTo($factory)

--- a/tests/units/classes/reports/asynchronous/vim.php
+++ b/tests/units/classes/reports/asynchronous/vim.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports\asynchronous
+	atoum,
+	atoum\reports\asynchronous
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -13,7 +13,7 @@ class vim extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->isSubclassOf('atoum\reports\asynchronous');
 	}
 
 	public function test__construct()
@@ -21,12 +21,12 @@ class vim extends atoum\test
 		$this
 			->if($report = new asynchronous\vim())
 			->then
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
 			->and($report = new asynchronous\vim($factory))
 			->then
 				->object($report->getFactory())->isIdenticalTo($factory)

--- a/tests/units/classes/reports/asynchronous/xunit.php
+++ b/tests/units/classes/reports/asynchronous/xunit.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
+	atoum,
+	atoum\report,
 	ageekguy\atoum\asserter\exception,
-	mageekguy\atoum\reports\asynchronous as reports
+	atoum\reports\asynchronous as reports
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,7 +15,7 @@ class xunit extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->isSubclassOf('atoum\reports\asynchronous');
 	}
 
 	public function testClassConstants()
@@ -29,12 +29,12 @@ class xunit extends atoum\test
 			->if($report = new reports\xunit())
 			->then
 				->array($report->getFields(atoum\runner::runStart))->isEmpty()
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\test\adapter())
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\test\adapter())
 			->and($adapter->extension_loaded = true)
 			->and($report = new reports\xunit($factory))
 			->then
@@ -49,7 +49,7 @@ class xunit extends atoum\test
 								new reports\xunit($factory);
 							}
 						)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('libxml PHP extension is mandatory for xunit report')
 		;
 	}
@@ -77,10 +77,10 @@ class xunit extends atoum\test
 			->then
 				->string($report->setTitle($title = uniqid())->handleEvent(atoum\runner::runStop, new atoum\runner())->getTitle())->isEqualTo($title)
 			->if($report = new reports\xunit())
-			->and($writer = new \mock\mageekguy\atoum\writers\file())
+			->and($writer = new \mock\atoum\writers\file())
 			->and($writer->getMockController()->write = $writer)
 			->then
-				->when(function() use ($report, $writer) { $report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \mageekguy\atoum\runner()); })
+				->when(function() use ($report, $writer) { $report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \atoum\runner()); })
 					->mock($writer)->call('writeAsynchronousReport')->withArguments($report)->once()
 		;
 	}

--- a/tests/units/classes/reports/realtime/cli.php
+++ b/tests/units/classes/reports/realtime/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime;
+namespace atoum\tests\units\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\reports,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -19,9 +19,9 @@ class cli extends atoum\test
 		$this
 			->if($report = new reports\realtime\cli())
 			->then
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEqualTo(array(
 						new fields\runner\php\path\cli(
 							new prompt('> '),
@@ -100,8 +100,8 @@ class cli extends atoum\test
 					)
 				)
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
 			->and($report = new reports\realtime\cli($factory))
 			->then
 				->object($report->getFactory())->isIdenticalTo($factory)

--- a/tests/units/classes/reports/realtime/cli/light.php
+++ b/tests/units/classes/reports/realtime/cli/light.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime\cli;
+namespace atoum\tests\units\reports\realtime\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\reports,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -19,9 +19,9 @@ class light extends atoum\test
 		$this
 			->if($report = new reports\realtime\cli\light())
 			->then
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEqualTo(array(
 						new fields\runner\event\cli(),
 						new fields\runner\result\cli(
@@ -63,8 +63,8 @@ class light extends atoum\test
 					)
 				)
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
 			->and($report = new reports\realtime\cli\light($factory))
 			->then
 				->object($report->getFactory())->isIdenticalTo($factory)

--- a/tests/units/classes/reports/realtime/phing.php
+++ b/tests/units/classes/reports/realtime/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime;
+namespace atoum\tests\units\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\reports,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -26,7 +26,7 @@ class phing extends atoum\test
 				->boolean($report->codeCoverageIsShowed())->isTrue()
 				->boolean($report->missingCodeCoverageIsShowed())->isTrue()
 				->boolean($report->progressIsShowed())->isTrue()
-				->object($report->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($report->getFactory())->isInstanceOf('atoum\factory')
 		  ;
 	}
 }

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\mock
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -15,10 +15,10 @@ class runner extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->hasInterface('mageekguy\atoum\observable')
-				->hasInterface('mageekguy\atoum\adapter\aggregator')
-			->string(atoum\runner::atoumVersionConstant)->isEqualTo('mageekguy\atoum\version')
-			->string(atoum\runner::atoumDirectoryConstant)->isEqualTo('mageekguy\atoum\directory')
+				->hasInterface('atoum\observable')
+				->hasInterface('atoum\adapter\aggregator')
+			->string(atoum\runner::atoumVersionConstant)->isEqualTo('atoum\version')
+			->string(atoum\runner::atoumDirectoryConstant)->isEqualTo('atoum\directory')
 			->string(atoum\runner::runStart)->isEqualTo('runnerStart')
 			->string(atoum\runner::runStop)->isEqualTo('runnerStop')
 		;
@@ -29,39 +29,39 @@ class runner extends atoum\test
 		$this
 			->if($runner = new atoum\runner())
 			->then
-				->object($runner->getScore())->isInstanceOf('mageekguy\atoum\score')
-				->object($runner->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($runner->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($runner->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
-				->object($runner->getTestDirectoryIterator())->isInstanceOf('mageekguy\atoum\iterators\recursives\directory')
-				->object($runner->getFactory())->isInstanceOf('mageekguy\atoum\factory')
-				->object($runner->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($runner->getAdapter())
-				->object($runner->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($runner->getLocale())
-				->object($runner->getFactory()->build('mageekguy\atoum\includer'))->isIdenticalTo($runner->getIncluder())
+				->object($runner->getScore())->isInstanceOf('atoum\score')
+				->object($runner->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($runner->getLocale())->isInstanceOf('atoum\locale')
+				->object($runner->getIncluder())->isInstanceOf('atoum\includer')
+				->object($runner->getTestDirectoryIterator())->isInstanceOf('atoum\iterators\recursives\directory')
+				->object($runner->getFactory())->isInstanceOf('atoum\factory')
+				->object($runner->getFactory()->build('atoum\adapter'))->isIdenticalTo($runner->getAdapter())
+				->object($runner->getFactory()->build('atoum\locale'))->isIdenticalTo($runner->getLocale())
+				->object($runner->getFactory()->build('atoum\includer'))->isIdenticalTo($runner->getIncluder())
 				->variable($runner->getRunningDuration())->isNull()
 				->boolean($runner->codeCoverageIsEnabled())->isTrue()
 				->variable($runner->getDefaultReportTitle())->isNull()
 				->array($runner->getObservers())->isEmpty()
-			->if($runner = new atoum\runner($factory = new \mock\mageekguy\atoum\factory()))
+			->if($runner = new atoum\runner($factory = new \mock\atoum\factory()))
 			->then
-				->object($runner->getScore())->isInstanceOf('mageekguy\atoum\score')
-				->object($runner->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($runner->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($runner->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
-				->object($runner->getTestDirectoryIterator())->isInstanceOf('mageekguy\atoum\iterators\recursives\directory')
+				->object($runner->getScore())->isInstanceOf('atoum\score')
+				->object($runner->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($runner->getLocale())->isInstanceOf('atoum\locale')
+				->object($runner->getIncluder())->isInstanceOf('atoum\includer')
+				->object($runner->getTestDirectoryIterator())->isInstanceOf('atoum\iterators\recursives\directory')
 				->object($runner->getFactory())->isIdenticalTo($factory)
-				->object($runner->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($runner->getAdapter())
-				->object($runner->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($runner->getLocale())
-				->object($runner->getFactory()->build('mageekguy\atoum\includer'))->isIdenticalTo($runner->getIncluder())
+				->object($runner->getFactory()->build('atoum\adapter'))->isIdenticalTo($runner->getAdapter())
+				->object($runner->getFactory()->build('atoum\locale'))->isIdenticalTo($runner->getLocale())
+				->object($runner->getFactory()->build('atoum\includer'))->isIdenticalTo($runner->getIncluder())
 				->variable($runner->getRunningDuration())->isNull()
 				->boolean($runner->codeCoverageIsEnabled())->isTrue()
 				->variable($runner->getDefaultReportTitle())->isNull()
 				->array($runner->getObservers())->isEmpty()
-			->if($factory['mageekguy\atoum\score'] = $score = new atoum\score())
-			->if($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
-			->if($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->if($factory['mageekguy\atoum\includer'] = $includer = new atoum\includer())
-			->if($factory['mageekguy\atoum\iterators\recursives\directory'] = $testDirectoryIterator = new atoum\iterators\recursives\directory())
+			->if($factory['atoum\score'] = $score = new atoum\score())
+			->if($factory['atoum\adapter'] = $adapter = new atoum\adapter())
+			->if($factory['atoum\locale'] = $locale = new atoum\locale())
+			->if($factory['atoum\includer'] = $includer = new atoum\includer())
+			->if($factory['atoum\iterators\recursives\directory'] = $testDirectoryIterator = new atoum\iterators\recursives\directory())
 			->and($runner = new atoum\runner($factory))
 			->then
 				->object($runner->getScore())->isIdenticalTo($score)
@@ -70,9 +70,9 @@ class runner extends atoum\test
 				->object($runner->getIncluder())->isIdenticalTo($includer)
 				->object($runner->getTestDirectoryIterator())->isIdenticalTo($testDirectoryIterator)
 				->object($runner->getFactory())->isIdenticalTo($factory)
-				->object($runner->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($runner->getAdapter())
-				->object($runner->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($runner->getLocale())
-				->object($runner->getFactory()->build('mageekguy\atoum\includer'))->isIdenticalTo($runner->getIncluder())
+				->object($runner->getFactory()->build('atoum\adapter'))->isIdenticalTo($runner->getAdapter())
+				->object($runner->getFactory()->build('atoum\locale'))->isIdenticalTo($runner->getLocale())
+				->object($runner->getFactory()->build('atoum\includer'))->isIdenticalTo($runner->getIncluder())
 				->variable($runner->getRunningDuration())->isNull()
 				->boolean($runner->codeCoverageIsEnabled())->isTrue()
 				->variable($runner->getDefaultReportTitle())->isNull()
@@ -154,7 +154,7 @@ class runner extends atoum\test
 			->if($runner = new atoum\runner())
 			->then
 				->array($runner->getObservers())->isEmpty()
-				->object($runner->addObserver($observer = new \mock\mageekguy\atoum\observers\runner()))->isIdenticalTo($runner)
+				->object($runner->addObserver($observer = new \mock\atoum\observers\runner()))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEqualTo(array($observer))
 		;
 	}
@@ -165,13 +165,13 @@ class runner extends atoum\test
 			->if($runner = new atoum\runner())
 			->then
 				->array($runner->getObservers())->isEmpty()
-				->object($runner->removeObserver(new \mock\mageekguy\atoum\observers\runner()))->isIdenticalTo($runner)
+				->object($runner->removeObserver(new \mock\atoum\observers\runner()))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEmpty()
-			->if($runner->addObserver($observer1 = new \mock\mageekguy\atoum\observers\runner()))
-			->and($runner->addObserver($observer2 = new \mock\mageekguy\atoum\observers\runner()))
+			->if($runner->addObserver($observer1 = new \mock\atoum\observers\runner()))
+			->and($runner->addObserver($observer2 = new \mock\atoum\observers\runner()))
 			->then
 				->array($runner->getObservers())->isEqualTo(array($observer1, $observer2))
-				->object($runner->removeObserver(new \mock\mageekguy\atoum\observers\runner()))->isIdenticalTo($runner)
+				->object($runner->removeObserver(new \mock\atoum\observers\runner()))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEqualTo(array($observer1, $observer2))
 				->object($runner->removeObserver($observer1))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEqualTo(array($observer2))
@@ -186,7 +186,7 @@ class runner extends atoum\test
 			->if($runner = new atoum\runner())
 			->then
 				->object($runner->callObservers(atoum\runner::runStart))->isIdenticalTo($runner)
-			->if($runner->addObserver($observer = new \mock\mageekguy\atoum\observers\runner()))
+			->if($runner->addObserver($observer = new \mock\atoum\observers\runner()))
 			->then
 				->object($runner->callObservers(atoum\runner::runStart))->isIdenticalTo($runner)
 				->mock($observer)->call('handleEvent')->withArguments(atoum\runner::runStart, $runner)->once()
@@ -269,7 +269,7 @@ class runner extends atoum\test
 	{
 		$this
 			->if($runner = new atoum\runner())
-			->and($includer = new \mock\mageekguy\atoum\includer())
+			->and($includer = new \mock\atoum\includer())
 			->and($includer->getMockController()->includePath = function() {})
 			->and($runner->setIncluder($includer))
 			->then
@@ -312,8 +312,8 @@ class runner extends atoum\test
 				->object($runner->removeReport(new atoum\reports\realtime\cli()))->isIdenticalTo($runner)
 				->array($runner->getReports())->isEmpty()
 				->array($runner->getObservers())->isEmpty()
-			->if($report1 = new \mock\mageekguy\atoum\report())
-			->and($report2 = new \mock\mageekguy\atoum\report())
+			->if($report1 = new \mock\atoum\report())
+			->and($report2 = new \mock\atoum\report())
 			->and($runner->addReport($report1)->addReport($report2))
 			->then
 				->array($runner->getReports())->isEqualTo(array($report1, $report2))
@@ -340,8 +340,8 @@ class runner extends atoum\test
 				->object($runner->removeReports())->isIdenticalTo($runner)
 				->array($runner->getReports())->isEmpty()
 				->array($runner->getObservers())->isEmpty()
-			->if($report1 = new \mock\mageekguy\atoum\report())
-			->and($report2 = new \mock\mageekguy\atoum\report())
+			->if($report1 = new \mock\atoum\report())
+			->and($report2 = new \mock\atoum\report())
 			->and($runner->addReport($report1)->addReport($report2))
 			->then
 				->array($runner->getReports())->isEqualTo(array($report1, $report2))
@@ -379,7 +379,7 @@ class runner extends atoum\test
 	public function testSetPathAndVersionInScore()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\score())
+			->if($score = new \mock\atoum\score())
 			->and($scoreController = $score->getMockController())
 			->and($adapter = new atoum\test\adapter())
 			->and($adapter->defined = false)
@@ -394,7 +394,7 @@ class runner extends atoum\test
 						$runner->setPathAndVersionInScore();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to open \'' . $phpPath . '\'')
 				->adapter($adapter)
 					->call('realpath')->withArguments($phpPath)->once()
@@ -414,7 +414,7 @@ class runner extends atoum\test
 						$runner->setPathAndVersionInScore();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to find \'' . $phpPath . '\'')
 				->adapter($adapter)
 					->call('realpath')->withArguments($phpPath)->once()
@@ -447,7 +447,7 @@ class runner extends atoum\test
 						$runner->setPathAndVersionInScore();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to get PHP version from \'' . $phpPath . '\'')
 				->adapter($adapter)
 					->call('realpath')->withArguments($phpPath)->once()
@@ -468,7 +468,7 @@ class runner extends atoum\test
 						$runner->setPathAndVersionInScore();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to get PHP version from \'' . $phpPath . '\'')
 				->adapter($adapter)
 					->call('realpath')->withArguments($phpPath)->once()

--- a/tests/units/classes/score.php
+++ b/tests/units/classes/score.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -15,7 +15,7 @@ class score extends atoum\test
 		$this
 			->if($score = new atoum\score())
 			->then
-				->object($score->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($score->getFactory())->isInstanceOf('atoum\factory')
 				->variable($score->getPhpPath())->isNull()
 				->variable($score->getPhpVersion())->isNull()
 				->variable($score->getAtoumPath())->isNull()
@@ -30,9 +30,9 @@ class score extends atoum\test
 				->array($score->getDurations())->isEmpty()
 				->array($score->getMemoryUsages())->isEmpty()
 				->array($score->getUncompletedMethods())->isEmpty()
-				->object($score->getCoverage())->isEqualTo(new \mageekguy\atoum\score\coverage($score->getFactory()))
+				->object($score->getCoverage())->isEqualTo(new \atoum\score\coverage($score->getFactory()))
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\score\coverage'] = $coverage = new \mageekguy\atoum\score\coverage())
+			->and($factory['atoum\score\coverage'] = $coverage = new \atoum\score\coverage())
 			->and($score = new atoum\score($factory))
 			->then
 				->object($score->getFactory())->isIdenticalTo($factory)
@@ -572,7 +572,7 @@ class score extends atoum\test
 							$score->setAtoumPath(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path of atoum is already set')
 				->object($score->reset()->setAtoumPath($path = rand(1, PHP_INT_MAX)))->isIdenticalTo($score)
 				->string($score->getAtoumPath())->isEqualTo((string) $path)
@@ -590,7 +590,7 @@ class score extends atoum\test
 							$score->setAtoumVersion(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Version of atoum is already set')
 				->object($score->reset()->setAtoumVersion($version = rand(1, PHP_INT_MAX)))->isIdenticalTo($score)
 				->string($score->getAtoumVersion())->isEqualTo((string) $version)
@@ -608,7 +608,7 @@ class score extends atoum\test
 							$score->setPhpPath(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('PHP path is already set')
 				->object($score->reset()->setPhpPath($path = rand(1, PHP_INT_MAX)))->isIdenticalTo($score)
 				->string($score->getPhpPath())->isEqualTo((string) $path)
@@ -626,7 +626,7 @@ class score extends atoum\test
 						$score->setPhpVersion(uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('PHP version is already set')
 		;
 	}
@@ -742,7 +742,7 @@ class score extends atoum\test
 		$this
 			->if($score = new atoum\score())
 			->then
-				->object($coverage = $score->getCoverage())->isInstanceOf('mageekguy\atoum\score\coverage')
+				->object($coverage = $score->getCoverage())->isInstanceOf('atoum\score\coverage')
 				->object($coverage->getFactory())->isIdenticalTo($score->getFactory())
 		;
 	}
@@ -1066,7 +1066,7 @@ class score extends atoum\test
 		$this
 			->if($score = new atoum\score())
 			->exception(function() use ($score, & $key) { $score->deleteError($key = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Error key \'' . $key . '\' does not exist')
 			->if($score->addError(uniqid(), rand(1, PHP_INT_MAX), uniqid(), uniqid(), $type = rand(1, PHP_INT_MAX), $message = uniqid(), uniqid(), rand(1, PHP_INT_MAX)))
 			->then

--- a/tests/units/classes/score/coverage.php
+++ b/tests/units/classes/score/coverage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\score;
+namespace atoum\tests\units\score;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\score
+	atoum,
+	atoum\mock,
+	atoum\score
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -24,7 +24,7 @@ class coverage extends atoum\test
 			->then
 				->variable($coverage->getValue())->isNull()
 				->array($coverage->getMethods())->isEmpty()
-				->object($coverage->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($coverage->getFactory())->isInstanceOf('atoum\factory')
 			->if($coverage = new score\coverage($factory = new atoum\factory()))
 			->then
 				->variable($coverage->getValue())->isNull()

--- a/tests/units/classes/script.php
+++ b/tests/units/classes/script.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mock\mageekguy\atoum as mock
+	atoum,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -22,19 +22,19 @@ class script extends atoum\test
 			->if($script = new mock\script($name = uniqid()))
 			->then
 				->string($script->getName())->isEqualTo($name)
-				->object($script->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($script->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($script->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
-				->object($script->getOutputWriter())->isInstanceOf('mageekguy\atoum\writers\std\out')
-				->object($script->getErrorWriter())->isInstanceOf('mageekguy\atoum\writers\std\err')
-				->object($script->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+				->object($script->getLocale())->isInstanceOf('atoum\locale')
+				->object($script->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($script->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
+				->object($script->getOutputWriter())->isInstanceOf('atoum\writers\std\out')
+				->object($script->getErrorWriter())->isInstanceOf('atoum\writers\std\err')
+				->object($script->getFactory())->isInstanceOf('atoum\factory')
 				->array($script->getHelp())->isEmpty()
-				->object($script->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($script->getLocale())
-				->object($script->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($script->getAdapter())
+				->object($script->getFactory()->build('atoum\locale'))->isIdenticalTo($script->getLocale())
+				->object($script->getFactory()->build('atoum\adapter'))->isIdenticalTo($script->getAdapter())
 			->if($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
-			->and($factory->import('mageekguy\atoum\writers\std'))
-			->and($factory->import('mageekguy\atoum\script\arguments'))
+			->and($factory->import('atoum'))
+			->and($factory->import('atoum\writers\std'))
+			->and($factory->import('atoum\script\arguments'))
 			->and($factory['atoum\locale'] = $locale = new atoum\locale())
 			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
 			->and($factory['arguments\parser'] = $argumentsParser = new atoum\script\arguments\parser())
@@ -50,8 +50,8 @@ class script extends atoum\test
 				->object($script->getErrorWriter())->isIdenticalTo($stdErr)
 				->object($script->getFactory())->isIdenticalTo($factory)
 				->array($script->getHelp())->isEmpty()
-				->object($script->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($script->getLocale())
-				->object($script->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($script->getAdapter())
+				->object($script->getFactory()->build('atoum\locale'))->isIdenticalTo($script->getLocale())
+				->object($script->getFactory()->build('atoum\adapter'))->isIdenticalTo($script->getAdapter())
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->php_sapi_name = uniqid())
 			->and($factory['atoum\adapter'] = $adapter)
@@ -60,7 +60,7 @@ class script extends atoum\test
 						new mock\script($name = uniqid(), $factory);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('\'' . $name . '\' must be used in CLI only')
 		;
 	}
@@ -176,8 +176,8 @@ class script extends atoum\test
 			->if($argumentsParser = new mock\script\arguments\parser())
 			->and($argumentsParser->getMockController()->addHandler = function() {})
 			->and($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
-			->and($factory->import('mageekguy\atoum\script\arguments'))
+			->and($factory->import('atoum'))
+			->and($factory->import('atoum\script\arguments'))
 			->and($factory['arguments\parser'] = $argumentsParser)
 			->and($factory['atoum\adapter'] = $adapter = new atoum\test\adapter())
 			->and($script = new mock\script(uniqid(), $factory))
@@ -203,7 +203,7 @@ class script extends atoum\test
 			->and($adapter = new atoum\test\adapter())
 			->and($adapter->fgets = $input = uniqid())
 			->and($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory['atoum\adapter'] = $adapter)
 			->and($factory['atoum\writers\std\out'] = $stdOut)
 			->and($script = new mock\script(uniqid(), $factory))

--- a/tests/units/classes/script/arguments/parser.php
+++ b/tests/units/classes/script/arguments/parser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\script\arguments;
+namespace atoum\tests\units\script\arguments;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\script
+	atoum,
+	atoum\script
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -50,7 +50,7 @@ class parser extends atoum\test
 	{
 		$this
 			->assert
-				->if($script = new \mock\mageekguy\atoum\script(uniqid()))
+				->if($script = new \mock\atoum\script(uniqid()))
 				->and($parser = new script\arguments\parser())
 				->then
 					->array($parser->getValues())->isEmpty()
@@ -78,7 +78,7 @@ class parser extends atoum\test
 	{
 		$this
 			->assert
-				->if($script = new \mock\mageekguy\atoum\script(uniqid()))
+				->if($script = new \mock\atoum\script(uniqid()))
 				->and($parser = new script\arguments\parser())
 				->and($parser->parse($script, array()))
 				->then
@@ -101,7 +101,7 @@ class parser extends atoum\test
 	{
 		$this
 			->assert('when using $_SERVER')
-				->if($script = new \mock\mageekguy\atoum\script(uniqid()))
+				->if($script = new \mock\atoum\script(uniqid()))
 				->and($superglobals = new atoum\superglobals())
 				->and($superglobals->_SERVER['argv'] = array())
 				->and($parser = new script\arguments\parser($superglobals))
@@ -204,7 +204,7 @@ class parser extends atoum\test
 							$parser->parse($script, array('b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+						->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 						->hasMessage('First argument \'b\' is invalid')
 				->if($superglobals->_SERVER['argv'] = array('scriptName', '-a', 'a1', 'a2', '-b', 'b1', 'b2', 'b3', '-d', 'd1', 'd2', '--c'))
 				->and($parser->addHandler(function($script, $argument, $value) {}, array('-d'), PHP_INT_MAX))
@@ -257,25 +257,25 @@ class parser extends atoum\test
 							$parser->addHandler(function() {}, $argument = array('-b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take three arguments')
 				->exception(function() use ($parser) {
 							$parser->addHandler(function($script) {}, array('-b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take three arguments')
 				->exception(function() use ($parser) {
 							$parser->addHandler(function($script, $argument) {}, array('-b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take three arguments')
 				->exception(function() use ($parser, & $badArgument) {
 							$parser->addHandler(function($script, $argument, $values) {}, array($badArgument = 'b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Argument \'' . $badArgument . '\' is invalid')
 				->object($parser->addHandler($otherHandler = function($script, $argument, $values) {}, array($otherArgument = '-b'), $priority = rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($parser)
 				->array($parser->getHandlers())->isEqualTo(array($argument => array($handler, $handler), $otherArgument => array($otherHandler)))

--- a/tests/units/classes/scripts/builder.php
+++ b/tests/units/classes/scripts/builder.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\scripts,
-	mageekguy\atoum\scripts\builder\vcs
+	atoum,
+	atoum\mock,
+	atoum\scripts,
+	atoum\scripts\builder\vcs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -27,7 +27,7 @@ class builder extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\script')
+			->testedClass->isSubclassOf('atoum\script')
 			->string(scripts\builder::defaultUnitTestRunnerScript)->isEqualTo('scripts/runner.php')
 			->string(scripts\builder::defaultPharGeneratorScript)->isEqualTo('scripts/phar/generator.php')
 		;
@@ -39,12 +39,12 @@ class builder extends atoum\test
 			->if($builder = new scripts\builder($name = uniqid()))
 			->then
 				->string($builder->getName())->isEqualTo($name)
-				->object($builder->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($builder->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($builder->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
-				->object($builder->getOutputWriter())->isInstanceOf('mageekguy\atoum\writers\std\out')
-				->object($builder->getErrorWriter())->isInstanceOf('mageekguy\atoum\writers\std\err')
-				->object($builder->getSuperglobals())->isInstanceOf('mageekguy\atoum\superglobals')
+				->object($builder->getLocale())->isInstanceOf('atoum\locale')
+				->object($builder->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($builder->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
+				->object($builder->getOutputWriter())->isInstanceOf('atoum\writers\std\out')
+				->object($builder->getErrorWriter())->isInstanceOf('atoum\writers\std\err')
+				->object($builder->getSuperglobals())->isInstanceOf('atoum\superglobals')
 				->array($builder->getRunnerConfigurationFiles())->isEmpty()
 				->variable($builder->getVersion())->isNull()
 				->variable($builder->getWorkingDirectory())->isNull()
@@ -55,10 +55,10 @@ class builder extends atoum\test
 				->string($builder->getUnitTestRunnerScript())->isEqualTo(scripts\builder::defaultUnitTestRunnerScript)
 				->string($builder->getPharGeneratorScript())->isEqualTo(scripts\builder::defaultPharGeneratorScript)
 				->variable($builder->getReportTitle())->isNull()
-				->object($builder->getVcs())->isInstanceOf('mageekguy\atoum\scripts\builder\vcs\svn')
+				->object($builder->getVcs())->isInstanceOf('atoum\scripts\builder\vcs\svn')
 				->variable($builder->getTaggerEngine())->isNull()
 			->if($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory->returnWhenBuild('atoum\locale', $locale = new atoum\locale()))
 			->and($factory->returnWhenBuild('atoum\adapter', $adapter = new atoum\adapter()))
 			->and($factory->returnWhenBuild('atoum\script\arguments\parser', $argumentsParser = new atoum\script\arguments\parser()))
@@ -134,7 +134,7 @@ class builder extends atoum\test
 					$builder->getPhpPath();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 		;
 
 		$builder->setPhpPath($php = uniqid());
@@ -179,7 +179,7 @@ class builder extends atoum\test
 		$vcsController->__construct = function() {};
 
 		$this->assert
-			->object($builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs(null, $vcsController)))->isIdenticalTo($builder)
+			->object($builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs(null, $vcsController)))->isIdenticalTo($builder)
 			->object($builder->getVcs())->isIdenticalTo($vcs)
 		;
 	}
@@ -338,11 +338,11 @@ class builder extends atoum\test
 	{
 		$factory = new atoum\factory();
 		$factory
-			->import('mageekguy\atoum')
+			->import('atoum')
 			->returnWhenBuild('atoum\adapter', $adapter = new atoum\test\adapter())
 		;
 
-		$builder = new \mock\mageekguy\atoum\scripts\builder(uniqid(), $factory);
+		$builder = new \mock\atoum\scripts\builder(uniqid(), $factory);
 
 		$builder->disableUnitTestChecking();
 
@@ -358,7 +358,7 @@ class builder extends atoum\test
 					$builder->checkUnitTests();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to check unit tests, working directory is undefined')
 		;
 
@@ -368,7 +368,7 @@ class builder extends atoum\test
 		$vcsController->__construct = function() {};
 		$vcsController->exportRepository = function() {};
 
-		$builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs(null, $vcsController));
+		$builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs(null, $vcsController));
 
 		$builder
 			->setUnitTestRunnerScript($unitTestRunnerScript = uniqid())
@@ -377,7 +377,7 @@ class builder extends atoum\test
 			->addRunnerConfigurationFile($runnerConfigurationFile = uniqid())
 		;
 
-		$score = new \mock\mageekguy\atoum\score();
+		$score = new \mock\atoum\score();
 
 		$scoreController = $score->getMockController();
 		$scoreController->getFailNumber = 0;
@@ -543,7 +543,7 @@ class builder extends atoum\test
 					$builder->checkUnitTests();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to delete score file \'' . $scoreFile . '\'')
 		;
 
@@ -598,14 +598,14 @@ class builder extends atoum\test
 	{
 		$factory = new atoum\factory();
 		$factory
-			->import('mageekguy\atoum')
+			->import('atoum')
 			->returnWhenBuild('atoum\adapter', $adapter = new atoum\test\adapter())
 		;
 
-		$builder = new \mock\mageekguy\atoum\scripts\builder(uniqid(), $factory);
+		$builder = new \mock\atoum\scripts\builder(uniqid(), $factory);
 
 		$builder
-			->setTaggerEngine($taggerEngine = new \mock\mageekguy\atoum\scripts\tagger\engine())
+			->setTaggerEngine($taggerEngine = new \mock\atoum\scripts\tagger\engine())
 			->disablePharCreation()
 		;
 
@@ -622,14 +622,14 @@ class builder extends atoum\test
 		$vcsController->getNextRevisions = array();
 		$vcsController->exportRepository = function() {};
 
-		$builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs(null, $vcsController));
+		$builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs(null, $vcsController));
 
 		$this->assert
 			->exception(function() use ($builder) {
 						$builder->createPhar();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to create phar, destination directory is undefined')
 		;
 
@@ -640,7 +640,7 @@ class builder extends atoum\test
 						$builder->createPhar();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to create phar, working directory is undefined')
 		;
 
@@ -804,7 +804,7 @@ class builder extends atoum\test
 						$builder->createPhar();
 					}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to save last revision in file \'' . $revisionFile . '\'')
 		;
 
@@ -868,11 +868,11 @@ class builder extends atoum\test
 
 		$factory = new atoum\factory();
 		$factory
-			->import('mageekguy\atoum')
+			->import('atoum')
 			->returnWhenBuild('atoum\adapter', $adapter)
 		;
 
-		$builder = new \mock\mageekguy\atoum\scripts\builder(uniqid(), $factory);
+		$builder = new \mock\atoum\scripts\builder(uniqid(), $factory);
 
 		$builderController = $builder->getMockController();
 		$builderController->createPhar = function() {};
@@ -896,7 +896,7 @@ class builder extends atoum\test
 	{
 		$this->assert
 			->if($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory->returnWhenBuild('atoum\adapter', $adapter = new atoum\test\adapter()))
 			->and($adapter->file_put_contents = function() {})
 			->and($builder = new scripts\builder(uniqid(), $factory))
@@ -911,7 +911,7 @@ class builder extends atoum\test
 							$builder->writeErrorInErrorsDirectory(uniqid());
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic')
+						->isInstanceOf('atoum\exceptions\logic')
 						->hasMessage('Revision is undefined')
 				->adapter($adapter)->call('file_put_contents')->never()
 		;
@@ -919,7 +919,7 @@ class builder extends atoum\test
 		$vcsController = new mock\controller();
 		$vcsController->__construct = function() {};
 
-		$builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs(null, $vcsController));
+		$builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs(null, $vcsController));
 
 		$vcs->setRevision($revision = rand(1, PHP_INT_MAX));
 
@@ -940,7 +940,7 @@ class builder extends atoum\test
 						$builder->writeErrorInErrorsDirectory($message = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to save error in file \'' . $errorDirectory . \DIRECTORY_SEPARATOR . $revision . '\'')
 			->adapter($adapter)->call('file_put_contents')->withArguments($errorDirectory . \DIRECTORY_SEPARATOR . $revision, $message, \LOCK_EX | \FILE_APPEND)->once()
 		;

--- a/tests/units/classes/scripts/builder/vcs/svn.php
+++ b/tests/units/classes/scripts/builder/vcs/svn.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\builder\vcs;
+namespace atoum\tests\units\scripts\builder\vcs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\scripts\builder\vcs
+	atoum,
+	atoum\mock,
+	atoum\mock\stream,
+	atoum\scripts\builder\vcs
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -26,7 +26,7 @@ class svn extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\adapter\aggregator');
+		$this->testedClass->isSubclassOf('atoum\adapter\aggregator');
 	}
 
 	public function test__construct()
@@ -34,7 +34,7 @@ class svn extends atoum\test
 		$this
 			->if($svn = new vcs\svn())
 			->then
-				->object($svn->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($svn->getAdapter())->isInstanceOf('atoum\adapter')
 				->variable($svn->getRepositoryUrl())->isNull()
 			->if($svn = new vcs\svn($adapter = new atoum\adapter()))
 			->then
@@ -142,7 +142,7 @@ class svn extends atoum\test
 						$svn->getNextRevisions();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to get logs, repository url is undefined')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->never()
@@ -201,7 +201,7 @@ class svn extends atoum\test
 		$adapter = new atoum\test\adapter();
 		$adapter->extension_loaded = true;
 
-		$svn = new \mock\mageekguy\atoum\scripts\builder\vcs\svn($adapter);
+		$svn = new \mock\atoum\scripts\builder\vcs\svn($adapter);
 
 		$this->assert
 			->object($svn->setWorkingDirectory($workingDirectory = uniqid()))->isIdenticalTo($svn)
@@ -216,7 +216,7 @@ class svn extends atoum\test
 		$adapter = new atoum\test\adapter();
 		$adapter->extension_loaded = true;
 
-		$svn = new \mock\mageekguy\atoum\scripts\builder\vcs\svn($adapter);
+		$svn = new \mock\atoum\scripts\builder\vcs\svn($adapter);
 
 		$svn->getMockController()->cleanWorkingDirectory = $svn;
 
@@ -225,7 +225,7 @@ class svn extends atoum\test
 						$svn->exportRepository(uniqid());
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to export repository, repository url is undefined')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->never()
@@ -248,7 +248,7 @@ class svn extends atoum\test
 						$svn->exportRepository();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to checkout repository \'' . $repositoryUrl . '\' in directory \'' . $workingDirectory . '\'')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->once()
@@ -271,7 +271,7 @@ class svn extends atoum\test
 						$svn->exportRepository();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to checkout repository \'' . $repositoryUrl . '\' in directory \'' . $workingDirectory . '\'')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->once()
@@ -294,7 +294,7 @@ class svn extends atoum\test
 						$svn->exportRepository();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to checkout repository \'' . $repositoryUrl . '\' in directory \'' . $workingDirectory . '\'')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->once()
@@ -351,7 +351,7 @@ class svn extends atoum\test
 			->and($workingDirectory->readdir[4] = $aFile = stream::getSubStream($workingDirectory))
 			->and($aFile->unlink = true)
 			->and($workingDirectory->readdir[5] = false)
-			->and($svn = new \mock\mageekguy\atoum\scripts\builder\vcs\svn($adapter, $svnController = new mock\controller()))
+			->and($svn = new \mock\atoum\scripts\builder\vcs\svn($adapter, $svnController = new mock\controller()))
 			->and($svn->setWorkingDirectory('atoum://workingDirectory'))
 			->then
 				->object($svn->cleanWorkingDirectory())->isIdenticalTo($svn)

--- a/tests/units/classes/scripts/phar/generator.php
+++ b/tests/units/classes/scripts/phar/generator.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\phar;
+namespace atoum\tests\units\scripts\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\scripts\phar
+	atoum,
+	atoum\mock,
+	atoum\mock\stream,
+	atoum\iterators,
+	atoum\scripts\phar
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class generator extends atoum\test
 	public function testClassConstants()
 	{
 		$this->assert
-			->string(phar\generator::phar)->isEqualTo('mageekguy.atoum.phar')
+			->string(phar\generator::phar)->isEqualTo('atoum.phar')
 		;
 	}
 
@@ -27,26 +27,26 @@ class generator extends atoum\test
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->php_sapi_name = function() { return uniqid(); })
 			->and($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 			->then
 				->exception(function() use (& $name, $factory) {
 						$generator = new phar\generator($name = uniqid(), $factory);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('\'' . $name . '\' must be used in CLI only')
 			->if($adapter->php_sapi_name = function() { return 'cli'; })
 			->and($generator = new phar\generator($name = uniqid(), $factory))
 			->then
-				->object($generator->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($generator->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($generator->getOutputWriter())->isInstanceOf('mageekguy\atoum\writer')
-				->object($generator->getErrorWriter())->isInstanceOf('mageekguy\atoum\writer')
+				->object($generator->getLocale())->isInstanceOf('atoum\locale')
+				->object($generator->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($generator->getOutputWriter())->isInstanceOf('atoum\writer')
+				->object($generator->getErrorWriter())->isInstanceOf('atoum\writer')
 				->string($generator->getName())->isEqualTo($name)
 				->variable($generator->getOriginDirectory())->isNull()
 				->variable($generator->getDestinationDirectory())->isNull()
-				->object($generator->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
+				->object($generator->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
 			->if($factory->returnWhenBuild('atoum\locale', $locale = new atoum\locale()))
 			->and($factory->returnWhenBuild('atoum\script\arguments\parser', $argumentsParser = new atoum\script\arguments\parser()))
 			->and($generator = new phar\generator($name = uniqid(), $factory))
@@ -67,7 +67,7 @@ class generator extends atoum\test
 			->and($adapter->php_sapi_name = function() { return 'cli'; })
 			->and($adapter->realpath = function($path) { return $path; })
 			->and($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 			->and($generator = new phar\generator(uniqid(), $factory))
 			->then
@@ -75,7 +75,7 @@ class generator extends atoum\test
 						$generator->setOriginDirectory('');
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Empty origin directory is invalid')
 			->if($adapter->is_dir = function() { return false; })
 			->then
@@ -83,7 +83,7 @@ class generator extends atoum\test
 						$generator->setOriginDirectory($directory = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path \'' . $directory . '\' of origin directory is invalid')
 			->if($adapter->is_dir = function() { return true; })
 			->then
@@ -97,7 +97,7 @@ class generator extends atoum\test
 						$generator->setOriginDirectory($generator->getDestinationDirectory());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Origin directory must be different from destination directory')
 			->if($realDirectory = $generator->getDestinationDirectory() . DIRECTORY_SEPARATOR . uniqid())
 			->and($adapter->realpath = function($path) use ($realDirectory) { return $realDirectory; })
@@ -114,7 +114,7 @@ class generator extends atoum\test
 			->and($adapter->php_sapi_name = function() { return 'cli'; })
 			->and($adapter->realpath = function($path) { return $path; })
 			->and($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 			->and($generator = new phar\generator(uniqid(), $factory))
 			->then
@@ -122,7 +122,7 @@ class generator extends atoum\test
 						$generator->setDestinationDirectory('');
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Empty destination directory is invalid')
 			->if ($adapter->is_dir = function() { return false; })
 			->then
@@ -130,7 +130,7 @@ class generator extends atoum\test
 						$generator->setDestinationDirectory($directory = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path \'' . $directory . '\' of destination directory is invalid')
 			->if($adapter->is_dir = function() { return true; })
 			->then
@@ -146,7 +146,7 @@ class generator extends atoum\test
 						$generator->setDestinationDirectory($generator->getOriginDirectory());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Destination directory must be different from origin directory')
 		;
 	}
@@ -158,7 +158,7 @@ class generator extends atoum\test
 			->and($adapter->php_sapi_name = function() { return 'cli'; })
 			->and($adapter->realpath = function($path) { return $path; })
 			->and($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
+			->and($factory->import('atoum'))
 			->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 			->and($generator = new phar\generator(uniqid(), $factory))
 			->then
@@ -166,7 +166,7 @@ class generator extends atoum\test
 						$generator->setStubFile('');
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Stub file is invalid')
 			->if($adapter->is_file = function() { return false; })
 			->then
@@ -174,7 +174,7 @@ class generator extends atoum\test
 						$generator->setStubFile(uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Stub file is not a valid file')
 			->if($adapter->is_file = function() { return true; })
 			->then
@@ -209,7 +209,7 @@ class generator extends atoum\test
 		$this
 			->assert
 				->if($generator = new phar\generator(uniqid()))
-				->and($stdout = new \mock\mageekguy\atoum\writers\std\out())
+				->and($stdout = new \mock\atoum\writers\std\out())
 				->and($stdout->getMockController()->write = function() {})
 				->and($generator->setOutputWriter($stdout))
 				->then
@@ -223,7 +223,7 @@ class generator extends atoum\test
 		$this
 			->assert
 				->if($generator = new phar\generator(uniqid()))
-				->and($stderr = new \mock\mageekguy\atoum\writers\std\err())
+				->and($stderr = new \mock\atoum\writers\std\err())
 				->and($stderr->getMockController()->write = function() {})
 				->and($generator->setErrorWriter($stderr))
 				->then
@@ -246,7 +246,7 @@ class generator extends atoum\test
 				->and($adapter->is_file = function() { return true; })
 				->and($adapter->unlink = function() {})
 				->and($factory = new atoum\factory())
-				->and($factory->import('mageekguy\atoum'))
+				->and($factory->import('atoum'))
 				->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 				->and($generator = new phar\generator(uniqid(), $factory))
 				->then
@@ -254,7 +254,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Origin directory must be defined')
 				->if($generator->setOriginDirectory((string) $originDirectory))
 				->then
@@ -262,7 +262,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Destination directory must be defined')
 				->if($generator->setDestinationDirectory(uniqid()))
 				->then
@@ -270,7 +270,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Stub file must be defined')
 				->if($generator->setStubFile($stubFile = uniqid()))
 				->and($adapter->is_readable = function() { return false; })
@@ -279,7 +279,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Origin directory \'' . $generator->getOriginDirectory() . '\' is not readable')
 				->if($adapter->is_readable = function($path) use ($originDirectory) { return ($path === (string) $originDirectory); })
 				->and($adapter->is_writable = function() { return false; })
@@ -288,7 +288,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Destination directory \'' . $generator->getDestinationDirectory() . '\' is not writable')
 				->if($adapter->is_writable = function() { return true; })
 				->then
@@ -296,7 +296,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Stub file \'' . $generator->getStubFile() . '\' is not readable')
 				->if($adapter->is_readable = function($path) use ($originDirectory, $stubFile) { return ($path === (string) $originDirectory || $path === $stubFile); })
 				->and($generator->setFactory($factory->setBuilder('phar', function($name) use (& $phar) {
@@ -320,7 +320,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('ABOUT file is missing in \'' . $generator->getOriginDirectory() . '\'')
 				->if($adapter->file_get_contents = function($file) use ($generator, & $description) {
 						switch ($file)
@@ -338,7 +338,7 @@ class generator extends atoum\test
 							$generator->run();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('COPYING file is missing in \'' . $generator->getOriginDirectory() . '\'')
 				->if($adapter->file_get_contents = function($file) use ($generator, & $description, & $licence, & $stub) {
 						switch ($file)
@@ -382,9 +382,9 @@ class generator extends atoum\test
 				->if($superglobals = new atoum\superglobals())
 				->and($superglobals->_SERVER = array('argv' => array(uniqid(), '--help')))
 				->and($generator->setArgumentsParser(new atoum\script\arguments\parser($superglobals)))
-				->and($stdout = new \mock\mageekguy\atoum\writers\std\out())
+				->and($stdout = new \mock\atoum\writers\std\out())
 				->and($stdout->getMockController()->write = function() {})
-				->and($stderr = new \mock\mageekguy\atoum\writers\std\err())
+				->and($stderr = new \mock\atoum\writers\std\err())
 				->and($stderr->getMockController()->write = function() {})
 				->and($generator->setOutputWriter($stdout))
 				->and($generator->setErrorWriter($stderr))

--- a/tests/units/classes/scripts/phar/stub.php
+++ b/tests/units/classes/scripts/phar/stub.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\phar;
+namespace atoum\tests\units\scripts\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\phar,
-	mock\mageekguy\atoum as mock
+	atoum,
+	atoum\scripts\phar,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,7 +15,7 @@ class stub extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\scripts\runner')
+			->testedClass->isSubclassOf('atoum\scripts\runner')
 		;
 	}
 
@@ -39,12 +39,12 @@ class stub extends atoum\test
 				->and($stdOut->getMockController()->write = function() {})
 				->then
 					->exception(function() use ($stub) { $stub->update(); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Unable to update the PHAR, phar.readonly is set, use \'-d phar.readonly=0\'')
 				->if($adapter->ini_get = function($name) { return $name === 'phar.readonly' ? 0 : $name = 'allow_url_fopen' ? 0 : ini_get($name); })
 				->then
 					->exception(function() use ($stub) { $stub->update(); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Unable to update the PHAR, allow_url_fopen is not set, use \'-d allow_url_fopen=1\'')
 				->if($adapter->ini_get = function($name) { return $name === 'phar.readonly' ? 0 : $name = 'allow_url_fopen' ? 1 : ini_get($name); })
 				->and($stub->getFactory()->setBuilder('phar', function($path) use (& $phar) {

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\scripts\builder\vcs
+	atoum,
+	atoum\scripts,
+	atoum\mock\stream,
+	atoum\scripts\builder\vcs
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class runner extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\script');
+		$this->testedClass->isSubclassOf('atoum\script');
 	}
 
 	public function testClassConstants()
@@ -31,14 +31,14 @@ class runner extends atoum\test
 			->if($scriptRunner = new scripts\runner($name = uniqid()))
 			->then
 				->string($scriptRunner->getName())->isEqualTo($name)
-				->object($scriptRunner->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($scriptRunner->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($scriptRunner->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
-				->object($scriptRunner->getRunner())->isInstanceOf('mageekguy\atoum\runner')
+				->object($scriptRunner->getLocale())->isInstanceOf('atoum\locale')
+				->object($scriptRunner->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($scriptRunner->getIncluder())->isInstanceOf('atoum\includer')
+				->object($scriptRunner->getRunner())->isInstanceOf('atoum\runner')
 				->object($scriptRunner->getRunner()->getFactory())->isIdenticalTo($scriptRunner->getFactory())
-				->object($scriptRunner->getFactory()->build('mageekguy\atoum\locale'))->isIdenticalTo($scriptRunner->getLocale())
-				->object($scriptRunner->getFactory()->build('mageekguy\atoum\adapter'))->isIdenticalTo($scriptRunner->getAdapter())
-				->object($scriptRunner->getFactory()->build('mageekguy\atoum\includer'))->isIdenticalTo($scriptRunner->getIncluder())
+				->object($scriptRunner->getFactory()->build('atoum\locale'))->isIdenticalTo($scriptRunner->getLocale())
+				->object($scriptRunner->getFactory()->build('atoum\adapter'))->isIdenticalTo($scriptRunner->getAdapter())
+				->object($scriptRunner->getFactory()->build('atoum\includer'))->isIdenticalTo($scriptRunner->getIncluder())
 				->variable($scriptRunner->getScoreFile())->isNull()
 				->array($scriptRunner->getArguments())->isEmpty()
 				->array($scriptRunner->getHelp())->isEqualTo(array(
@@ -160,11 +160,11 @@ class runner extends atoum\test
 					)
 				)
 			->if($factory = new atoum\factory())
-			->and($factory->import('mageekguy\atoum'))
-			->and($factory['mageekguy\atoum\locale'] = $locale = new atoum\locale())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\adapter())
-			->and($factory['mageekguy\atoum\runner'] = $runner = new atoum\runner())
-			->and($factory['mageekguy\atoum\includer'] = $includer = new atoum\includer())
+			->and($factory->import('atoum'))
+			->and($factory['atoum\locale'] = $locale = new atoum\locale())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\adapter())
+			->and($factory['atoum\runner'] = $runner = new atoum\runner())
+			->and($factory['atoum\includer'] = $includer = new atoum\includer())
 			->and($scriptRunner = new scripts\runner($name = uniqid(), $factory))
 			->then
 				->string($scriptRunner->getName())->isEqualTo($name)
@@ -311,14 +311,14 @@ class runner extends atoum\test
 	{
 		$this
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\locale'] = $locale = new \mock\mageekguy\atoum\locale())
+			->and($factory['atoum\locale'] = $locale = new \mock\atoum\locale())
 			->and($runner = new scripts\runner($name = uniqid(), $factory))
 			->then
 				->exception(function() use ($runner, & $file) {
 						$runner->useConfigFile($file = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\includer\exception')
+					->isInstanceOf('atoum\includer\exception')
 					->hasMessage('Unable to find configuration file \'' . $file . '\'')
 				->mock($locale)->call('_')->withArguments('Unable to find configuration file \'%s\'')->once()
 			->if($configFile = stream::get())
@@ -333,7 +333,7 @@ class runner extends atoum\test
 	public function testUseDefaultConfigFiles()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner($name = uniqid()))
+			->if($runner = new \mock\atoum\scripts\runner($name = uniqid()))
 			->and($runner->getMockController()->useConfigFile = function() {})
 			->then
 				->object($runner->useDefaultConfigFiles())->isIdenticalTo($runner)

--- a/tests/units/classes/scripts/tagger.php
+++ b/tests/units/classes/scripts/tagger.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class tagger extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\script')
+			->testedClass->isSubclassOf('atoum\script')
 		;
 	}
 
@@ -23,7 +23,7 @@ class tagger extends atoum\test
 		$tagger = new scripts\tagger(uniqid());
 
 		$this->assert
-			->object($tagger->getEngine())->isInstanceOf('mageekguy\atoum\scripts\tagger\engine')
+			->object($tagger->getEngine())->isInstanceOf('atoum\scripts\tagger\engine')
 			->object($tagger->getEngine()->getAdapter())->isIdenticalTo($tagger->getAdapter())
 		;
 	}
@@ -40,10 +40,10 @@ class tagger extends atoum\test
 
 	public function testRun()
 	{
-		$tagger = new \mock\mageekguy\atoum\scripts\tagger(uniqid());
+		$tagger = new \mock\atoum\scripts\tagger(uniqid());
 
 		$tagger
-			->setEngine($engine = new \mock\mageekguy\atoum\scripts\tagger\engine())
+			->setEngine($engine = new \mock\atoum\scripts\tagger\engine())
 			->getMockController()->writeMessage = $tagger
 		;
 

--- a/tests/units/classes/scripts/tagger/engine.php
+++ b/tests/units/classes/scripts/tagger/engine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\tagger;
+namespace atoum\tests\units\scripts\tagger;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\scripts\tagger
+	atoum,
+	atoum\mock,
+	atoum\scripts\tagger
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -16,8 +16,8 @@ class engine extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->hasInterface('mageekguy\atoum\adapter\aggregator')
-			->string(\mageekguy\atoum\scripts\tagger\engine::defaultVersionPattern)->isEqualTo('/\$Rev: [^ ]+ \$/')
+				->hasInterface('atoum\adapter\aggregator')
+			->string(\atoum\scripts\tagger\engine::defaultVersionPattern)->isEqualTo('/\$Rev: [^ ]+ \$/')
 		;
 	}
 
@@ -29,8 +29,8 @@ class engine extends atoum\test
 			->variable($tagger->getSrcDirectory())->isNull()
 			->variable($tagger->getDestinationDirectory())->isNull()
 			->variable($tagger->getVersion())->isNull()
-			->string($tagger->getVersionPattern())->isEqualTo(\mageekguy\atoum\scripts\tagger\engine::defaultVersionPattern)
-			->object($tagger->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->string($tagger->getVersionPattern())->isEqualTo(\atoum\scripts\tagger\engine::defaultVersionPattern)
+			->object($tagger->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$tagger = new tagger\engine($adapter = new atoum\adapter());
@@ -39,7 +39,7 @@ class engine extends atoum\test
 			->variable($tagger->getSrcDirectory())->isNull()
 			->variable($tagger->getDestinationDirectory())->isNull()
 			->variable($tagger->getVersion())->isNull()
-			->string($tagger->getVersionPattern())->isEqualTo(\mageekguy\atoum\scripts\tagger\engine::defaultVersionPattern)
+			->string($tagger->getVersionPattern())->isEqualTo(\atoum\scripts\tagger\engine::defaultVersionPattern)
 			->object($tagger->getAdapter())->isIdenticalTo($adapter)
 		;
 	}
@@ -120,7 +120,7 @@ class engine extends atoum\test
 					$tagger->setSrcIteratorInjector(function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Src iterator injector must take one argument')
 			->object($tagger->setSrcIteratorInjector(function($directory) { return new \recursiveDirectoryIterator($directory); }))->isIdenticalTo($tagger)
 			->object($tagger->getSrcIterator())->isInstanceOf('recursiveDirectoryIterator')
@@ -137,7 +137,7 @@ class engine extends atoum\test
 					$tagger->getSrcIterator();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to get files iterator, source directory is undefined')
 		;
 
@@ -161,7 +161,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to tag, src directory is undefined')
 		;
 
@@ -172,7 +172,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to tag, version is undefined')
 		;
 
@@ -186,7 +186,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to tag, src iterator injector does not return an iterator')
 		;
 
@@ -222,7 +222,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to tag, path \'' . $file2 . '\' is unreadable')
 		;
 
@@ -235,7 +235,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to tag, path \'' . $file2 . '\' is unwritable')
 		;
 

--- a/tests/units/classes/superglobals.php
+++ b/tests/units/classes/superglobals.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -36,7 +36,7 @@ class superglobals extends atoum\test
 						$superglobals->{$name = uniqid()} = uniqid();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('PHP superglobal \'$' . $name . '\' does not exist')
 		;
 

--- a/tests/units/classes/template.php
+++ b/tests/units/classes/template.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -51,14 +51,14 @@ class template extends atoum\test
 		$template = new atoum\template();
 
 		$this->assert
-			->object($iterator = $template->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
 		;
 
 		$template->addChild($childTag = new atoum\template\tag(uniqid()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($childTag)
 		;
@@ -66,7 +66,7 @@ class template extends atoum\test
 		$template->addChild($otherChildTag = new atoum\template\tag($childTag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(2)
 			->object($iterator->current())->isIdenticalTo($childTag)
 			->object($iterator->next()->current())->isIdenticalTo($otherChildTag)
@@ -75,11 +75,11 @@ class template extends atoum\test
 		$template->addChild($anotherChildTag = new atoum\template\tag(uniqid()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(2)
 			->object($iterator->current())->isIdenticalTo($childTag)
 			->object($iterator->next()->current())->isIdenticalTo($otherChildTag)
-			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($anotherChildTag)
 		;
@@ -87,12 +87,12 @@ class template extends atoum\test
 		$childTag->addChild($littleChildTag  = new atoum\template\tag($childTag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(3)
 			->object($iterator->current())->isIdenticalTo($childTag)
 			->object($iterator->next()->current())->isIdenticalTo($littleChildTag)
 			->object($iterator->next()->current())->isIdenticalTo($otherChildTag)
-			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($anotherChildTag)
 		;
@@ -612,7 +612,7 @@ class template extends atoum\test
 						$template->addChild($templateWithSameId);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Id \'' . $id . '\' is already defined')
 		;
 	}
@@ -657,16 +657,16 @@ class template extends atoum\test
 		$template = new atoum\template();
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
 		;
 
 		$template->addChild($tag = new atoum\template\tag(uniqid()));
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
-			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($tag)
 		;
@@ -674,9 +674,9 @@ class template extends atoum\test
 		$template->addChild($otherTag = new atoum\template\tag($tag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
-			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(2)
 			->object($iterator->current())->isIdenticalTo($tag)
 			->object($iterator->next()->current())->isIdenticalTo($otherTag)
@@ -685,9 +685,9 @@ class template extends atoum\test
 		$tag->addChild($childTag = new atoum\template\tag($tag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
-			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(3)
 			->object($iterator->current())->isIdenticalTo($tag)
 			->object($iterator->next()->current())->isIdenticalTo($childTag)

--- a/tests/units/classes/template/data.php
+++ b/tests/units/classes/template/data.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\template
+	atoum,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/template/iterator.php
+++ b/tests/units/classes/template/iterator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\template
+	atoum,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -25,7 +25,7 @@ class iterator extends atoum\test
 		$iterator = new template\iterator();
 
 		$this->assert
-			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isZero()
 		;
 
@@ -37,20 +37,20 @@ class iterator extends atoum\test
 		$tag->addChild($childTag = new template\tag($tag->getTag()));
 
 		$this->assert
-			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isZero()
-			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isEqualTo(1)
 		;
 
 		$childTag->addChild($littleChildTag = new template\tag(uniqid()));
 
 		$this->assert
-			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isZero()
-			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isEqualTo(1)
-			->object($innerIterator = $iterator->{$childTag->getTag()}->{$littleChildTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{$childTag->getTag()}->{$littleChildTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isEqualTo(1)
 		;
 	}
@@ -110,7 +110,7 @@ class iterator extends atoum\test
 		$iterator = new template\iterator();
 
 		$template = new atoum\template();
-		$template->addChild($tag = new \mock\mageekguy\atoum\template\tag(uniqid()));
+		$template->addChild($tag = new \mock\atoum\template\tag(uniqid()));
 		$tag->getMockController()->build = function() {};
 
 		$iterator->addTag($tag->getTag(), $template);

--- a/tests/units/classes/template/parser.php
+++ b/tests/units/classes/template/parser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\template
+	atoum,
+	atoum\test,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class parser extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->hasInterface('mageekguy\atoum\adapter\aggregator')
+			->testedClass->hasInterface('atoum\adapter\aggregator')
 		;
 	}
 
@@ -25,21 +25,21 @@ class parser extends atoum\test
 
 		$this->assert
 			->string($parser->getNamespace())->isEqualTo(template\parser::defaultNamespace)
-			->object($parser->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($parser->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$parser = new template\parser($namespace = uniqid());
 
 		$this->assert
 			->string($namespace)->isEqualTo($parser->getNamespace())
-			->object($parser->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($parser->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$parser = new template\parser($namespace = rand(1, PHP_INT_MAX));
 
 		$this->assert
 			->string($parser->getNamespace())->isEqualTo((string) $namespace)
-			->object($parser->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($parser->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$parser = new template\parser($namespace = uniqid(), $adapter = new atoum\test\adapter());
@@ -77,7 +77,7 @@ class parser extends atoum\test
 
 	public function testCheckString()
 	{
-		$this->define->parserException = '\mageekguy\atoum\tests\units\asserters\template\parser\exception';
+		$this->define->parserException = '\atoum\tests\units\asserters\template\parser\exception';
 
 		$parser = new template\parser();
 
@@ -98,8 +98,8 @@ class parser extends atoum\test
 					$parser->checkString('<' . template\parser::defaultNamespace . ':' . $tag . ' id="" />');
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id must not be empty')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -116,8 +116,8 @@ class parser extends atoum\test
 					$parser->checkString($tagWithId . $tagWithId);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id \'' . $id . '\' is already defined in line 1 at offset 1')
 				->hasErrorLine(1)
 				->hasErrorOffset(41)
@@ -130,8 +130,8 @@ class parser extends atoum\test
 					$parser->checkString($tagWithInvalidAttribute);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Attribute \'foo\' is unknown')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -144,8 +144,8 @@ class parser extends atoum\test
 					$parser->checkString($firstTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -160,8 +160,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $firstTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -174,8 +174,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $spaces . $firstTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -189,8 +189,8 @@ class parser extends atoum\test
 					$parser->checkString($firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -198,8 +198,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -207,8 +207,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $spaces . $firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -217,7 +217,7 @@ class parser extends atoum\test
 
 	public function testCheckFile()
 	{
-		$this->define->parserException = '\mageekguy\atoum\tests\units\asserters\template\parser\exception';
+		$this->define->parserException = '\atoum\tests\units\asserters\template\parser\exception';
 
 		$parser = new template\parser(null, $adapter = new test\adapter());
 
@@ -228,7 +228,7 @@ class parser extends atoum\test
 					$parser->checkFile($path = uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to get contents from file \'' . $path . '\'')
 		;
 
@@ -275,8 +275,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id must not be empty')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -315,8 +315,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id \'' . $id . '\' is already defined in line 1 at offset 1')
 				->hasErrorLine(1)
 				->hasErrorOffset(41)
@@ -329,8 +329,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Attribute \'foo\' is unknown')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -343,8 +343,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -357,8 +357,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -371,8 +371,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -388,8 +388,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -402,8 +402,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -416,8 +416,8 @@ class parser extends atoum\test
 					$parser->checkFile($eols . $spaces . $firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -429,28 +429,28 @@ class parser extends atoum\test
 		$parser = new template\parser();
 
 		$this->assert
-			->object($root = $parser->parseString(''))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString(''))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->isEmpty()
 		;
 
 		$this->assert
-			->object($root = $parser->parseString($string = uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString($string = uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$this->assert
-			->object($root = $parser->parseString($string = uniqid() . "\n" . uniqid() . "\n"))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString($string = uniqid() . "\n" . uniqid() . "\n"))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' />'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' />'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -459,9 +459,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -470,9 +470,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '" />'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '" />'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -481,9 +481,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '"/>'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '"/>'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -492,9 +492,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -503,39 +503,39 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
 		$this->assert
-			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '">' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '">' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(1)->getId())->isEqualTo($id)
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
 		$this->assert
 			->object($root = $parser->parseString(($string = str_repeat("\n", 6)) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>'))
 			->array($root->getChildren())->hasSize(2)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(7)
@@ -554,41 +554,41 @@ class parser extends atoum\test
 					$parser->parseFile($path = uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to get contents from file \'' . $path . '\'')
 		;
 
 		$adapter->file_get_contents = '';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->isEmpty()
 		;
 
 		$adapter->file_get_contents = $string = uniqid();
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$adapter->file_get_contents = $string = uniqid() . "\n" . uniqid() . "\n";
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' />';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -599,9 +599,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -612,9 +612,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '" />';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -625,9 +625,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '"/>';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -638,9 +638,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -651,32 +651,32 @@ class parser extends atoum\test
 		$adapter->file_get_contents = ($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid());
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
 		$adapter->file_get_contents = ($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '">' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid());
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(1)->getId())->isEqualTo($id)
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
@@ -685,9 +685,9 @@ class parser extends atoum\test
 		$this->assert
 			->object($root = $parser->parseFile(uniqid()))
 			->array($root->getChildren())->hasSize(2)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(7)

--- a/tests/units/classes/template/tag.php
+++ b/tests/units/classes/template/tag.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\template
+	atoum,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class tag extends atoum\test
 	public function test__construct()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\template')
+			->testedClass->isSubClassOf('atoum\template')
 		;
 
 		$this->assert
@@ -22,31 +22,31 @@ class tag extends atoum\test
 					$template = new template\tag('');
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Tag must not be an empty string')
 			->exception(function() {
 					$template = new template\tag(uniqid(), null, 0);
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Line must be greater than 0')
 			->exception(function() {
 						$template = new template\tag(uniqid(), null, - rand(1, PHP_INT_MAX));
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Line must be greater than 0')
 			->exception(function() {
 						$template = new template\tag(uniqid(), null, rand(1, PHP_INT_MAX), 0);
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Offset must be greater than 0')
 			->exception(function() {
 					$template = new template\tag(uniqid(), null, rand(1, PHP_INT_MAX), - rand(1, PHP_INT_MAX));
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Offset must be greater than 0')
 		;
 
@@ -78,7 +78,7 @@ class tag extends atoum\test
 						$template->setId('');
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Id must not be empty')
 		;
 
@@ -100,7 +100,7 @@ class tag extends atoum\test
 						$template->setId($id);
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Id \'' . $id . '\' is already defined in line unknown at offset unknown')
 		;
 	}
@@ -136,7 +136,7 @@ class tag extends atoum\test
 						$template->setAttribute($attribute = uniqid(), uniqid());
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Attribute \'' . $attribute . '\' is unknown')
 		;
 	}
@@ -155,7 +155,7 @@ class tag extends atoum\test
 						$template->unsetAttribute($attribute = uniqid());
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Attribute \'' . $attribute . '\' is unknown')
 		;
 	}

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace mageekguy\atoum
+namespace atoum
 {
 	class emptyTest {}
 	class notEmptyTest {}
 }
 
-namespace mageekguy\atoum\mock\mageekguy\atoum
+namespace atoum\mock\atoum
 {
 	class test {}
 }
 
-namespace mageekguy\atoum\tests\units
+namespace atoum\tests\units
 {
 	use
-		mageekguy\atoum,
-		mageekguy\atoum\mock
+		atoum,
+		atoum\mock
 	;
 
 	require_once __DIR__ . '/../runner.php';
@@ -52,7 +52,7 @@ namespace mageekguy\atoum\tests\units
 	{
 		public function __construct()
 		{
-			$this->setTestedClassName('mageekguy\atoum\test');
+			$this->setTestedClassName('atoum\test');
 
 			parent::__construct();
 		}
@@ -62,7 +62,7 @@ namespace mageekguy\atoum\tests\units
 	{
 		public function testClass()
 		{
-			$this->testedClass->hasInterface('mageekguy\atoum\adapter\aggregator');
+			$this->testedClass->hasInterface('atoum\adapter\aggregator');
 		}
 
 		public function testClassConstants()
@@ -91,7 +91,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getFactory())->isInstanceOf('mageekguy\atoum\factory')
+					->object($test->getFactory())->isInstanceOf('atoum\factory')
 					->object($test->getScore())->isEqualTo(new atoum\score($test->getFactory()))
 					->object($test->getLocale())->isEqualTo(new atoum\locale())
 					->object($test->getAdapter())->isEqualTo(new atoum\adapter())
@@ -107,10 +107,10 @@ namespace mageekguy\atoum\tests\units
 					->integer($test->getMaxChildrenNumber())->isEqualTo(666)
 					->variable($test->getBootstrapFile())->isNull()
 				->if($factory = new atoum\factory())
-				->and($factory->returnWhenBuild('mageekguy\atoum\score', $score = new atoum\score()))
-				->and($factory->returnWhenBuild('mageekguy\atoum\locale', $locale = new atoum\locale()))
-				->and($factory->returnWhenBuild('mageekguy\atoum\adapter', $adapter = new atoum\adapter()))
-				->and($factory->returnWhenBuild('mageekguy\atoum\superglobals', $superglobals = new atoum\superglobals()))
+				->and($factory->returnWhenBuild('atoum\score', $score = new atoum\score()))
+				->and($factory->returnWhenBuild('atoum\locale', $locale = new atoum\locale()))
+				->and($factory->returnWhenBuild('atoum\adapter', $adapter = new atoum\adapter()))
+				->and($factory->returnWhenBuild('atoum\superglobals', $superglobals = new atoum\superglobals()))
 				->and($test = new emptyTest($factory))
 				->then
 					->object($test->getFactory())->isIdenticalTo($factory)
@@ -141,9 +141,9 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->assert)->isInstanceOf('mageekguy\atoum\test\assertion\manager')
-					->object($test->define)->isInstanceOf('mageekguy\atoum\test\asserter\generator')
-					->object($test->mockGenerator)->isInstanceOf('mageekguy\atoum\mock\generator')
+					->object($test->assert)->isInstanceOf('atoum\test\assertion\manager')
+					->object($test->define)->isInstanceOf('atoum\test\asserter\generator')
+					->object($test->mockGenerator)->isInstanceOf('atoum\mock\generator')
 				->if($test->setMockGenerator($mockGenerator = new atoum\test\mock\generator($this)))
 				->then
 					->object($test->mockGenerator)->isIdenticalTo($mockGenerator)
@@ -151,7 +151,7 @@ namespace mageekguy\atoum\tests\units
 				->then
 					->object($test->assert)->isIdenticalTo($test->getAssertionManager())
 					->exception(function() use ($test, & $property) { $test->{$property = uniqid()}; })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Asserter \'' . $property . '\' does not exist')
 			;
 		}
@@ -163,7 +163,7 @@ namespace mageekguy\atoum\tests\units
 					->if($adapter = new atoum\test\adapter())
 					->and($adapter->extension_loaded = function($extension) { return $extension == 'xdebug'; })
 					->and($factory = new atoum\factory())
-					->and($factory->returnWhenBuild('mageekguy\atoum\adapter', $adapter))
+					->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 					->and($test = new emptyTest($factory))
 					->then
 						->boolean($test->codeCoverageIsEnabled())->isTrue()
@@ -177,7 +177,7 @@ namespace mageekguy\atoum\tests\units
 				->assert('Code coverage must not be enabled if xdebug is not available')
 					->if($adapter->extension_loaded = function($extension) { return $extension != 'xdebug'; })
 					->and($factory = new atoum\factory())
-					->and($factory->returnWhenBuild('mageekguy\atoum\adapter', $adapter))
+					->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 					->and($test = new emptyTest($factory))
 					->then
 						->boolean($test->codeCoverageIsEnabled())->isFalse()
@@ -192,7 +192,7 @@ namespace mageekguy\atoum\tests\units
 				->if($adapter = new atoum\test\adapter())
 				->and($adapter->extension_loaded = true)
 				->and($factory = new atoum\factory())
-				->and($factory->returnWhenBuild('mageekguy\atoum\adapter', $adapter))
+				->and($factory->returnWhenBuild('atoum\adapter', $adapter))
 				->and($test = new emptyTest($factory))
 				->then
 					->boolean($test->codeCoverageIsEnabled())->isTrue()
@@ -221,7 +221,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getMockGenerator())->isInstanceOf('mageekguy\atoum\mock\generator')
+					->object($test->getMockGenerator())->isInstanceOf('atoum\mock\generator')
 				->if($test->setMockGenerator($mockGenerator = new atoum\test\mock\generator($this)))
 				->then
 					->object($test->getMockGenerator())->isIdenticalTo($mockGenerator)
@@ -245,7 +245,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getAsserterGenerator())->isInstanceOf('mageekguy\atoum\test\asserter\generator')
+					->object($test->getAsserterGenerator())->isInstanceOf('atoum\test\asserter\generator')
 				->if($test->setAsserterGenerator($asserterGenerator = new atoum\test\asserter\generator($this)))
 				->then
 					->object($test->getAsserterGenerator())->isIdenticalTo($asserterGenerator)
@@ -286,7 +286,7 @@ namespace mageekguy\atoum\tests\units
 				->and($test->getMockController()->getClass = $testClass = 'foo')
 				->then
 					->exception(function() use ($test) { $test->getTestedClassName(); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Test class \'' . $testClass . '\' is not in a namespace which match pattern \'' . $test->getTestNamespace() . '\'')
 				->if($test->getMockController()->getClass = 'tests\units\foo')
 				->then
@@ -314,7 +314,7 @@ namespace mageekguy\atoum\tests\units
 							}
 						)
 						->isInstanceOf('invalidArgumentException')
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test namespace must not be empty')
 			;
 		}
@@ -324,7 +324,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+					->object($test->getAdapter())->isInstanceOf('atoum\adapter')
 			;
 		}
 
@@ -374,10 +374,10 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->exception(function() use ($test) { $test->setMaxChildrenNumber(- rand(1, PHP_INT_MAX)); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Maximum number of children must be greater or equal to 1')
 					->exception(function() use ($test) { $test->setMaxChildrenNumber(0); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Maximum number of children must be greater or equal to 1')
 					->object($test->setMaxChildrenNumber($maxChildrenNumber = rand(1, PHP_INT_MAX)))->isIdenticalTo($test)
 					->integer($test->getMaxChildrenNumber())->isEqualTo($maxChildrenNumber)
@@ -528,7 +528,7 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->exception(function() use ($test, & $method) { $test->methodIsIgnored($method = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() is unknown')
 			;
 		}
@@ -551,7 +551,7 @@ namespace mageekguy\atoum\tests\units
 					->object($test->setMethodTags('testMethod1', $tags = array(uniqid(), uniqid())))->isIdenticalTo($test)
 					->array($test->getMethodTags('testMethod1'))->isEqualTo($tags)
 					->exception(function() use ($test, & $method) { $test->setMethodTags($method = uniqid(), array()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() is unknown')
 			;
 		}
@@ -563,7 +563,7 @@ namespace mageekguy\atoum\tests\units
 				->then
 					->array($test->getMethodTags('testMethod1'))->isEqualTo(array('test', 'method', 'one'))
 					->exception(function() use ($test, & $method) { $test->getMethodTags($method = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() is unknown')
 			;
 		}
@@ -577,12 +577,12 @@ namespace mageekguy\atoum\tests\units
 					->object($test->run())->isIdenticalTo($test)
 					->mock($test)
 						->call('callObservers')
-							->withArguments(\mageekguy\atoum\test::runStart)->once()
-							->withArguments(\mageekguy\atoum\test::runStop)->once()
-							->withArguments(\mageekguy\atoum\test::beforeSetUp)->never()
-							->withArguments(\mageekguy\atoum\test::afterSetUp)->never()
-							->withArguments(\mageekguy\atoum\test::beforeTestMethod)->never()
-							->withArguments(\mageekguy\atoum\test::afterTestMethod)->never()
+							->withArguments(\atoum\test::runStart)->once()
+							->withArguments(\atoum\test::runStop)->once()
+							->withArguments(\atoum\test::beforeSetUp)->never()
+							->withArguments(\atoum\test::afterSetUp)->never()
+							->withArguments(\atoum\test::beforeTestMethod)->never()
+							->withArguments(\atoum\test::afterTestMethod)->never()
 			;
 		}
 
@@ -591,16 +591,16 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new foo())
 				->then
-					->string($test->getTestedClassName())->isEqualTo('mageekguy\atoum\test')
+					->string($test->getTestedClassName())->isEqualTo('atoum\test')
 					->exception(function() use ($test) { $test->setTestedClassName(uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Tested class name is already defined')
 				->if($test = new self())
 				->then
 					->object($test->setTestedClassName($class = uniqid()))->isIdenticalTo($test)
 					->string($test->getTestedClassName())->isEqualTo($class)
 					->exception(function() use ($test) { $test->setTestedClassName(uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Tested class name is already defined')
 			;
 		}
@@ -675,12 +675,12 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->exception(function() use ($test, & $method) { $test->setDataProvider($method = uniqid(), uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() is unknown')
 				->if($test = new notEmptyTest())
 				->then
 					->exception(function() use ($test, & $dataProvider) { $test->setDataProvider('testMethod1', $dataProvider = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Data provider ' . get_class($test) . '::' . $dataProvider . '() is unknown')
 					->object($test->setDataProvider('testMethod1', 'aDataProvider'))->isIdenticalTo($test)
 					->array($test->getDataProviders())->isEqualTo(array('testMethod1' => 'aDataProvider'))

--- a/tests/units/classes/test/adapter.php
+++ b/tests/units/classes/test/adapter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test;
+namespace atoum\tests\units\test;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\test\adapter as testedClass,
-	mageekguy\atoum\test\adapter\invoker,
-	mageekguy\atoum\dependence,
-	mageekguy\atoum\dependencies
+	atoum\test,
+	atoum\test\adapter as testedClass,
+	atoum\test\adapter\invoker,
+	atoum\dependence,
+	atoum\dependencies
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -21,7 +21,7 @@ class adapter extends test
 			->then
 				->array($adapter->getInvokers())->isEmpty()
 				->array($adapter->getCalls())->isEmpty()
-				->object($dependencies = $adapter->getDependencies())->isInstanceOf('mageekguy\atoum\dependencies')
+				->object($dependencies = $adapter->getDependencies())->isInstanceOf('atoum\dependencies')
 				->object($dependencies['invoker']())->isEqualTo(new invoker())
 			->if($adapter = new testedClass($dependencies = new dependencies()))
 			->then
@@ -49,14 +49,14 @@ class adapter extends test
 				->object($adapter->md5->getClosure())->isIdenticalTo($closure)
 			->if($adapter->md5 = $return = uniqid())
 			->then
-				->object($adapter->md5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
-				->object($adapter->MD5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($adapter->md5)->isInstanceOf('atoum\test\adapter\invoker')
+				->object($adapter->MD5)->isInstanceOf('atoum\test\adapter\invoker')
 				->string($adapter->invoke('md5'))->isEqualTo($return)
 				->string($adapter->invoke('MD5'))->isEqualTo($return)
 			->if($adapter->MD5 = $return = uniqid())
 			->then
-				->object($adapter->md5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
-				->object($adapter->MD5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($adapter->md5)->isInstanceOf('atoum\test\adapter\invoker')
+				->object($adapter->MD5)->isInstanceOf('atoum\test\adapter\invoker')
 				->string($adapter->invoke('md5'))->isEqualTo($return)
 				->string($adapter->invoke('MD5'))->isEqualTo($return)
 		;
@@ -155,13 +155,13 @@ class adapter extends test
 							$adapter->require(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Function \'require()\' is not invokable by an adapter')
 				->exception(function() use ($adapter) {
 							$adapter->REQUIRE(uNiqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Function \'REQUIRE()\' is not invokable by an adapter')
 			->if($adapter->md5 = 0)
 			->and($adapter->md5[1] = 1)

--- a/tests/units/classes/test/adapter/callable.php
+++ b/tests/units/classes/test/adapter/callable.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\adapter;
+namespace atoum\tests\units\test\adapter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\adapter
+	atoum,
+	atoum\test\adapter
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -43,7 +43,7 @@ class invoker extends atoum\test
 					$invoker->{uniqid()} = uniqid();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 		;
 	}
 
@@ -66,7 +66,7 @@ class invoker extends atoum\test
 					$invoker->setClosure(function() {}, - rand(1, PHP_INT_MAX));
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->object($invoker->setClosure($value = function() {}))->isIdenticalTo($invoker)
 			->boolean($invoker->isEmpty())->isFalse()
@@ -89,7 +89,7 @@ class invoker extends atoum\test
 					$invoker->getClosure(- rand(1, PHP_INT_MAX));
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->variable($invoker->getClosure(rand(0, PHP_INT_MAX)))->isNull()
 		;
@@ -111,7 +111,7 @@ class invoker extends atoum\test
 					$invoker->closureIsSetForCall(- rand(1, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->boolean($invoker->closureIsSetForCall(rand(0, PHP_INT_MAX)))->isFalse()
 		;
@@ -134,13 +134,13 @@ class invoker extends atoum\test
 					$invoker->unsetClosure(- rand(1, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->exception(function() use ($invoker, & $call) {
 					$invoker->unsetClosure($call = rand(0, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('There is no closure defined for call ' . $call)
 		;
 
@@ -162,7 +162,7 @@ class invoker extends atoum\test
 					$invoker->offsetSet(- rand(1, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->object($invoker->offsetSet(1, $value = function() {}))->isIdenticalTo($invoker)
 			->boolean($invoker->isEmpty())->isFalse()
@@ -181,7 +181,7 @@ class invoker extends atoum\test
 					$invoker->offsetGet(- rand(1, PHP_INT_MAX));
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->variable($invoker->getClosure(rand(0, PHP_INT_MAX)))->isNull()
 		;
@@ -205,7 +205,7 @@ class invoker extends atoum\test
 					$invoker->offsetExists(- rand(1, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->boolean($invoker->offsetExists(rand(0, PHP_INT_MAX)))->isFalse()
 		;
@@ -227,13 +227,13 @@ class invoker extends atoum\test
 					$invoker->offsetUnset(- rand(1, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Call number must be greater than or equal to zero')
 			->exception(function() use ($invoker, & $call) {
 					$invoker->offsetUnset($call = rand(0, PHP_INT_MAX), function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('There is no closure defined for call ' . $call)
 		;
 
@@ -255,7 +255,7 @@ class invoker extends atoum\test
 					$invoker->invoke();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('There is no closure defined for call 0')
 		;
 

--- a/tests/units/classes/test/assertion/manager.php
+++ b/tests/units/classes/test/assertion/manager.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\assertion;
+namespace atoum\tests\units\test\assertion;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\test\assertion
+	atoum,
+	atoum\test,
+	atoum\test\assertion
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -31,7 +31,7 @@ class manager extends atoum\test
 						$assertionManager->{$event = uniqid()};
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\assertion\manager\exception')
+					->isInstanceOf('atoum\test\assertion\manager\exception')
 					->hasMessage('There is no handler defined for event \'' . $event . '\'')
 			->if($assertionManager->setDefaultHandler(function() use (& $defaultReturn) { return ($defaultReturn = uniqid()); }))
 			->then
@@ -51,7 +51,7 @@ class manager extends atoum\test
 						$assertionManager->{$event = uniqid()}();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\assertion\manager\exception')
+					->isInstanceOf('atoum\test\assertion\manager\exception')
 					->hasMessage('There is no handler defined for event \'' . $event . '\'')
 			->if($assertionManager->setDefaultHandler(function($event, $defaultArg) { return $defaultArg; }))
 			->then
@@ -95,7 +95,7 @@ class manager extends atoum\test
 						$assertionManager->invoke($event = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\assertion\manager\exception')
+					->isInstanceOf('atoum\test\assertion\manager\exception')
 					->hasMessage('There is no handler defined for event \'' . $event . '\'')
 			->if($assertionManager->setDefaultHandler(function($event, $arg) { return $arg; }))
 			->then

--- a/tests/units/classes/test/assertion/manager/exception.php
+++ b/tests/units/classes/test/assertion/manager/exception.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\assertion\manager;
+namespace atoum\tests\units\test\assertion\manager;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubClassOf('mageekguy\atoum\exceptions\runtime');
+		$this->testedClass->isSubClassOf('atoum\exceptions\runtime');
 	}
 }

--- a/tests/units/classes/test/engine.php
+++ b/tests/units/classes/test/engine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test;
+namespace atoum\tests\units\test;
 
 require_once __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class engine extends atoum\test
@@ -18,10 +18,10 @@ class engine extends atoum\test
 	public function test__construct()
 	{
 		$this
-			->if($engine = new \mock\mageekguy\atoum\test\engine())
+			->if($engine = new \mock\atoum\test\engine())
 			->then
 				->object($engine->getFactory())->isEqualTo(new atoum\factory())
-			->if($engine = new \mock\mageekguy\atoum\test\engine($factory = new atoum\factory()))
+			->if($engine = new \mock\atoum\test\engine($factory = new atoum\factory()))
 			->then
 				->object($engine->getFactory())->isIdenticalTo($factory)
 		;
@@ -30,7 +30,7 @@ class engine extends atoum\test
 	public function testSetFactory()
 	{
 		$this
-			->if($engine = new \mock\mageekguy\atoum\test\engine())
+			->if($engine = new \mock\atoum\test\engine())
 			->then
 				->object($engine->setFactory($factory = new atoum\factory()))->isIdenticalTo($engine)
 				->object($engine->getFactory())->isIdenticalTo($factory)

--- a/tests/units/classes/test/engines/concurrent.php
+++ b/tests/units/classes/test/engines/concurrent.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\engines;
+namespace atoum\tests\units\test\engines;
 
 require_once __DIR__ . '/../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\engines
+	atoum,
+	atoum\test\engines
 ;
 
 class concurrent extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\test\engine');
+		$this->testedClass->isSubclassOf('atoum\test\engine');
 	}
 
 	public function test__construct()
@@ -38,10 +38,10 @@ class concurrent extends atoum\test
 	{
 		$this
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\test\adapter())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\test\adapter())
 			->and($engine = new engines\concurrent($factory))
 			->then
-				->object($engine->run($test = new \mock\mageekguy\atoum\test()))->isIdenticalTo($engine)
+				->object($engine->run($test = new \mock\atoum\test()))->isIdenticalTo($engine)
 				->boolean($engine->isRunning())->isFalse()
 			->if($test->getMockController()->getCurrentMethod = $method = uniqid())
 			->and($test->getMockController()->getPath = $testPath = uniqid())
@@ -51,7 +51,7 @@ class concurrent extends atoum\test
 			->and($adapter->proc_open = false)
 			->then
 				->exception(function() use ($engine, $test) { $engine->run($test); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to use \'' . $phpPath . '\'')
 			->if($adapter->proc_open = function($command, array $descriptors, array & $pipes) use (& $resource, & $stdIn, & $stdOut, & $stdErr) {
 					$pipes = array(
@@ -73,7 +73,7 @@ class concurrent extends atoum\test
 					->call('fwrite')->withArguments(
 						$stdIn,
 						'<?php ' .
-						'define(\'mageekguy\atoum\autorun\', false);' .
+						'define(\'atoum\autorun\', false);' .
 						'require \'' . atoum\directory . '/scripts/runner.php\';' .
 						'require \'' . $testPath . '\';' .
 						'$test = new ' . get_class($test) . '();' .
@@ -93,9 +93,9 @@ class concurrent extends atoum\test
 			->then
 				->variable($engine->getScore())->isNull()
 			->if($factory = new atoum\factory())
-			->and($factory['mageekguy\atoum\adapter'] = $adapter = new atoum\test\adapter())
+			->and($factory['atoum\adapter'] = $adapter = new atoum\test\adapter())
 			->and($engine = new engines\concurrent($factory))
-			->and($engine->run($test = new \mock\mageekguy\atoum\test()))
+			->and($engine->run($test = new \mock\atoum\test()))
 			->then
 				->variable($engine->getScore())->isNull()
 			->if($test->getMockController()->getCurrentMethod = $method = uniqid())
@@ -124,7 +124,7 @@ class concurrent extends atoum\test
 				->variable($engine->getScore())->isNull()
 			->if($adapter->proc_get_status = array('running' => false, 'exitcode' => $exitCode = rand(1, PHP_INT_MAX)))
 			->then
-				->object($score = $engine->getScore())->isInstanceOf('mageekguy\atoum\score')
+				->object($score = $engine->getScore())->isInstanceOf('atoum\score')
 				->array($score->getUncompletedMethods())->isEqualTo(array(array('class' => get_class($test), 'method' => $method, 'exitCode' => $exitCode, 'output' => $output . $output)))
 			->if($adapter->stream_get_contents = serialize($score))
 			->and($engine->run($test))

--- a/tests/units/classes/test/engines/inline.php
+++ b/tests/units/classes/test/engines/inline.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\engines;
+namespace atoum\tests\units\test\engines;
 
 require_once __DIR__ . '/../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\engines
+	atoum,
+	atoum\test\engines
 ;
 
 class inline extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\test\engine');
+		$this->testedClass->isSubclassOf('atoum\test\engine');
 	}
 
 	public function testIsAsynchronous()
@@ -30,7 +30,7 @@ class inline extends atoum\test
 		$this
 			->if($engine = new engines\inline())
 			->then
-				->object($engine->run($test = new \mock\mageekguy\atoum\test()))->isIdenticalTo($engine)
+				->object($engine->run($test = new \mock\atoum\test()))->isIdenticalTo($engine)
 			->if($test->getMockController()->getCurrentMethod = $method = uniqid())
 			->and($test->getMockController()->runTestMethod = $test)
 			->then
@@ -48,13 +48,13 @@ class inline extends atoum\test
 		$this
 			->if($engine = new engines\inline())
 			->then
-				->object($engine->getScore())->isInstanceof('mageekguy\atoum\score')
-			->if($test = new \mock\mageekguy\atoum\test())
+				->object($engine->getScore())->isInstanceof('atoum\score')
+			->if($test = new \mock\atoum\test())
 			->and($test->getMockController()->getCurrentMethod = $method = uniqid())
 			->and($test->getMockController()->runTestMethod = $test)
 			->and($engine->run($test))
 			->then
-				->object($engine->getScore())->isInstanceOf('mageekguy\atoum\score')
+				->object($engine->getScore())->isInstanceOf('atoum\score')
 		;
 	}
 }

--- a/tests/units/classes/tools/diff.php
+++ b/tests/units/classes/tools/diff.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\tools;
+namespace atoum\tests\units\tools;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\tools
+	atoum,
+	atoum\tools
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/tools/diffs/variable.php
+++ b/tests/units/classes/tools/diffs/variable.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\tools\diffs;
+namespace atoum\tests\units\tools\diffs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\tools
+	atoum,
+	atoum\tools
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -55,7 +55,7 @@ class variable extends atoum\test
 
 		$this->assert
 			->exception($exception)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Reference is undefined')
 		;
 
@@ -69,7 +69,7 @@ class variable extends atoum\test
 
 		$this->assert
 			->exception($exception)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Data is undefined')
 		;
 

--- a/tests/units/classes/writer.php
+++ b/tests/units/classes/writer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\mock
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -13,13 +13,13 @@ class writer extends atoum\test
 {
 	public function test__construct()
 	{
-		$writer = new \mock\mageekguy\atoum\writer();
+		$writer = new \mock\atoum\writer();
 
 		$this->assert
-			->object($writer->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($writer->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
-		$writer = new \mock\mageekguy\atoum\writer($adapter = new atoum\test\adapter());
+		$writer = new \mock\atoum\writer($adapter = new atoum\test\adapter());
 
 		$this->assert
 			->object($writer->getAdapter())->isIdenticalTo($adapter)
@@ -28,7 +28,7 @@ class writer extends atoum\test
 
 	public function testSetAdapter()
 	{
-		$writer = new \mock\mageekguy\atoum\writer();
+		$writer = new \mock\atoum\writer();
 
 		$this->assert
 			->object($writer->setAdapter($adapter = new atoum\adapter()))->isIdenticalTo($writer)

--- a/tests/units/classes/writers/file.php
+++ b/tests/units/classes/writers/file.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers;
+namespace atoum\tests\units\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers
+	atoum,
+	atoum\writers
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,9 +15,9 @@ class file extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->hasInterface('mageekguy\atoum\adapter\aggregator')
-				->hasInterface('mageekguy\atoum\report\writers\realtime')
-				->hasInterface('mageekguy\atoum\report\writers\asynchronous')
+				->hasInterface('atoum\adapter\aggregator')
+				->hasInterface('atoum\report\writers\realtime')
+				->hasInterface('atoum\report\writers\asynchronous')
 		;
 	}
 
@@ -26,7 +26,7 @@ class file extends atoum\test
 		$file = new writers\file();
 
 		$this->assert
-			->object($file->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($file->getAdapter())->isInstanceOf('atoum\adapter')
 			->string($file->getFilename())->isEqualTo('atoum.log')
 		;
 

--- a/tests/units/classes/writers/mail.php
+++ b/tests/units/classes/writers/mail.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers;
+namespace atoum\tests\units\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\writers,
-	mageekguy\atoum\mailers
+	atoum,
+	atoum\mock,
+	atoum\writers,
+	atoum\mailers
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,9 +18,9 @@ class mail extends atoum\test
 		$writer = new writers\mail();
 
 		$this->assert
-			->object($writer->getMailer())->isInstanceOf('mageekguy\atoum\mailers\mail')
-			->object($writer->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-			->object($writer->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($writer->getMailer())->isInstanceOf('atoum\mailers\mail')
+			->object($writer->getLocale())->isInstanceOf('atoum\locale')
+			->object($writer->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$writer = new writers\mail($mailer = new atoum\mailers\mail(), $locale = new atoum\locale(), $adapter = new atoum\adapter());
@@ -36,8 +36,8 @@ class mail extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubclassOf('mageekguy\atoum\writer')
-				->hasInterface('mageekguy\atoum\report\writers\asynchronous')
+				->isSubclassOf('atoum\writer')
+				->hasInterface('atoum\report\writers\asynchronous')
 		;
 	}
 
@@ -63,7 +63,7 @@ class mail extends atoum\test
 
 	public function testWrite()
 	{
-		$mailer = new \mock\mageekguy\atoum\mailer();
+		$mailer = new \mock\atoum\mailer();
 		$mailer->getMockController()->send = $mailer;
 
 		$writer = new writers\mail();
@@ -79,13 +79,13 @@ class mail extends atoum\test
 	{
 		$mailer = new atoum\mailers\mail();
 
-		$writer = new \mock\mageekguy\atoum\writers\mail($mailer, $locale = new \mock\mageekguy\atoum\locale(), $adapter = new atoum\test\adapter());
+		$writer = new \mock\atoum\writers\mail($mailer, $locale = new \mock\atoum\locale(), $adapter = new atoum\test\adapter());
 		$writer->getMockController()->write = $writer;
 
 		$adapter->date = function($arg) { return $arg; };
 
 		$this->assert
-			->object($writer->writeAsynchronousReport($report = new \mock\mageekguy\atoum\reports\asynchronous()))->isIdenticalTo($writer)
+			->object($writer->writeAsynchronousReport($report = new \mock\atoum\reports\asynchronous()))->isIdenticalTo($writer)
 			->mock($writer)->call('write')->withArguments((string) $report)->once()
 			->string($mailer->getSubject())->isEqualTo('Unit tests report, the Y-m-d at H:i:s')
 			->mock($locale)
@@ -96,7 +96,7 @@ class mail extends atoum\test
 
 		$mailer = new atoum\mailers\mail();
 
-		$writer = new \mock\mageekguy\atoum\writers\mail($mailer, $locale = new \mock\mageekguy\atoum\locale(), $adapter = new atoum\test\adapter());
+		$writer = new \mock\atoum\writers\mail($mailer, $locale = new \mock\atoum\locale(), $adapter = new atoum\test\adapter());
 		$writer->getMockController()->write = $writer;
 
 		$this->assert

--- a/tests/units/classes/writers/std/err.php
+++ b/tests/units/classes/writers/std/err.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers\std;
+namespace atoum\tests\units\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers\std
+	atoum,
+	atoum\writers\std
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,10 +15,10 @@ class err extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\writers\std')
-				->hasInterface('mageekguy\atoum\adapter\aggregator')
-				->hasInterface('mageekguy\atoum\report\writers\realtime')
-				->hasInterface('mageekguy\atoum\report\writers\asynchronous')
+				->isSubClassOf('atoum\writers\std')
+				->hasInterface('atoum\adapter\aggregator')
+				->hasInterface('atoum\report\writers\realtime')
+				->hasInterface('atoum\report\writers\asynchronous')
 		;
 	}
 

--- a/tests/units/classes/writers/std/out.php
+++ b/tests/units/classes/writers/std/out.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers\std;
+namespace atoum\tests\units\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers\std
+	atoum,
+	atoum\writers\std
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,10 +15,10 @@ class out extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\writers\std')
-				->hasInterface('mageekguy\atoum\adapter\aggregator')
-				->hasInterface('mageekguy\atoum\report\writers\realtime')
-				->hasInterface('mageekguy\atoum\report\writers\asynchronous')
+				->isSubClassOf('atoum\writers\std')
+				->hasInterface('atoum\adapter\aggregator')
+				->hasInterface('atoum\report\writers\realtime')
+				->hasInterface('atoum\report\writers\asynchronous')
 		;
 	}
 

--- a/tests/units/runner.php
+++ b/tests/units/runner.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 require_once __DIR__ . '/../../scripts/runner.php';
 
-\mageekguy\atoum\autoloader::get()
+\atoum\autoloader::get()
 	->addDirectory(__NAMESPACE__, __DIR__ . '/classes')
 	->addDirectory(__NAMESPACE__ . '\asserters', __DIR__ . '/asserters')
 ;


### PR DESCRIPTION
I also renamed the `mageekguy.atoum.phar` to `atoum.phar`
Notice that for composer, mageekguy still the vendor name.
