### PR TITLE
Adding same path more than once for one namespace

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -65,9 +65,11 @@ class autoloader
 
 	public function addDirectory($namespace, $directory)
 	{
+		$namespace = trim($namespace, '\\') . '\\';
+		$directory = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 		if (isset($this->directories[$namespace]) === false || in_array($directory, $this->directories[$namespace]) === false)
 		{
-			$this->directories[trim($namespace, '\\') . '\\'][] = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+			$this->directories[$namespace][] = $directory;
 
 			krsort($this->directories, \SORT_STRING);
 		}

--- a/tests/units/classes/autoloader.php
+++ b/tests/units/classes/autoloader.php
@@ -109,6 +109,13 @@ class autoloader extends atoum\test
 						$otherNamespace => array($otherDirectory)
 					)
 				)
+				->object($autoloader->addDirectory($otherNamespace, rtrim($otherDirectory, DIRECTORY_SEPARATOR)))->isIdenticalTo($autoloader)
+				->array($autoloader->getDirectories())->isEqualTo(array(
+						'mageekguy\atoum\\' => array(atoum\directory . (\phar::running() ? '/' : DIRECTORY_SEPARATOR) . 'classes' . DIRECTORY_SEPARATOR),
+						$namespace . '\\' => array($directory . DIRECTORY_SEPARATOR),
+						$otherNamespace => array($otherDirectory)
+					)
+				)
 				->object($autoloader->addDirectory($namespace, $secondDirectory = (uniqid() . DIRECTORY_SEPARATOR)))->isIdenticalTo($autoloader)
 				->array($autoloader->getDirectories())->isEqualTo(array(
 						'mageekguy\atoum\\' => array(atoum\directory . (\phar::running() ? '/' : DIRECTORY_SEPARATOR) . 'classes' . DIRECTORY_SEPARATOR),


### PR DESCRIPTION
Adding test for the method autoload::addDirectory and fix the case when we try to add the same path at least twice for one namespace.
