### PR TITLE
use current working dir as base dir to search for .atoum files

### DIFF
--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -212,7 +212,7 @@ class runner extends atoum\script
 	{
 		if ($startDirectory === null)
 		{
-			$startDirectory = getcwd();
+			$startDirectory = $this->adapter->getcwd();
 		}
 
 		foreach (self::getSubDirectoryPath($startDirectory) as $directory)

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -353,6 +353,20 @@ class runner extends atoum\test
 						}
 					)
 		;
+
+
+		$this
+			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($runner->getMockController()->useConfigFile = function() {})
+			->and($runner->getAdapter()->cwd= function(){ return atoum\directory; })
+			->then
+				->object($runner->useDefaultConfigFiles())->isIdenticalTo($runner)
+				->mock($runner)
+					->foreach(scripts\runner::getSubDirectoryPath(atoum\directory), function($mock, $path) {
+						$mock->call('useConfigFile')->withArguments($path . scripts\runner::defaultConfigFile)->once();
+					}
+					)
+		;
 	}
 
 	public function getTestAllDirectories()


### PR DESCRIPTION
on a shared installation of atoum, for example if there is a symlink to
atoum in the ~/bin directory, atoum will search for configuration file
from that dir.

for example, in that case :

```
/
|-- home
   |-- user
      | -- bin
          | -- atoum -> pathToAtoum/bin/atoum
```

If we call our tests from

```
/home/user/Projects/myProject
```

atoum will lookup for .atoum files in :
- /
- /user
- /user/bin

instead of searching in
- /
- /user
- /user/Projects
- /user/Projects/myProject

This works when atoum and the tested Project are installed in the same
directory but not when we call it from another dir.

Thoses changes make atoum search for .atoum files from the current
working directy instead of the atoum dir.
