### PR TITLE
Add PhpStorm failure field

### DIFF
--- a/classes/report/fields/runner/failures/execute.php
+++ b/classes/report/fields/runner/failures/execute.php
@@ -69,7 +69,7 @@ class execute extends runner\failures
 
 			foreach ($fails as $file => $line)
 			{
-				$this->adapter->system(sprintf($this->command, $file, $line));
+				$this->adapter->system(sprintf($this->getCommand(), $file, $line));
 			}
 		}
 

--- a/classes/report/fields/runner/failures/phpstorm.php
+++ b/classes/report/fields/runner/failures/phpstorm.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace mageekguy\atoum\report\fields\runner\failures;
+
+class phpstorm extends execute
+{
+	public function getCommand()
+	{
+		return $this->command . ' --line %2$s %1$s &';
+	}
+}

--- a/tests/units/classes/report/fields/runner/failures/phpstorm.php
+++ b/tests/units/classes/report/fields/runner/failures/phpstorm.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\report\fields\runner\failures;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\report\fields\runner\failures\phpstorm as testedClass
+;
+
+require_once __DIR__ . '/../../../../../runner.php';
+
+class phpstorm extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\failures\execute')
+		;
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($field = new testedClass($command = uniqid()))
+			->then
+				->string($field->getCommand())->contains($command)
+		;
+	}
+
+	public function testGetCommand()
+	{
+		$this
+			->if($field = new testedClass($command = uniqid()))
+			->then
+				->string($field->getCommand())->isEqualTo($command . ' --line %2$s %1$s &')
+		;
+	}
+}


### PR DESCRIPTION
This commit adds a PhpStorm failure field wich let us open failed test file in the IDE.
Here is an exemple usage (on Mac OS X) :

``` php
<?php
//.atoum.php
use mageekguy\atoum;

//...

$cliReport = new atoum\reports\realtime\cli();
$cliReport->addWriter($stdOutWriter);

$cliReport->addField(new atoum\report\fields\runner\failures\phpstorm('open -a PhpStorm -n --args'));

//...
```
