### PR TITLE
refactoring - removed useless constructor in atoum\template

### DIFF
--- a/classes/template.php
+++ b/classes/template.php
@@ -11,11 +11,6 @@ class template extends template\data
 {
 	protected $children = array();
 
-	public function __construct($data = null)
-	{
-		parent::__construct($data);
-	}
-
 	public function __set($tag, $data)
 	{
 		foreach ($this->getByTag($tag) as $child)


### PR DESCRIPTION
same constructor is inherited from parent class atoum\template\data
