### PR TITLE
Add void, skipped & uncompleted methods to phing report

### DIFF
--- a/classes/reports/realtime/phing.php
+++ b/classes/reports/realtime/phing.php
@@ -180,6 +180,20 @@ class phing extends realtime
 		$exceptionColorizer = new colorizer('0;35');
 		$exceptionPrompt = clone $secondLevelPrompt;
 		$exceptionPrompt->setColorizer($exceptionColorizer);
+		
+		$uncompletedTestColorizer = new colorizer('0;37');
+		$uncompletedTestMethodPrompt = clone $secondLevelPrompt;
+		$uncompletedTestMethodPrompt->setColorizer($uncompletedTestColorizer);
+		$uncompletedTestOutputPrompt = new prompt('  ', $uncompletedTestColorizer);
+		
+		$voidTestColorizer = new colorizer('0;34');
+		$voidTestMethodPrompt = clone $secondLevelPrompt;
+		$voidTestMethodPrompt->setColorizer($voidTestColorizer);
+
+		$skippedTestColorizer = new colorizer('0;90');
+		$skippedTestMethodPrompt = clone $secondLevelPrompt;
+		$skippedTestMethodPrompt->setColorizer($skippedTestColorizer);
+
 
 		$phpPathField = new runner\php\path\cli();
 		$phpPathField
@@ -282,6 +296,34 @@ class phing extends realtime
 		;
 
 		$this->addField($exceptionsField);
