### PR TITLE
Remove posix as a hard dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,13 @@
 		"php": ">=5.3.3",
 		"ext-hash": "*",
 		"ext-json": "*",
-		"ext-posix": "*",
 		"ext-session": "*",
 		"ext-tokenizer": "*",
 		"ext-xml": "*"
 	},
 	"replace": {
-        "mageekguy/atoum": "*"
-    },
+		"mageekguy/atoum": "*"
+	},
 	"bin":
 	[
 		"bin/atoum"


### PR DESCRIPTION
Removes the `ext-posix` from composer requirements (should fix #166)
