### PR TITLE
Fix a typo

### DIFF
--- a/CREDIT
+++ b/CREDIT
@@ -17,4 +17,4 @@ Geoffrey Bachelet (grosfrais@gmail.com)
 Nathanaël Louison (bennetteson@gmail.com)
 Simon Jodet (simon@jodet.com)
 
-All all other contributors !
+All all other contributors!


### PR DESCRIPTION
In English, we don't have a space or a non-breaking space before punctuation.