+
+		$runnerUncompletedField = new runner\tests\uncompleted\cli();
+		$runnerUncompletedField
+			->setTitlePrompt($firstLevelPrompt)
+			->setTitleColorizer($uncompletedTestColorizer)
+			->setMethodPrompt($uncompletedTestMethodPrompt)
+			->setOutputPrompt($uncompletedTestOutputPrompt)
+		;
+
+		$this->addField($runnerUncompletedField);
+
+		$runnerVoidField = new runner\tests\void\cli();
+		$runnerVoidField
+			->setTitlePrompt($firstLevelPrompt)
+			->setTitleColorizer($voidTestColorizer)
+			->setMethodPrompt($voidTestMethodPrompt)
+		;
+
+		$this->addField($runnerVoidField);
+		
+		$runnerSkippedField = new runner\tests\skipped\cli();
+		$runnerSkippedField
+			->setTitlePrompt($firstLevelPrompt)
+			->setTitleColorizer($skippedTestColorizer)
+			->setMethodPrompt($skippedTestMethodPrompt)
+		;
+		
+		$this->addField($runnerSkippedField);
 
 		if ($this->showProgress === true)
 		{

--- a/tests/units/classes/reports/realtime/phing.php
+++ b/tests/units/classes/reports/realtime/phing.php
@@ -22,6 +22,96 @@ class phing extends atoum\test
 	public function test__construct()
 	{
 		$this
+			->define($phpPathField = new fields\runner\php\path\cli())
+				->and($phpPathField
+					->setPrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('1;36'))
+				)
+			->define($phpVersionField = new fields\runner\php\version\cli())
+				->and($phpVersionField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('1;36'))
+					->setVersionPrompt(new prompt(' ', new colorizer('1;36')))
+				)
+			->define($runnerTestsDurationField = new fields\runner\duration\cli())
+				->and($runnerTestsDurationField
+					->setPrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('1;36'))
+				)
+			->define($runnerTestsMemoryField = new fields\runner\tests\memory\phing())
+				->and($runnerTestsMemoryField
+					->setPrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('1;36'))
+				)
+			->define($runnerTestsCoverageField = new fields\runner\tests\coverage\phing())
+				->and($runnerTestsCoverageField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setClassPrompt(new prompt(' ', new colorizer('1;36')))
+					->setMethodPrompt(new prompt('  ', new colorizer('1;36')))
+					->setTitleColorizer(new colorizer('1;36'))
+				)
+			->define($runnerResultField = new fields\runner\result\cli())
+				->and($runnerResultField
+					->setPrompt(new prompt(PHP_EOL))
+					->setSuccessColorizer(new colorizer('0;37', '42'))
+					->setFailureColorizer(new colorizer('0;37', '41'))
+				)
+			->define($runnerFailuresField = new fields\runner\failures\cli())
+				->and($runnerFailuresField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('0;31'))
+					->setMethodPrompt(new prompt(' ', new colorizer('0;31')))
+				)
+			->define($runnerOutputsField = new fields\runner\outputs\cli())
+				->and($runnerOutputsField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('1;36'))
+					->setMethodPrompt(new prompt(' ', new colorizer('1;36')))
+				)
+			->define($runnerErrorsField = new fields\runner\errors\cli())
+				->and($runnerErrorsField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('0;33'))
+					->setMethodPrompt(new prompt(' ', new colorizer('0;33')))
+				)
+			->define($runnerExceptionsField = new fields\runner\exceptions\cli())
+				->and($runnerExceptionsField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('0;35'))
+					->setMethodPrompt(new prompt(' ', new colorizer('0;35')))
+				)
+			->define($runnerUncompletedField = new fields\runner\tests\uncompleted\cli())
+				->and($runnerUncompletedField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('0;37'))
+					->setMethodPrompt(new prompt(' ', new colorizer('0;37')))
+					->setOutputPrompt(new prompt('  ', new colorizer('0;37')))
+				)
+			->define($runnerVoidField = new fields\runner\tests\void\cli())
+				->and($runnerVoidField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('0;34'))
+					->setMethodPrompt(new prompt(' ', new colorizer('0;34')))
+				)
+			->define($runnerSkippedField = new fields\runner\tests\skipped\cli())
+				->and($runnerSkippedField
+					->setTitlePrompt(new prompt(PHP_EOL))
+					->setTitleColorizer(new colorizer('0;90'))
+					->setMethodPrompt(new prompt(' ', new colorizer('0;90')))
+				)
+			->define($testRunField = new fields\test\run\phing())
+				->and($testRunField
+					->setPrompt(new prompt(PHP_EOL))
+					->setColorizer(new colorizer('1;36'))
+				)
+			->define($testDurationField = new fields\test\duration\phing())
+				->and($testDurationField
+					->setPrompt(new prompt(' ', new colorizer('1;36')))
+				)
+			->define($testMemoryField = new fields\test\memory\phing())
+				->and($testMemoryField
+					->setPrompt(new prompt(' ', new colorizer('1;36')))
+				)
 			->if($report = new testedClass())
 			->then
 				->boolean($report->progressIsShowed())->isTrue()
@@ -31,6 +121,27 @@ class phing extends atoum\test
 				->boolean($report->memoryIsShowed())->isTrue()
 				->variable($report->getCodeCoverageReportPath())->isNull()
 				->variable($report->getCodeCoverageReportUrl())->isNull()
+				->array($report->getFields())->isEqualTo(array(
+						$phpPathField,
+						$phpVersionField,
+						$runnerTestsDurationField,
+						$runnerTestsMemoryField,
+						$runnerTestsCoverageField,
+						$runnerResultField,
+						$runnerFailuresField,
+						$runnerOutputsField,
+						$runnerErrorsField,
+						$runnerExceptionsField,
+						$runnerUncompletedField,
+						$runnerVoidField,
+						$runnerSkippedField,
+						$testRunField,
+						new fields\test\event\phing(),
+						$testDurationField,
+						$testMemoryField,
+					)
+				)
+
 		  ;
 	}
 


### PR DESCRIPTION
Void and skipped fields are added to phing report according #102.
I've also added field for uncompleted methods, and test for phing report fields.

Those fields use cli's instances from atoum/report/fields/runner/tests/\* in order to display detailed reports.
Let me know if i'm wrong.
