### PR TITLE
Add the expected size in the object size assertion message

### DIFF
--- a/classes/asserters/object.php
+++ b/classes/asserters/object.php
@@ -67,7 +67,7 @@ class object extends asserters\variable
 		}
 		else
 		{
-			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s has not size %d'), $this, $size));
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('%s has size %d, expected size %d'), $this, sizeof($this->valueIsSet()->value), $size));
 		}
 
 		return $this;

--- a/tests/units/classes/asserters/object.php
+++ b/tests/units/classes/asserters/object.php
@@ -74,7 +74,7 @@ class object extends atoum\test
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(0); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('%s has not size %d'), $asserter, 0))
+					->hasMessage(sprintf($generator->getLocale()->_('%s has size %d, expected size %d'), $asserter, sizeof($this), 0))
 				->object($asserter->hasSize(sizeof($this)))->isIdenticalTo($asserter);
 		;
 	}


### PR DESCRIPTION
I like the integer assertion message for example and I really wanted to have the same thing on the object size assertion.

Without this PR:

```
XXX has not size Y
```

With this PR

```
XXX has size Z, expected size Y
```
