### PR TITLE
Ajout d'une vérification de error_reporting()

### DIFF
--- a/classes/includer.php
+++ b/classes/includer.php
@@ -15,7 +15,10 @@ class includer
 		$path = (string) $path;
 
 		$errorHandler = set_error_handler(function($error, $message, $file, $line, $context) use (& $errors) {
-				$errors[] = func_get_args();
+				if (error_reporting() !== 0)
+				{
+					$errors[] = func_get_args();
+				}
 			}
 		);
 


### PR DESCRIPTION
Ajout d'une vérification de `error_reporting()` avant le stockage de l'erreur : permet de garder l'impact de l'instruction `@` lorsque l'erreur est relancée dans le handler d'origine.
