### PR TITLE
New isTerminal() implementation

### DIFF
--- a/classes/cli.php
+++ b/classes/cli.php
@@ -19,7 +19,22 @@ class cli
 
 		if (self::$isTerminal === null)
 		{
-			self::$isTerminal = $adapter->defined('PHP_WINDOWS_VERSION_BUILD') ? (Boolean) $adapter->getenv('ANSICON') : ($adapter->defined('STDOUT') === true && $adapter->function_exists('posix_isatty') === true && $adapter->posix_isatty($adapter->constant('STDOUT')) === true);
+			if ($adapter->defined('STDOUT') === false)
+			{
+				self::$isTerminal = false;
+			}
+			else
+			{
+				$stat = $adapter->fstat($adapter->constant('STDOUT'));
+				// please, see <sys/stat.h>.
+				$mode = $stat['mode'] & 0170000;
+				self::$isTerminal = $mode === 0020000;
+
+				if ($adapter->defined('PHP_WINDOWS_VERSION_BUILD') === true)
+				{
+					self::$isTerminal = self::$isTerminal && (Boolean) $adapter->getenv('ANSICON');
+				}
+			}
 		}
 	}
 

--- a/tests/units/classes/cli/colorizer.php
+++ b/tests/units/classes/cli/colorizer.php
@@ -11,14 +11,6 @@ require_once __DIR__ . '/../../runner.php';
 
 class colorizer extends atoum\test
 {
-	public function beforeTestMethod($testMethod)
-	{
-		if (defined('STDOUT') === false)
-		{
-			define('STDOUT', uniqid());
-		}
-	}
-
 	public function test__construct()
 	{
 		$colorizer = new cli\colorizer();

--- a/tests/units/classes/cli/progressBar.php
+++ b/tests/units/classes/cli/progressBar.php
@@ -12,14 +12,6 @@ require_once __DIR__ . '/../../runner.php';
 
 class progressBar extends atoum\test
 {
-	public function beforeTestMethod($testMethod)
-	{
-		if (defined('STDOUT') === false)
-		{
-			define('STDOUT', uniqid());
-		}
-	}
-
 	public function testClassConstants()
 	{
 		$this


### PR DESCRIPTION
The goal of this function is twofold. First: detect if STDOUT is a character device (e.g. screen, so a device that supports characters and attached to a terminal) or not (a pipe, a redirection, something else…).
Second: detect if the terminal supports colours. We assume that POSIX-compliant systems always support colours, and for Windows, we look for an additional program that creates a variable in the environment (says ANSICON).

This patch then works in two steps. First: detect if STDOUT is a character device. We have removed the dependency to the posix_isatty() function by using fstat(). The previous isTerminal() implementation did not consider that Windows supports redirections (because of the unavailibility of posix_*() functions). This new approach works on all systems, POSIX or not.
Second: we detect if the terminal supports colours (only for Windows).
The result is a conjunction of these two steps.

This is inspired from Hoa\Console, and please, see sys/stat.h to understand the numbers.

Tests have been consequently updated.
