### PR TITLE
Related to issue 223 : Escape shell command on windows doesn't work.

### DIFF
--- a/classes/php.php
+++ b/classes/php.php
@@ -30,7 +30,11 @@ class php
 
 	public function __toString()
 	{
-		$command = $this->binaryPath;
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			$command = '"'.$this->binaryPath.'"';
+		} else {
+			$command = $this->binaryPath;
+		}
 
 		foreach ($this->options as $option => $value)
 		{
@@ -59,7 +63,11 @@ class php
 			}
 		}
 
-		return escapeshellcmd($command);
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			return $command;
+		} else {
+			return escapeshellcmd($command);
+		}
 	}
 
 	public function reset()


### PR DESCRIPTION
Related to issue 223 :
Escape shell command on windows doesn't work.
In windows, binaryPath need to be escaped by "" and we don't use escape shell command.
