### PR TITLE
Tryning to bypass the PHP error on duplicate class name

### DIFF
--- a/classes/asserters/currentlyTestedClass.php
+++ b/classes/asserters/currentlyTestedClass.php
@@ -9,7 +9,7 @@ use
 	mageekguy\atoum\exceptions
 ;
 
-class testedClass extends asserters\phpClass
+class currentlyTestedClass extends asserters\phpClass
 {
 	public function setWith($class)
 	{

--- a/classes/test.php
+++ b/classes/test.php
@@ -259,6 +259,7 @@ abstract class test implements observable, \countable
 
 		$this->assertionManager
 			->setHandler('define', function() use ($asserterGenerator) { return $asserterGenerator; })
+			->setHandler('testedClass', function() use ($asserterGenerator) { return $asserterGenerator->currentlyTestedClass; })
 			->setDefaultHandler(function($asserter, $arguments) use ($asserterGenerator) { return $asserterGenerator->getAsserterInstance($asserter, $arguments); })
 		;
 

--- a/tests/units/classes/asserters/currentlyTestedClass.php
+++ b/tests/units/classes/asserters/currentlyTestedClass.php
@@ -10,7 +10,7 @@ use
 
 require_once __DIR__ . '/../../runner.php';
 
-class testedClass extends atoum\test
+class currentlyTestedClass extends atoum\test
 {
 	public function testClass()
 	{
@@ -20,7 +20,7 @@ class testedClass extends atoum\test
 	public function testSetWith()
 	{
 		$this
-			->if($asserter = new asserters\testedClass(new asserter\generator()))
+			->if($asserter = new asserters\currentlyTestedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->setWith(uniqid()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic\badMethodCall')


### PR DESCRIPTION
Got this error when trying to run `bin/atoum --test-it` on `PHP 5.4.6` :

```
Cannot use mageekguy\atoum\asserters\extension as testedClass 
because the name is already in use 
in atoum/tests/units/classes/asserters/extension.php on line 8
```

So, I renamed the `testedClass` asserter to `currentlyTestedClass` and aliased it thanks to the power of the atoum's assertion manager.

We end up with something which lets us use both the `testedClass` alias and `testedClass` asserter in our unit tests.
