### PR TITLE
Add twice and thrice to adapter and mock asserters

### DIFF
--- a/classes/asserters/adapter.php
+++ b/classes/asserters/adapter.php
@@ -174,15 +174,15 @@ class adapter extends atoum\asserter
 		return $this->exactly(1, $failMessage);
 	}
 
-    public function twice($failMessage = null)
-    {
-        return $this->exactly(2, $failMessage);
-    }
+	public function twice($failMessage = null)
+	{
+		return $this->exactly(2, $failMessage);
+	}
 
-    public function thrice($failMessage = null)
-    {
-        return $this->exactly(3, $failMessage);
-    }
+	public function thrice($failMessage = null)
+	{
+		return $this->exactly(3, $failMessage);
+	}
 
 	public function atLeastOnce($failMessage = null)
 	{

--- a/classes/asserters/mock.php
+++ b/classes/asserters/mock.php
@@ -201,7 +201,17 @@ class mock extends atoum\asserter
 
 	public function once($failMessage = null)
 	{
-        return $this->exactly(1, $failMessage);
+		return $this->exactly(1, $failMessage);
+	}
+
+	public function twice($failMessage = null)
+	{
+		return $this->exactly(2, $failMessage);
+	}
+
+	public function thrice($failMessage = null)
+	{
+		return $this->exactly(3, $failMessage);
 	}
 
 	public function atLeastOnce($failMessage = null)

--- a/tests/units/classes/asserters/adapter.php
+++ b/tests/units/classes/asserters/adapter.php
@@ -329,7 +329,7 @@ class adapter extends atoum\test
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
-            ->then
+			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()))
@@ -355,104 +355,104 @@ class adapter extends atoum\test
 		;
 	}
 
-    public function testTwice()
-    {
-        $this
-            ->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-            ->then
-                ->exception(function() use ($asserter) { $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-                    ->hasMessage('Adapter is undefined')
-            ->if($asserter->setWith($adapter = new test\adapter()))
-            ->then
-                ->exception(function() use ($asserter) { $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-                    ->hasMessage('Called function is undefined')
-            ->if($asserter->call('md5'))
-            ->then
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
-            ->if($call = new php\call('md5'))
-            ->and($adapter->md5($firstArgument = uniqid()))
-            ->then
-                ->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
-            ->if($adapter->md5($secondArgument = uniqid()))
-            ->then
-                ->object($asserter->twice())->isIdenticalTo($asserter)
-            ->if($adapter->md5($thirdArgument = uniqid()))
-            ->then
-                ->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)))
-            ->if($adapter->resetCalls())
-            ->and($asserter->withArguments($arg = uniqid()))
-            ->and($adapter->md5($arg))
-            ->then
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                     ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-            ->if($asserter->withArguments(uniqid()))
-            ->then
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-        ;
-    }
+	public function testTwice()
+	{
+		$this
+			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
+			->if($asserter->setWith($adapter = new test\adapter()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->call('md5'))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($call = new php\call('md5'))
+			->and($adapter->md5($firstArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
+			->if($adapter->md5($secondArgument = uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($adapter->md5($thirdArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->and($adapter->md5($arg))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					 ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
+		;
+	}
 
-    public function testThrice()
-    {
-        $this
-            ->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-            ->then
-                ->exception(function() use ($asserter) { $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-                    ->hasMessage('Adapter is undefined')
-            ->if($asserter->setWith($adapter = new test\adapter()))
-            ->then
-                ->exception(function() use ($asserter) { $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\exceptions\logic')
-                    ->hasMessage('Called function is undefined')
-            ->if($asserter->call('md5'))
-            ->then
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()))
-            ->if($call = new php\call('md5'))
-            ->and($adapter->md5($firstArgument = uniqid()))
-            ->then
-                ->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
-            ->if($adapter->md5($secondArgument = uniqid()))
-            ->then
-                ->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
-            ->if($adapter->md5($thirdArgument = uniqid()))
-            ->then
-                ->object($asserter->thrice())->isIdenticalTo($asserter)
-            ->if($adapter->md5($fourthArgument = uniqid()))
-            ->then
-                ->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArgument)))
-            ->if($adapter->resetCalls())
-            ->and($asserter->withArguments($arg = uniqid()))
-            ->and($adapter->md5($arg))
-            ->then
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-            ->if($asserter->withArguments(uniqid()))
-            ->then
-                ->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
-                    ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-        ;
-    }
+	public function testThrice()
+	{
+		$this
+			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
+			->if($asserter->setWith($adapter = new test\adapter()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->call('md5'))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($call = new php\call('md5'))
+			->and($adapter->md5($firstArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
+			->if($adapter->md5($secondArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
+			->if($adapter->md5($thirdArgument = uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($adapter->md5($fourthArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArgument)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->and($adapter->md5($arg))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
+		;
+	}
 
 	public function testAtLeastOnce()
 	{

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -407,11 +407,9 @@ class mock extends atoum\test
 				->exception(function() use ($asserter) { $asserter->once(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
-			/*
 			->if($mock->foo(uniqid()))
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+				->object($asserter->once())->isIdenticalTo($asserter)
+			/*
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->bar(uniqid()))
 			->and($mock->foo(uniqid()))
@@ -419,6 +417,7 @@ class mock extends atoum\test
 				->exception(function() use ($asserter) { $asserter->once(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called before method %s'), $asserter->getCall(), current($asserter->getBeforeMethodCalls())))
+			*/
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->foo(uniqid()))
 			->and($mock->bar(uniqid()))
@@ -431,6 +430,7 @@ class mock extends atoum\test
 				->exception(function() use ($asserter) { $asserter->once(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
+			/*
 			->if($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
@@ -443,20 +443,278 @@ class mock extends atoum\test
 				->exception(function() use ($asserter) { $asserter->once(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called after method %s'), $asserter->getCall(), current($asserter->getAfterMethodCalls())))
+			*/
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->bar(uniqid()))
 			->and($mock->foo(uniqid()))
 			->then
 				->object($asserter->once())->isIdenticalTo($asserter)
 			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-				->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-				->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
-				->and($mock->foo(uniqid()))
-				->then
-					->exception(function() use ($asserter) { $asserter->once(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
-						->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
-		*/
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+		;
+	}
+
+	public function testTwice()
+	{
+		$this
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->call('foo'))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($call = new php\call('foo', null, $mock))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($secondArg = uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mock->foo($thirdArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->beforeMethodCall('bar')->call('foo'))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($mock->foo($usedArg = uniqid()))
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo(uniqid()))
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->foo($usedArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->afterMethodCall('bar')->call('foo'))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->bar(uniqid()))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+			->and($mock->foo(uniqid()))
+			->if($mock->bar($arg))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testThrice()
+	{
+		$this
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->call('foo'))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($call = new php\call('foo', null, $mock))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($secondArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
+			->if($mock->foo($thirdArg = uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mock->foo($fourthArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArg)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->beforeMethodCall('bar')->call('foo'))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->foo($firstArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
+			->if($mock->foo($secondArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
+			->if($mock->foo(uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->afterMethodCall('bar')->call('foo'))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->bar(uniqid()))
+			->and($mock->foo($firstArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
+			->if($mock->bar(uniqid()))
+			->and($mock->foo($secondArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+			->if($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+			->and($mock->foo(uniqid()))
+			->if($mock->bar($arg))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
 		;
 	}
 
@@ -559,6 +817,7 @@ class mock extends atoum\test
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg)) . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
+
 		;
 	}
 


### PR DESCRIPTION
As _twice_ and _thrice_ are two commonly used words, I think it could be useful to have them as asserters.
