### PR TITLE
Hande E_RECOVERABLE_ERROR in test's error handler

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -1028,7 +1028,7 @@ abstract class test implements observable, \countable
 			$this->score->addError($file, $this->class, $this->currentMethod, $line, $errno, $errstr, $errfile, $errline);
 		}
 
-		return true;
+		return ($errorReporting & $errno) & E_RECOVERABLE_ERROR ? false : true;
 	}
 
 	public function setUp() {}

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -844,6 +844,8 @@ namespace mageekguy\atoum\tests\units
 					->variable($test->getScore()->errorExists($errstr, E_USER_WARNING))->isNotNull()
 					->boolean($test->errorHandler(E_DEPRECATED, $errstr = uniqid(), uniqid(), rand(1, PHP_INT_MAX), uniqid()))->isTrue()
 					->variable($test->getScore()->errorExists($errstr, E_DEPRECATED))->isNotNull()
+					->boolean($test->errorHandler(E_RECOVERABLE_ERROR, $errstr = uniqid(), uniqid(), rand(1, PHP_INT_MAX), uniqid()))->isFalse()
+					->variable($test->getScore()->errorExists($errstr, E_RECOVERABLE_ERROR))->isNotNull()
 				->if($adapter->error_reporting = E_ALL & ~E_DEPRECATED)
 				->then
 					->boolean($test->errorHandler(E_NOTICE, $errstr = uniqid(), uniqid(), rand(1, PHP_INT_MAX), uniqid()))->isTrue()
@@ -856,6 +858,10 @@ namespace mageekguy\atoum\tests\units
 					->variable($test->getScore()->errorExists($errstr, E_USER_WARNING))->isNotNull()
 					->boolean($test->errorHandler(E_DEPRECATED, $errstr = uniqid(), uniqid(), rand(1, PHP_INT_MAX), uniqid()))->isTrue()
 					->variable($test->getScore()->errorExists($errstr, E_DEPRECATED))->isNull()
+				->if($adapter->error_reporting = E_ALL & ~E_RECOVERABLE_ERROR)
+				->then
+					->boolean($test->errorHandler(E_RECOVERABLE_ERROR, $errstr = uniqid(), uniqid(), rand(1, PHP_INT_MAX), uniqid()))->isTrue()
+					->variable($test->getScore()->errorExists($errstr, E_RECOVERABLE_ERROR))->isNull()
 			;
 		}
 	}


### PR DESCRIPTION
@juliens discovered a tiny bug in atoum test's error handler : it does not correctly handle E_RECOVERABLE_ERROR if there is another error after it.

He built an example repository to reproduce the bug : https://github.com/Juliens/atoum_sandbox

To sum-up: given we have something like this:

``` php
<?php
//typehint.php
namespace Test;

class Foo { public function test() { } }

class TypeHint
{
    public function foo(Foo $test) { $test->test(); }
    public function foo2(Foo $test) { }
}
```

And the test:

``` php
<?php
namespace Test\tests\units;


require_once __DIR__ . '/typehint.php';
require_once __DIR__ . '/atoum/scripts/runner.php';

use \Test\TypeHint as testedClass;

class TypeHint extends \atoum\test
{    
    public function testTypeHintFail()
    {
        $class = new testedClass();        

        $this->variable($class->foo(''))->isNull();
    }
    public function testTypeHintSuccess()
    {
        $class = new testedClass();        

        $this->variable($class->foo2(''))->isNull();
    }
}
```

When we run this test, we get an output which only shows the `FATAL ERROR` telling us we are callin a method (`test`) on a non-object because we didn't pass the required parameter in the `testTypeHintFail` test method.

Fo the second one, `testTypeHintSuccess`, the `E_RECOVERABLE_ERROR` is shown as expected because it's the only error in the test.

This PR changes the error handler behavior a bit so that it correctly handle `E_RECOVERABLE_ERROR`: the handler now returns false when it gets called for this type of error, stopping the test execution and letting us see the right error message (the first raised error). 

**[EDIT: Here is a before/after snippet, perhaps it's a bit clearer]**
**Before:**

```
> There are 2 errors:
=> Test\tests\units\TypeHint::testTypeHintFail():
==> Error FATAL ERROR in /Users/jubianchi/repositories/atoum_sandbox/test.php on unknown line, generated by file /Users/jubianchi/repositories/atoum_sandbox/typehint.php on line 14:
Call to a member function test() on a non-object

=> Test\tests\units\TypeHint::testTypeHintSuccess():
==> Error E_RECOVERABLE_ERROR in /Users/jubianchi/repositories/atoum_sandbox/test.php on line 20, generated by file /Users/jubianchi/repositories/atoum_sandbox/typehint.php on line 17:
Argument 1 passed to Test\TypeHint::foo2() must be an instance of Test\Foo, string given, called in /Users/jubianchi/repositories/atoum_sandbox/test.php on line 20 and defined
```

**After:**

```
> There are 2 errors:
=> Test\tests\units\TypeHint::testTypeHintFail():
==> Error CATCHABLE FATAL ERROR in /Users/jubianchi/repositories/atoum_sandbox/test.php on unknown line, generated by file /Users/jubianchi/repositories/atoum_sandbox/typehint.php on line 12:
Argument 1 passed to Test\TypeHint::foo() must be an instance of Test\Foo, string given, called in /Users/jubianchi/repositories/atoum_sandbox/test.php on line 15 and defined

=> Test\tests\units\TypeHint::testTypeHintSuccess():
==> Error CATCHABLE FATAL ERROR in /Users/jubianchi/repositories/atoum_sandbox/test.php on unknown line, generated by file /Users/jubianchi/repositories/atoum_sandbox/typehint.php on line 17:
Argument 1 passed to Test\TypeHint::foo2() must be an instance of Test\Foo, string given, called in /Users/jubianchi/repositories/atoum_sandbox/test.php on line 20 and defined
```
