### PR TITLE
[WIP] If disableConstructor is passed, we generate a default __construct instead of copy signature of parent.

### DIFF
--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -11,6 +11,7 @@ class generator
 {
 	const defaultNamespace = 'mock';
 
+	protected $disableConstructor = false;
 	protected $factory = null;
 	protected $shuntedMethods = array();
 	protected $overloadedMethods = array();
@@ -117,8 +118,9 @@ class generator
 		}
 	}
 
-	public function generate($class, $mockNamespace = null, $mockClass = null)
+	public function generate($class, $mockNamespace = null, $mockClass = null, $disableConstructor = false)
 	{
+		$this->disableConstructor = (bool) $disableConstructor;
 		eval($this->getMockedClassCode($class, $mockNamespace, $mockClass));
 
 		$this->shuntedMethods = array();
@@ -153,6 +155,10 @@ class generator
 
 			if ($isConstructor === true)
 			{
+				if ($this->disableConstructor === true)
+				{
+					continue;
+				}
 				$hasConstructor = true;
 			}
 
@@ -406,6 +412,10 @@ class generator
 
 				if ($isConstructor === true)
 				{
+					if ($this->disableConstructor === true)
+					{
+						continue;
+					}
 					$hasConstructor = true;
 				}
 

--- a/classes/test.php
+++ b/classes/test.php
@@ -243,8 +243,8 @@ abstract class test implements observable, adapter\aggregator, \countable
 		$this->assertionManager
 			->setHandler('assert', function($case = null) use ($test) { $test->stopCase(); if ($case !== null) { $test->startCase($case); } return $test->getAssertionManager(); })
 			->setHandler('mockGenerator', function() use ($test) { return $test->getMockGenerator(); })
-			->setHandler('mockClass', function($class, $mockNamespace = null, $mockClass = null) use ($test) { $test->getMockGenerator()->generate($class, $mockNamespace, $mockClass); return $test; })
-			->setHandler('mockTestedClass', function($mockNamespace = null, $mockClass = null) use ($test) { $test->getMockGenerator()->generate($test->getTestedClassName(), $mockNamespace, $mockClass); return $test; })
+			->setHandler('mockClass', function($class, $mockNamespace = null, $mockClass = null, $disableConstructor = false) use ($test) { $test->getMockGenerator()->generate($class, $mockNamespace, $mockClass, $disableConstructor); return $test; })
+			->setHandler('mockTestedClass', function($mockNamespace = null, $mockClass = null, $disableConstructor = false) use ($test) { $test->getMockGenerator()->generate($test->getTestedClassName(), $mockNamespace, $mockClass, $disableConstructor); return $test; })
 		;
 
 		$asserterGenerator = $this->asserterGenerator;


### PR DESCRIPTION
Hi

User can call:

``` php
<?php
$this->mock('MyClass', null, null, true); 
// to disable the original constructor and by default don't have to mock each deps
```

If you're OK, i've to write tests and update documentation :)
