### PR TITLE
Avoid an E_DEPRECATED on php-5.5 alpha

### DIFF
--- a/classes/configurator.php
+++ b/classes/configurator.php
@@ -17,7 +17,7 @@ class configurator
 
 			foreach ($arguments as $argument)
 			{
-				$this->methods[preg_replace('/-(.)/', '$1', ltrim($argument, '-'))] = $argument;
+				$this->methods[strtolower(str_replace('-', '', $argument))] = $argument;
 			}
 		}
 	}


### PR DESCRIPTION
This PR prevents an E_DERECATED on php-5.5 alpha : as told on [the doc](http://fr.php.net/manual/fr/reference.pcre.pattern.modifiers.php#reference.pcre.pattern.modifiers), the `\e` modifier will be deprecated.
