### PR TITLE
Modify mock generator class for support iteratorAgregate Interface

### DIFF
--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -10,8 +10,6 @@ use
 
 require_once __DIR__ . '/../../runner.php';
 
-interface foo extends \Traversable {}
-
 class generator extends atoum\test
 {
 	public function test__construct()


### PR DESCRIPTION
I modify mock generator class for support iteratorAggregate interface

Before : 

```
$test = new \mock\iteratorAggregate;
```

   return 

```
Class mock\iteratorAggregate cannot implement both IteratorAggregate and Iterator at the    same time
```
