### PR TITLE
Add new utf8String asserter

### DIFF
--- a/classes/asserters/utf8String.php
+++ b/classes/asserters/utf8String.php
@@ -11,6 +11,16 @@ use
 
 class utf8String extends asserters\string
 {
+	public function __construct(asserter\generator $generator, atoum\adapter $adapter = null)
+	{
+		parent::__construct($generator, $adapter);
+
+		if ($this->adapter->extension_loaded('mbstring') === false)
+		{
+			throw new exceptions\runtime('mbstring PHP extension is mandatory to use utf8String asserter');
+		}
+	}
+
 	public function __toString()
 	{
 		return (is_string($this->value) === false ? parent::__toString() : sprintf($this->getLocale()->_('string(%s) \'%s\''), mb_strlen($this->value, 'UTF-8'), addcslashes($this->value, $this->charlist)));

--- a/tests/units/classes/asserters/utf8String.php
+++ b/tests/units/classes/asserters/utf8String.php
@@ -44,6 +44,22 @@ class utf8String extends atoum\test
 				->object($asserter->getAdapter())->isEqualTo(new atoum\adapter())
 				->variable($asserter->getValue())->isNull()
 				->boolean($asserter->wasSet())->isFalse()
+
+			->if($adapter = new atoum\test\adapter())
+			->and($adapter->extension_loaded = true)
+			->and($asserter = new asserters\utf8String($generator = new asserter\generator(), $adapter))
+			->then
+				->object($asserter->getLocale())->isIdenticalTo($generator->getLocale())
+				->object($asserter->getGenerator())->isIdenticalTo($generator)
+				->object($asserter->getAdapter())->isEqualTo($adapter)
+				->variable($asserter->getValue())->isNull()
+				->boolean($asserter->wasSet())->isFalse()
+
+			->if($adapter->extension_loaded = false)
+			->then
+				->exception(function() use ($adapter) { new asserters\utf8String(new asserter\generator(), $adapter); })
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->hasMessage('mbstring PHP extension is mandatory to use utf8String asserter')
 		;
 	}
 


### PR DESCRIPTION
Here is a brand new asserter to test utf8 strings using mb_\* functions.

This asserter extends string and has no new method.

All tests was copied from string tests.
