### PR TITLE
Migrate to atoum namespace instead of mageekguy\atoum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.gitconfig

--- a/FAQ
+++ b/FAQ
@@ -14,15 +14,15 @@ It's a work in progress and you're welcome to improve it.
 Moreover, atoum's unit test is the documentation.
 You find them in the directory path/to/atoum/tests/units.
 
-* Why php mageekguy.atoum.phar does not works?
-Try a "php -n mageekguy.atoum.phar" in a terminal.
+* Why php atoum.phar does not works?
+Try a "php -n atoum.phar" in a terminal.
 If it works, the problem is in your PHP configuration.
 Try to remove ioncube extension, which seems not compatible with atoum.
 If you use suhosin, you can also add "suhosin.executor.include.whitelist="phar"" to your php.ini.
 Try to add "detect_unicode=0" in your php.ini.
 
 * What can i do to avoid error about __COMPILER_HALT_OFFSET__?
-Use only require_once to include mageekguy.atoum.phar in your scripts.
+Use only require_once to include atoum.phar in your scripts.
 
 * Why I get a fail message when testing a class that uses APC?
 APC is "a free, open, and robust framework for caching and optimizing PHP intermediate code" (http://php.net/apc.configuration) distributed under the form of a PHP extension.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# *atoum* [![Build Status](https://secure.travis-ci.org/mageekguy/atoum.png?branch=master)](http://travis-ci.org/mageekguy/atoum)
+# *atoum* [![Build Status](https://secure.travis-ci.org/atoum/atoum.png?branch=master)](http://travis-ci.org/atoum/atoum)
 
 ## A simple, modern and intuitive unit testing framework for PHP!
 
-Just like SimpleTest or PHPUnit, *atoum* is a unit testing framework specific to the [PHP](http://www.php.net) language.  
+Just like SimpleTest or PHPUnit, *atoum* is a unit testing framework specific to the [PHP](http://www.php.net) language.
 However, it has been designed from the start with the following ideas in mind :
 
 * Can be implemented *rapidly* ;
 * *Simplify* test development ;
 * Allow for writing *reliable, readable, and clear* unit tests ;
 
-To accomplish that, it massively uses capabilities provided by *PHP 5.3*, to give the developer *a whole new way* of writing unit tests.  
-Therefore, it can be installed and integrated inside an existing project extremely easily, since it is only a *single PHAR archive*, which is the one and only entry point for the developper.  
-Also, thanks to its *fluid interface*, it allows for writing unit tests in a fashion close to natural language.  
-It also makes it easier to implement stubbing within tests, thanks to intelligent uses of *anonymous functions and closures*.  
-*atoum* natively, and by default, performs the execution of each unit test within a separate [PHP](http://www.php.net) process, to warrant *isolation*.  
-Of course, it can be used seamlessly for continuous integration, and given its design, it can be made to cope with specific needs extremely easily.  
-*atoum* also accomplishes all of this without affecting performance, since it has been developed to boast a reduced memory footprint while allowing for hastened test execution.  
-It can also generate unit test execution reports in the Xunit format, which makes it compatible with continuous integration tools such as [Jenkins](http://jenkins-ci.org/).  
-*atoum* also generates code coverage reports, in order to make it possible to supervise unit tests.  
-Finally, even though it is developed mainly on UNIX, it can also work on Windows.  
+To accomplish that, it massively uses capabilities provided by *PHP 5.3*, to give the developer *a whole new way* of writing unit tests.
+Therefore, it can be installed and integrated inside an existing project extremely easily, since it is only a *single PHAR archive*, which is the one and only entry point for the developper.
+Also, thanks to its *fluid interface*, it allows for writing unit tests in a fashion close to natural language.
+It also makes it easier to implement stubbing within tests, thanks to intelligent uses of *anonymous functions and closures*.
+*atoum* natively, and by default, performs the execution of each unit test within a separate [PHP](http://www.php.net) process, to warrant *isolation*.
+Of course, it can be used seamlessly for continuous integration, and given its design, it can be made to cope with specific needs extremely easily.
+*atoum* also accomplishes all of this without affecting performance, since it has been developed to boast a reduced memory footprint while allowing for hastened test execution.
+It can also generate unit test execution reports in the Xunit format, which makes it compatible with continuous integration tools such as [Jenkins](http://jenkins-ci.org/).
+*atoum* also generates code coverage reports, in order to make it possible to supervise unit tests.
+Finally, even though it is developed mainly on UNIX, it can also work on Windows.
 
 ## Prerequisites to use *atoum*
 
@@ -28,19 +28,19 @@ On UNIX, in order to check whether you have the right PHP version, you just need
 	# php -v | grep -oi 'php 5.\([3-4]\).\([3-9]\|1[0-9]\{1,\}\)'
 
 If `PHP 5.3.x` or equivalent gets displayed, then you have the right PHP version installed.
-Should you want to use *atoum* using its PHAR archive, you also need [PHP](http://www.php.net) to be able to access the `phar` module, which is normally available by default.  
+Should you want to use *atoum* using its PHAR archive, you also need [PHP](http://www.php.net) to be able to access the `phar` module, which is normally available by default.
 On UNIX, in order to check whether you have this module or not, you just need to run the following command in your terminal :
 
 	# php -m | grep -i phar
 
-If `Phar` or equivalent gets displayed, then the module is properly installed.  
-Generating reports in the Xunit format requires the `xml` module.  
+If `Phar` or equivalent gets displayed, then the module is properly installed.
+Generating reports in the Xunit format requires the `xml` module.
 On UNIX, in order to check whether you have this module or not, you just need to run the following command in your terminal :
 
 	# php -m | grep -i xml
 
-If `Xml` or equivalent gets displayed, then the module is properly installed.  
-Should you wish to monitor the coverage rate of your code by the unit tests, the [Xdebug](http://xdebug.org/) 2.2 module will be required.  
+If `Xml` or equivalent gets displayed, then the module is properly installed.
+Should you wish to monitor the coverage rate of your code by the unit tests, the [Xdebug](http://xdebug.org/) 2.2 module will be required.
 On UNIX, in order to check whether you have this module or not, you just need to run the following command in your terminal :
 
 	# php -v | grep -oi 'xdebug v2.2.[0-9]*'
@@ -51,13 +51,13 @@ If `Xdebug v2.2.x` or equivalent gets displayed, then the module is properly ins
 
 ### Step 1 : Install *atoum*
 
-You just have to download [its PHAR archive](http://downloads.atoum.org/nightly/mageekguy.atoum.phar) and store it where you wish, for example under `/path/to/project/tests/mageekguy.atoum.phar`.  
-This PHAR archive contains the latest development version to pass the totality of *atoum*'s unit tests.  
-*atoum*'s source code is also available via [the github repository](https://github.com/atoum/atoum).  
-To check if *atoum* works correctly with your configuration, you can execute all its unit tests.  
+You just have to download [its PHAR archive](http://downloads.atoum.org/nightly/atoum.phar) and store it where you wish, for example under `/path/to/project/tests/atoum.phar`.
+This PHAR archive contains the latest development version to pass the totality of *atoum*'s unit tests.
+*atoum*'s source code is also available via [the github repository](https://github.com/atoum/atoum).
+To check if *atoum* works correctly with your configuration, you can execute all its unit tests.
 To do that, you just need to run the following command in your terminal :
 
-	# php mageekguy.atoum.phar --test-it
+	# php atoum.phar --test-it
 
 ### Step 2 : Write your tests
 
@@ -68,11 +68,11 @@ Using your preferred text editor, create the file `path/to/project/tests/units/h
 
 namespace vendor\project\tests\units;
 
-require_once 'path/to/mageekguy.atoum.phar';
+require_once 'path/to/atoum.phar';
 
 include 'path/to/project/classes/helloWorld.php';
 
-use \mageekguy\atoum;
+use \atoum;
 use \vendor\project;
 
 class helloWorld extends atoum\test
@@ -142,11 +142,11 @@ You should get the following result, or something equivalent :
 
 namespace vendor\project\tests\units;
 
-require_once 'path/to/mageekguy.atoum.phar';
+require_once 'path/to/atoum.phar';
 
 include_once 'path/to/project/classes/helloWorld.php';
 
-use mageekguy\atoum;
+use atoum;
 use vendor\project;
 
 class helloWorld extends atoum\test
@@ -165,11 +165,11 @@ class helloWorld extends atoum\test
 
 ## To go further
 
-[*atoum*'s documentation](http://docs.atoum.org) is still being written.  
+[*atoum*'s documentation](http://docs.atoum.org) is still being written.
 Any help to improve it will be appreciated.
 However, if you want to further explore immediately *atoum*'s possibilities, we recommend :
 
-* Running in your terminal, either the command `php mageekguy.atoum.phar -h`, or the command `php scripts/runner.php -h` ;
+* Running in your terminal, either the command `php atoum.phar -h`, or the command `php scripts/runner.php -h` ;
 * Exploring the contents of the `configurations` directory in *atoum*'s source, as it contains configuration file samples ;
 * Exploring the contents of the `tests/unit/classes` directory in *atoum*'s source, as it contains all of the unit tests ;
 * Read the [conference slides](http://www.slideshare.net/impossiblium/atoum-le-framework-de-tests-unitaires-pour-php-53-simple-moderne-et-intuitif) about it, available online ;
@@ -181,14 +181,14 @@ However, if you want to further explore immediately *atoum*'s possibilities, we 
 
 ### *atoum*'s PHAR archive seems to not be working
 
-In this case, the first thing you will want to do is confirm whether you have the latest version of the archive.  
-You just need to [download](http://downloads.atoum.org/nightly/mageekguy.atoum.phar) it again.  
+In this case, the first thing you will want to do is confirm whether you have the latest version of the archive.
+You just need to [download](http://downloads.atoum.org/nightly/atoum.phar) it again.
 If it still doesn't work, run the following command in a terminal window :
 
-	# php -n mageekguy.atoum.phar -v
+	# php -n atoum.phar -v
 
-If you get *atoum*'s version number, then the problem is coming from your PHP configuration.  
-In most cases, the cause would be within extensions, that might be incompatible with the PHAR format, or that would prevent executing PHAR archives as a security measure.  
+If you get *atoum*'s version number, then the problem is coming from your PHP configuration.
+In most cases, the cause would be within extensions, that might be incompatible with the PHAR format, or that would prevent executing PHAR archives as a security measure.
 The `ioncube` extension for instance seems incompatible with PHAR archives, and you must therefore deactivate it if you are using it, by commenting the following line out of your `php.ini`, by prefixing it with the `;` character :
 
 	zend_extension = /path/to/ioncube_loader*.*
@@ -197,22 +197,22 @@ The `suhosin` extension prevents executing PHAR archives, therefore its default 
 
 	suhosin.executor.include.whitelist="phar"
 
-Finally, if running *atoum* causes the screen to display characters looking like `???%`, this would be because the `detect_unicode` directive inside your `php.ini` file is set to 1.  
+Finally, if running *atoum* causes the screen to display characters looking like `???%`, this would be because the `detect_unicode` directive inside your `php.ini` file is set to 1.
 To fix the problem, you just need to set it to 0 by editing your `php.ini` file or by running *atoum* with the following command :
 
-	# php -d detect_unicode=0 mageekguy.atoum.phar [options]
+	# php -d detect_unicode=0 atoum.phar [options]
 
-If these three operations do not allow *atoum* to work, we suggest you send an e-mail to the address *support[AT]atoum(DOT)org*, describing in detail your configuration and your problem.  
+If these three operations do not allow *atoum* to work, we suggest you send an e-mail to the address *support[AT]atoum(DOT)org*, describing in detail your configuration and your problem.
 You can also ask for help from the *atoum* development staff on the IRC channel *##atoum* on the *freenode* network.
 
-### Error: Constant __COMPILER_HALT_OFFSET__ already defined /path/to/mageekguy.atoum.phar
+### Error: Constant __COMPILER_HALT_OFFSET__ already defined /path/to/atoum.phar
 
-This error comes from the fact the *atoum* PHAR archive is included in more than one place within your code using `include` or `require`.  
+This error comes from the fact the *atoum* PHAR archive is included in more than one place within your code using `include` or `require`.
 To fix this problem, you just need to include the archive by using only `include_once` or `require_once`, in order to ensure it is not included several times.
 
 ### APC seems not work with *atoum*
-[APC](http://fr.php.net/manual/en/apc.configuration.php)  is a free, open, and robust framework for caching and optimizing PHP intermediate code distributed under the form of a PHP extension.  
-When testing classes that use APC, you may get some failure message showing that `apc_fetch` function is unable to retrieve a value.  
+[APC](http://fr.php.net/manual/en/apc.configuration.php)  is a free, open, and robust framework for caching and optimizing PHP intermediate code distributed under the form of a PHP extension.
+When testing classes that use APC, you may get some failure message showing that `apc_fetch` function is unable to retrieve a value.
 As all PHP extension, APC has some configuration options to enable it :
 
 * `apc.enabled` whether to enable or disable APC ;
@@ -221,10 +221,10 @@ As all PHP extension, APC has some configuration options to enable it :
 In order to use [APC](http://fr.php.net/manual/en/apc.configuration.php) with *atoum*, you have to set `apc.enabled` and `apc.enable_cli` to `1`, otherwise, it won't be enabled for the PHP CLI version, which is used by *atoum*.
 
 ### Getting segfault when mocking objects
-When using *atoum* and mocking objects, you will sometime get segfaults coming from [PHP](http://www.php.net).  
-These segfaults are caused by [XDebug](http://xdebug.org/) in version less than 2.1.0 which has problem handling reflection in some cases.  
-To check the current version of [XDebug](http://xdebug.org/), you can run `php -v`.  
-To fix this issue, you have to update [XDebug](http://xdebug.org/) to the latest [stable version](http://xdebug.org/download.php).  
-If you can't update [XDebug](http://xdebug.org/) on your system, you can still disable the extension to avoid getting segfaults.  
-To be sure that [XDebug](http://xdebug.org/) has been succefully updated or disabled, you can run `php -v`.  
-When you are done updating or disabling [XDebug](http://xdebug.org/), run `php mageekguy.atoum.phar --test-it` to be sure that all the segfaults have gone and that *atoum* is working.
+When using *atoum* and mocking objects, you will sometime get segfaults coming from [PHP](http://www.php.net).
+These segfaults are caused by [XDebug](http://xdebug.org/) in version less than 2.1.0 which has problem handling reflection in some cases.
+To check the current version of [XDebug](http://xdebug.org/), you can run `php -v`.
+To fix this issue, you have to update [XDebug](http://xdebug.org/) to the latest [stable version](http://xdebug.org/download.php).
+If you can't update [XDebug](http://xdebug.org/) on your system, you can still disable the extension to avoid getting segfaults.
+To be sure that [XDebug](http://xdebug.org/) has been succefully updated or disabled, you can run `php -v`.
+When you are done updating or disabling [XDebug](http://xdebug.org/), run `php atoum.phar --test-it` to be sure that all the segfaults have gone and that *atoum* is working.

--- a/bin/atoum
+++ b/bin/atoum
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-define('mageekguy\atoum\scripts\runner', __FILE__);
+define('atoum\scripts\runner', __FILE__);
 
 require_once __DIR__ . '/../scripts/runner.php';
 

--- a/classes/adapter.php
+++ b/classes/adapter.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class adapter implements adapter\definition

--- a/classes/adapter/definition.php
+++ b/classes/adapter/definition.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\adapter;
+namespace atoum\adapter;
 
 interface definition
 {

--- a/classes/annotations/extractor.php
+++ b/classes/annotations/extractor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\annotations;
+namespace atoum\annotations;
 
 class extractor
 {

--- a/classes/asserter.php
+++ b/classes/asserter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\exceptions
 ;
 
 abstract class asserter

--- a/classes/asserter/exception.php
+++ b/classes/asserter/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\asserter;
+namespace atoum\asserter;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class exception extends \runtimeException {}

--- a/classes/asserter/generator.php
+++ b/classes/asserter/generator.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\asserter;
+namespace atoum\asserter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class generator
 {
-	const defaultAsserterNamespace = 'mageekguy\atoum\asserters';
+	const defaultAsserterNamespace = 'atoum\asserters';
 
 	protected $aliases = array();
 	protected $locale = null;

--- a/classes/asserters/adapter.php
+++ b/classes/asserters/adapter.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\test,
-	mageekguy\atoum\tools\arguments
+	atoum,
+	atoum\php,
+	atoum\asserter,
+	atoum\exceptions,
+	atoum\test,
+	atoum\tools\arguments
 ;
 
 class adapter extends atoum\asserter
@@ -24,7 +24,7 @@ class adapter extends atoum\asserter
 	{
 		$this->adapter = $adapter;
 
-		if ($this->adapter instanceof \mageekguy\atoum\test\adapter === false)
+		if ($this->adapter instanceof \atoum\test\adapter === false)
 		{
 			$this->fail(sprintf($this->getLocale()->_('%s is not a test adapter'), $this->getTypeOf($this->adapter)));
 		}

--- a/classes/asserters/adapter/call/adapter.php
+++ b/classes/asserters/adapter/call/adapter.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters\adapter\call;
+namespace atoum\asserters\adapter\call;
 
 use
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\php,
+	atoum\test,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class adapter extends php\call

--- a/classes/asserters/adapter/call/mock.php
+++ b/classes/asserters/adapter/call/mock.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters\adapter\call;
+namespace atoum\asserters\adapter\call;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\php,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class mock extends php\call

--- a/classes/asserters/boolean.php
+++ b/classes/asserters/boolean.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class boolean extends asserters\variable

--- a/classes/asserters/castToString.php
+++ b/classes/asserters/castToString.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
-use mageekguy\atoum\asserters;
+use atoum\asserters;
 
 class castToString extends asserters\string
 {

--- a/classes/asserters/dateInterval.php
+++ b/classes/asserters/dateInterval.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class dateInterval extends asserters\object

--- a/classes/asserters/dateTime.php
+++ b/classes/asserters/dateTime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class dateTime extends asserters\object

--- a/classes/asserters/error.php
+++ b/classes/asserters/error.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class error extends atoum\asserter

--- a/classes/asserters/exception.php
+++ b/classes/asserters/exception.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\diffs
+	atoum\test,
+	atoum\asserters,
+	atoum\exceptions,
+	atoum\tools\diffs
 ;
 
 class exception extends asserters\object

--- a/classes/asserters/extension.php
+++ b/classes/asserters/extension.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\exceptions
 ;
 
 class extension extends atoum\asserter

--- a/classes/asserters/float.php
+++ b/classes/asserters/float.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\diffs
+	atoum\asserters,
+	atoum\exceptions,
+	atoum\tools\diffs
 ;
 
 class float extends asserters\integer

--- a/classes/asserters/hash.php
+++ b/classes/asserters/hash.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class hash extends asserters\string

--- a/classes/asserters/integer.php
+++ b/classes/asserters/integer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class integer extends asserters\variable

--- a/classes/asserters/mock.php
+++ b/classes/asserters/mock.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\arguments
+	atoum,
+	atoum\php,
+	atoum\test,
+	atoum\asserter,
+	atoum\exceptions,
+	atoum\tools\arguments
 ;
 
 class mock extends atoum\asserter
@@ -39,7 +39,7 @@ class mock extends atoum\asserter
 	{
 		$this->mock = $mock;
 
-		if ($this->mock instanceof \mageekguy\atoum\mock\aggregator === false)
+		if ($this->mock instanceof \atoum\mock\aggregator === false)
 		{
 			$this->fail(sprintf($this->getLocale()->_('%s is not a mock'), $this->getTypeOf($this->mock)));
 		}

--- a/classes/asserters/mock/call/adapter.php
+++ b/classes/asserters/mock/call/adapter.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters\mock\call;
+namespace atoum\asserters\mock\call;
 
 use
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\php,
+	atoum\test,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class adapter extends php\call

--- a/classes/asserters/mock/call/mock.php
+++ b/classes/asserters/mock/call/mock.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters\mock\call;
+namespace atoum\asserters\mock\call;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\php,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class mock extends php\call

--- a/classes/asserters/mysqlDateTime.php
+++ b/classes/asserters/mysqlDateTime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class mysqlDateTime extends asserters\dateTime

--- a/classes/asserters/object.php
+++ b/classes/asserters/object.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class object extends asserters\variable

--- a/classes/asserters/output.php
+++ b/classes/asserters/output.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserters
 ;
 
 class output extends asserters\string

--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class phpArray extends asserters\variable implements \arrayAccess

--- a/classes/asserters/phpClass.php
+++ b/classes/asserters/phpClass.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class phpClass extends atoum\asserter

--- a/classes/asserters/phpFunction.php
+++ b/classes/asserters/phpFunction.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\php,
+	atoum\exceptions
 ;
 
 class phpFunction extends atoum\asserter

--- a/classes/asserters/sizeOf.php
+++ b/classes/asserters/sizeOf.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
-use mageekguy\atoum\asserters;
+use atoum\asserters;
 
 class sizeOf extends asserters\integer
 {

--- a/classes/asserters/stream.php
+++ b/classes/asserters/stream.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class stream extends atoum\asserter

--- a/classes/asserters/string.php
+++ b/classes/asserters/string.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class string extends asserters\variable

--- a/classes/asserters/testedClass.php
+++ b/classes/asserters/testedClass.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class testedClass extends asserters\phpClass

--- a/classes/asserters/utf8String.php
+++ b/classes/asserters/utf8String.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\exceptions
 ;
 
 class utf8String extends asserters\string

--- a/classes/asserters/variable.php
+++ b/classes/asserters/variable.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\asserters;
+namespace atoum\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\diffs
+	atoum,
+	atoum\exceptions,
+	atoum\tools\diffs
 ;
 
 class variable extends atoum\asserter

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class autoloader
 {
@@ -36,12 +36,12 @@ class autoloader
 			$this->addDirectory($namespace, $directory);
 		}
 
-		foreach ($namespaceAliases ?: array('atoum' => __NAMESPACE__) as $alias => $target)
+		foreach ($namespaceAliases ?: array('mageekguy\\atoum' => __NAMESPACE__) as $alias => $target)
 		{
 			$this->addNamespaceAlias($alias, $target);
 		}
 
-		foreach ($classAliases ?: array('atoum' => __NAMESPACE__ . '\test', __NAMESPACE__ => __NAMESPACE__ . '\test') as $alias => $target)
+		foreach ($classAliases ?: array(__NAMESPACE__ => __NAMESPACE__ . '\test') as $alias => $target)
 		{
 			$this->addClassAlias($alias, $target);
 		}

--- a/classes/cli.php
+++ b/classes/cli.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class cli

--- a/classes/cli/colorizer.php
+++ b/classes/cli/colorizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\cli;
+namespace atoum\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writer
+	atoum,
+	atoum\writer
 ;
 
 class colorizer implements writer\decorator

--- a/classes/cli/progressBar.php
+++ b/classes/cli/progressBar.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\cli;
+namespace atoum\cli;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class progressBar

--- a/classes/cli/prompt.php
+++ b/classes/cli/prompt.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\cli;
+namespace atoum\cli;
 
 class prompt
 {

--- a/classes/configurator.php
+++ b/classes/configurator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class configurator
 {

--- a/classes/exception.php
+++ b/classes/exception.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 interface exception {}

--- a/classes/exceptions/logic.php
+++ b/classes/exceptions/logic.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions;
+namespace atoum\exceptions;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class logic extends \logicException implements atoum\exception {}

--- a/classes/exceptions/logic/badMethodCall.php
+++ b/classes/exceptions/logic/badMethodCall.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\logic;
+namespace atoum\exceptions\logic;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class badMethodCall extends \badMethodCallException implements atoum\exception {}

--- a/classes/exceptions/logic/invalidArgument.php
+++ b/classes/exceptions/logic/invalidArgument.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\logic;
+namespace atoum\exceptions\logic;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class invalidArgument extends \invalidArgumentException implements atoum\exception {}

--- a/classes/exceptions/runtime.php
+++ b/classes/exceptions/runtime.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions;
+namespace atoum\exceptions;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class runtime extends \runtimeException implements atoum\exception {}

--- a/classes/exceptions/runtime/file.php
+++ b/classes/exceptions/runtime/file.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\runtime;
+namespace atoum\exceptions\runtime;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class file extends exceptions\runtime {}

--- a/classes/exceptions/runtime/unexpectedValue.php
+++ b/classes/exceptions/runtime/unexpectedValue.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\exceptions\runtime;
+namespace atoum\exceptions\runtime;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class unexpectedValue extends \unexpectedValueException implements atoum\exception {}

--- a/classes/fs/path.php
+++ b/classes/fs/path.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\fs;
+namespace atoum\fs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\fs\path\exception
+	atoum,
+	atoum\fs\path\exception
 ;
 
 class path

--- a/classes/fs/path/exception.php
+++ b/classes/fs/path/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\fs\path;
+namespace atoum\fs\path;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/fs/path/factory.php
+++ b/classes/fs/path/factory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\fs\path;
+namespace atoum\fs\path;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\fs\path
+	atoum,
+	atoum\fs\path
 ;
 
 class factory

--- a/classes/includer.php
+++ b/classes/includer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\includer
+	atoum,
+	atoum\includer
 ;
 
 class includer

--- a/classes/includer/exception.php
+++ b/classes/includer/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\includer;
+namespace atoum\includer;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/iterators/filters/recursives/atoum/source.php
+++ b/classes/iterators/filters/recursives/atoum/source.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives\atoum;
+namespace atoum\iterators\filters\recursives\atoum;
 
 use
-	mageekguy\atoum\iterators\filters\recursives
+	atoum\iterators\filters\recursives
 ;
 
 class source extends recursives\dot

--- a/classes/iterators/filters/recursives/closure.php
+++ b/classes/iterators/filters/recursives/closure.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives;
+namespace atoum\iterators\filters\recursives;
 
 class closure extends \recursiveFilterIterator
 {

--- a/classes/iterators/filters/recursives/dot.php
+++ b/classes/iterators/filters/recursives/dot.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives;
+namespace atoum\iterators\filters\recursives;
 
 class dot extends \recursiveFilterIterator
 {

--- a/classes/iterators/filters/recursives/extension.php
+++ b/classes/iterators/filters/recursives/extension.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\iterators\filters\recursives;
+namespace atoum\iterators\filters\recursives;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class extension extends \recursiveFilterIterator

--- a/classes/iterators/recursives/atoum/source.php
+++ b/classes/iterators/recursives/atoum/source.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\iterators\recursives\atoum;
+namespace atoum\iterators\recursives\atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators
+	atoum,
+	atoum\iterators
 ;
 
 class source implements \outerIterator

--- a/classes/iterators/recursives/directory/factory.php
+++ b/classes/iterators/recursives/directory/factory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\iterators\recursives\directory;
+namespace atoum\iterators\recursives\directory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\iterators\filters
+	atoum,
+	atoum\exceptions,
+	atoum\iterators\filters
 ;
 
 class factory implements \iteratorAggregate

--- a/classes/locale.php
+++ b/classes/locale.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class locale
 {

--- a/classes/mailer.php
+++ b/classes/mailer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 abstract class mailer

--- a/classes/mailers/mail.php
+++ b/classes/mailers/mail.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mailers;
+namespace atoum\mailers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class mail extends atoum\mailer

--- a/classes/mock/aggregator.php
+++ b/classes/mock/aggregator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum\mock
+	atoum\mock
 ;
 
 interface aggregator

--- a/classes/mock/controller.php
+++ b/classes/mock/controller.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\mock,
+	atoum\test,
+	atoum\exceptions
 ;
 
 class controller extends test\adapter

--- a/classes/mock/controller/iterator.php
+++ b/classes/mock/controller/iterator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\controller;
+namespace atoum\mock\controller;
 
 use
-	mageekguy\atoum\mock
+	atoum\mock
 ;
 
 class iterator implements \iteratorAggregate

--- a/classes/mock/controller/linker.php
+++ b/classes/mock/controller/linker.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\controller;
+namespace atoum\mock\controller;
 
 use
-	mageekguy\atoum\mock
+	atoum\mock
 ;
 
 class linker

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\mock,
+	atoum\exceptions
 ;
 
 class generator
@@ -272,7 +272,7 @@ class generator
 			$mockedMethods .= "\t\t" . '$arguments = array_merge(array(' . join(', ', $parameters) . '), array_slice(func_get_args(), ' . sizeof($parameters) . ', -1));' . PHP_EOL;
 			$mockedMethods .= "\t\t" . 'if ($mockController === null)' . PHP_EOL;
 			$mockedMethods .= "\t\t" . '{' . PHP_EOL;
-			$mockedMethods .= "\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL;
+			$mockedMethods .= "\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL;
 			$mockedMethods .= "\t\t" . '}' . PHP_EOL;
 			$mockedMethods .= "\t\t" . 'if ($mockController !== null)' . PHP_EOL;
 			$mockedMethods .= "\t\t" . '{' . PHP_EOL;
@@ -425,7 +425,7 @@ class generator
 					{
 						$methodCode .= "\t\t" . 'if ($mockController === null)' . PHP_EOL;
 						$methodCode .= "\t\t" . '{' . PHP_EOL;
-						$methodCode .= "\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL;
+						$methodCode .= "\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL;
 						$methodCode .= "\t\t" . '}' . PHP_EOL;
 						$methodCode .= "\t\t" . 'if ($mockController !== null)' . PHP_EOL;
 						$methodCode .= "\t\t" . '{' . PHP_EOL;
@@ -583,7 +583,7 @@ class generator
 		return
 			"\t" . 'public function getMockController()' . PHP_EOL .
 			"\t" . '{' . PHP_EOL .
-			"\t\t" . '$mockController = \mageekguy\atoum\mock\controller::getForMock($this);' . PHP_EOL .
+			"\t\t" . '$mockController = \atoum\mock\controller::getForMock($this);' . PHP_EOL .
 			"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
 			"\t\t\t" . '$this->setMockController($mockController = new \\' . __NAMESPACE__ . '\\controller());' . PHP_EOL .
@@ -596,7 +596,7 @@ class generator
 			"\t" . '}' . PHP_EOL .
 			"\t" . 'public function resetMockController()' . PHP_EOL .
 			"\t" . '{' . PHP_EOL .
-			"\t\t" . '\mageekguy\atoum\mock\controller::getForMock($this)->reset();' . PHP_EOL .
+			"\t\t" . '\atoum\mock\controller::getForMock($this)->reset();' . PHP_EOL .
 			"\t\t" . 'return $this;' . PHP_EOL .
 			"\t" . '}' . PHP_EOL
 		;
@@ -609,7 +609,7 @@ class generator
 			"\t" . '{' . PHP_EOL .
 			"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
-			"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+			"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 			"\t\t" . '}' . PHP_EOL .
 			"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .

--- a/classes/mock/php/method.php
+++ b/classes/mock/php/method.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mock\php;
+namespace atoum\mock\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class method

--- a/classes/mock/php/method/argument.php
+++ b/classes/mock/php/method/argument.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\php\method;
+namespace atoum\mock\php\method;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class argument

--- a/classes/mock/stream.php
+++ b/classes/mock/stream.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\mock;
+namespace atoum\mock;
 
 use
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\exceptions\logic,
-	mageekguy\atoum\exceptions\runtime
+	atoum\adapter,
+	atoum\exceptions\logic,
+	atoum\exceptions\runtime
 ;
 
 class stream

--- a/classes/mock/stream/controller.php
+++ b/classes/mock/stream/controller.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mock\stream;
+namespace atoum\mock\stream;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum\test,
+	atoum\exceptions
 ;
 
 class controller extends test\adapter

--- a/classes/mock/stream/invoker.php
+++ b/classes/mock/stream/invoker.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\stream;
+namespace atoum\mock\stream;
 
 use
-	mageekguy\atoum\test\adapter
+	atoum\test\adapter
 ;
 
 class invoker extends adapter\invoker
@@ -22,7 +22,7 @@ class invoker extends adapter\invoker
 
 	public function offsetSet($call, $mixed)
 	{
-		if ($this->methodName == 'dir_readdir' && $mixed instanceof \mageekguy\atoum\mock\stream\controller)
+		if ($this->methodName == 'dir_readdir' && $mixed instanceof \atoum\mock\stream\controller)
 		{
 			$mixed = $mixed->getBasename();
 		}

--- a/classes/mock/streams/fs/controller.php
+++ b/classes/mock/streams/fs/controller.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\mock\streams\fs;
+namespace atoum\mock\streams\fs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\mock\stream
+	atoum,
+	atoum\exceptions,
+	atoum\mock\stream
 ;
 
 class controller extends stream\controller

--- a/classes/mock/streams/fs/controller/factory.php
+++ b/classes/mock/streams/fs/controller/factory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\streams\fs\controller;
+namespace atoum\mock\streams\fs\controller;
 
 use
-	mageekguy\atoum\mock\streams\fs\controller
+	atoum\mock\streams\fs\controller
 ;
 
 class factory

--- a/classes/mock/streams/fs/directory.php
+++ b/classes/mock/streams/fs/directory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\streams\fs;
+namespace atoum\mock\streams\fs;
 
 use
-	mageekguy\atoum\mock\stream
+	atoum\mock\stream
 ;
 
 class directory extends stream

--- a/classes/mock/streams/fs/directory/controller.php
+++ b/classes/mock/streams/fs/directory/controller.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mock\streams\fs\directory;
+namespace atoum\mock\streams\fs\directory;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\mock\streams\fs
+	atoum\exceptions,
+	atoum\mock\streams\fs
 ;
 
 class controller extends fs\controller

--- a/classes/mock/streams/fs/file.php
+++ b/classes/mock/streams/fs/file.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\mock\streams\fs;
+namespace atoum\mock\streams\fs;
 
 use
-	mageekguy\atoum\mock\stream
+	atoum\mock\stream
 ;
 
 class file extends stream

--- a/classes/mock/streams/fs/file/controller.php
+++ b/classes/mock/streams/fs/file/controller.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\mock\streams\fs\file;
+namespace atoum\mock\streams\fs\file;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\mock\streams\fs
+	atoum\exceptions,
+	atoum\mock\streams\fs
 ;
 
 class controller extends fs\controller

--- a/classes/observable.php
+++ b/classes/observable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 interface observable
 {

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 interface observer
 {

--- a/classes/observers/runner.php
+++ b/classes/observers/runner.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\observers;
+namespace atoum\observers;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 interface runner extends atoum\observer {}

--- a/classes/observers/test.php
+++ b/classes/observers/test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\observers;
+namespace atoum\observers;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 interface test extends atoum\observer {}

--- a/classes/php.php
+++ b/classes/php.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php
+	atoum,
+	atoum\php
 ;
 
 class php

--- a/classes/php/call.php
+++ b/classes/php/call.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\php;
+namespace atoum\php;
 
 class call
 {

--- a/classes/php/call/arguments/decorator.php
+++ b/classes/php/call/arguments/decorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\php\call\arguments;
+namespace atoum\php\call\arguments;
 
 class decorator
 {

--- a/classes/php/call/decorator.php
+++ b/classes/php/call/decorator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php\call;
+namespace atoum\php\call;
 
 use
-	mageekguy\atoum\php
+	atoum\php
 ;
 
 class decorator

--- a/classes/php/exception.php
+++ b/classes/php/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php;
+namespace atoum\php;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/php/mocker.php
+++ b/classes/php/mocker.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\php;
+namespace atoum\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class mocker

--- a/classes/php/tokenizer.php
+++ b/classes/php/tokenizer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php;
+namespace atoum\php;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class tokenizer implements \iteratorAggregate

--- a/classes/php/tokenizer/iterator.php
+++ b/classes/php/tokenizer/iterator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer;
+namespace atoum\php\tokenizer;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer\iterator
+	atoum\exceptions,
+	atoum\php\tokenizer\iterator
 ;
 
 class iterator extends iterator\value

--- a/classes/php/tokenizer/iterator/value.php
+++ b/classes/php/tokenizer/iterator/value.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterator;
+namespace atoum\php\tokenizer\iterator;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 abstract class value implements \iterator, \countable

--- a/classes/php/tokenizer/iterators/phpArgument.php
+++ b/classes/php/tokenizer/iterators/phpArgument.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpArgument extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpClass.php
+++ b/classes/php/tokenizer/iterators/phpClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpClass extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpConstant.php
+++ b/classes/php/tokenizer/iterators/phpConstant.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\php\tokenizer
+	atoum\php\tokenizer
 ;
 
 class phpConstant extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpDefaultValue.php
+++ b/classes/php/tokenizer/iterators/phpDefaultValue.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpDefaultValue extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpFunction.php
+++ b/classes/php/tokenizer/iterators/phpFunction.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpFunction extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpImportation.php
+++ b/classes/php/tokenizer/iterators/phpImportation.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpImportation extends tokenizer\iterator {}

--- a/classes/php/tokenizer/iterators/phpMethod.php
+++ b/classes/php/tokenizer/iterators/phpMethod.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpMethod extends tokenizer\iterators\phpFunction {}

--- a/classes/php/tokenizer/iterators/phpNamespace.php
+++ b/classes/php/tokenizer/iterators/phpNamespace.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpNamespace extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpProperty.php
+++ b/classes/php/tokenizer/iterators/phpProperty.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpProperty extends tokenizer\iterator

--- a/classes/php/tokenizer/iterators/phpScript.php
+++ b/classes/php/tokenizer/iterators/phpScript.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer\iterators;
+namespace atoum\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum\exceptions,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 class phpScript extends tokenizer\iterators\phpNamespace

--- a/classes/php/tokenizer/token.php
+++ b/classes/php/tokenizer/token.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\php\tokenizer;
+namespace atoum\php\tokenizer;
 
 use
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\php\tokenizer\iterator
+	atoum\exceptions,
+	atoum\php\tokenizer\iterator
 ;
 
 class token extends iterator\value

--- a/classes/reader.php
+++ b/classes/reader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 abstract class reader
 {

--- a/classes/readers/std/in.php
+++ b/classes/readers/std/in.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\readers\std;
+namespace atoum\readers\std;
 
 use
-	mageekguy\atoum\reader,
-	mageekguy\atoum\exceptions
+	atoum\reader,
+	atoum\exceptions
 ;
 
 class in extends reader

--- a/classes/report.php
+++ b/classes/report.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 class report implements observer
 {

--- a/classes/report/field.php
+++ b/classes/report/field.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report;
+namespace atoum\report;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 abstract class field

--- a/classes/report/fields/event.php
+++ b/classes/report/fields/event.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields;
+namespace atoum\report\fields;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\test\cli,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\report,
+	atoum\test\cli,
+	atoum\exceptions
 ;
 
 abstract class event extends report\field

--- a/classes/report/fields/runner.php
+++ b/classes/report/fields/runner.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields;
+namespace atoum\report\fields;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 abstract class runner extends report\field

--- a/classes/report/fields/runner/atoum.php
+++ b/classes/report/fields/runner/atoum.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 require_once __DIR__ . '/../../../../constants.php';
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report
+	atoum\runner,
+	atoum\report
 ;
 
 abstract class atoum extends report\field
@@ -35,7 +35,7 @@ abstract class atoum extends report\field
 		return $this->path;
 	}
 
-	public function handleEvent($event, \mageekguy\atoum\observable $observable)
+	public function handleEvent($event, \atoum\observable $observable)
 	{
 		if (parent::handleEvent($event, $observable) === false)
 		{
@@ -43,7 +43,7 @@ abstract class atoum extends report\field
 		}
 		else
 		{
-			$this->author = \mageekguy\atoum\author;
+			$this->author = \atoum\author;
 			$this->path = $observable->getScore()->getAtoumPath();
 			$this->version = $observable->getScore()->getAtoumVersion();
 

--- a/classes/report/fields/runner/atoum/cli.php
+++ b/classes/report/fields/runner/atoum/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\atoum;
+namespace atoum\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\atoum

--- a/classes/report/fields/runner/atoum/logo.php
+++ b/classes/report/fields/runner/atoum/logo.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\atoum;
+namespace atoum\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class logo extends cli

--- a/classes/report/fields/runner/atoum/phing.php
+++ b/classes/report/fields/runner/atoum/phing.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\atoum;
+namespace atoum\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum\report
+	atoum\report
 ;
 
 class phing extends report\fields\runner\atoum\cli

--- a/classes/report/fields/runner/coverage.php
+++ b/classes/report/fields/runner/coverage.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\php,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\exceptions\runtime,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\observable,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report
+	atoum\php,
+	atoum\adapter,
+	atoum\exceptions\runtime,
+	atoum\iterators,
+	atoum\observable,
+	atoum\runner,
+	atoum\report
 ;
 
 abstract class coverage extends report\field
@@ -111,7 +111,7 @@ abstract class coverage extends report\field
 				$phpCode =
 					'<?php ' .
 					'ob_start();' .
-					'require \'' . \mageekguy\atoum\directory . '/classes/autoloader.php\';'
+					'require \'' . \atoum\directory . '/classes/autoloader.php\';'
 				;
 
 				$bootstrapFile = $observable->getBootstrapFile();
@@ -119,9 +119,9 @@ abstract class coverage extends report\field
 				if ($bootstrapFile !== null)
 				{
 					$phpCode .=
-						'$includer = new mageekguy\atoum\includer();' .
+						'$includer = new atoum\includer();' .
 						'try { $includer->includePath(\'' . $bootstrapFile . '\'); }' .
-						'catch (mageekguy\atoum\includer\exception $exception)' .
+						'catch (atoum\includer\exception $exception)' .
 						'{ die(\'Unable to include bootstrap file \\\'' . $bootstrapFile . '\\\'\'); }'
 					;
 				}

--- a/classes/report/fields/runner/coverage/cli.php
+++ b/classes/report/fields/runner/coverage/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\coverage;
+namespace atoum\report\fields\runner\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\coverage

--- a/classes/report/fields/runner/coverage/html.php
+++ b/classes/report/fields/runner/coverage/html.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\coverage;
+namespace atoum\report\fields\runner\coverage;
 
 require_once __DIR__ . '/../../../../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\template,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\locale,
+	atoum\report,
+	atoum\template,
+	atoum\exceptions,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class html extends report\fields\runner\coverage\cli

--- a/classes/report/fields/runner/coverage/treemap.php
+++ b/classes/report/fields/runner/coverage/treemap.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\coverage;
+namespace atoum\report\fields\runner\coverage;
 
 require_once __DIR__ . '/../../../../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\template,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\locale,
+	atoum\report,
+	atoum\template,
+	atoum\exceptions,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class treemap extends report\fields\runner\coverage\cli

--- a/classes/report/fields/runner/duration.php
+++ b/classes/report/fields/runner/duration.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class duration extends report\field

--- a/classes/report/fields/runner/duration/cli.php
+++ b/classes/report/fields/runner/duration/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\duration;
+namespace atoum\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration
 ;
 
 class cli extends duration

--- a/classes/report/fields/runner/duration/phing.php
+++ b/classes/report/fields/runner/duration/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\duration;
+namespace atoum\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration
 ;
 
 class phing extends duration\cli

--- a/classes/report/fields/runner/errors.php
+++ b/classes/report/fields/runner/errors.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class errors extends report\field

--- a/classes/report/fields/runner/errors/cli.php
+++ b/classes/report/fields/runner/errors/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\errors;
+namespace atoum\report\fields\runner\errors;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\locale,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\errors

--- a/classes/report/fields/runner/event.php
+++ b/classes/report/fields/runner/event.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\test,
+	atoum\runner,
+	atoum\locale,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class event extends report\fields\event

--- a/classes/report/fields/runner/event/cli.php
+++ b/classes/report/fields/runner/event/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\event;
+namespace atoum\report\fields\runner\event;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\progressBar
+	atoum\test,
+	atoum\runner,
+	atoum\report,
+	atoum\exceptions,
+	atoum\cli\progressBar
 ;
 
 class cli extends report\fields\runner\event

--- a/classes/report/fields/runner/event/nyancat.php
+++ b/classes/report/fields/runner/event/nyancat.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\event;
+namespace atoum\report\fields\runner\event;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\progressBar,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\test,
+	atoum\runner,
+	atoum\report,
+	atoum\exceptions,
+	atoum\cli\progressBar,
+	atoum\cli\colorizer
 ;
-use mageekguy\atoum;
 
 
 class nyancat extends cli

--- a/classes/report/fields/runner/exceptions.php
+++ b/classes/report/fields/runner/exceptions.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class exceptions extends report\field

--- a/classes/report/fields/runner/exceptions/cli.php
+++ b/classes/report/fields/runner/exceptions/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\exceptions;
+namespace atoum\report\fields\runner\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\exceptions

--- a/classes/report/fields/runner/failures.php
+++ b/classes/report/fields/runner/failures.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\locale,
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class failures extends report\field

--- a/classes/report/fields/runner/failures/cli.php
+++ b/classes/report/fields/runner/failures/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures;
+namespace atoum\report\fields\runner\failures;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner
 ;
 
 class cli extends runner\failures

--- a/classes/report/fields/runner/failures/execute.php
+++ b/classes/report/fields/runner/failures/execute.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures;
+namespace atoum\report\fields\runner\failures;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\adapter,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner
 ;
 
 class execute extends runner\failures

--- a/classes/report/fields/runner/failures/execute/macos/macvim.php
+++ b/classes/report/fields/runner/failures/execute/macos/macvim.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures\execute\macos;
+namespace atoum\report\fields\runner\failures\execute\macos;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\report\fields\runner\failures
+	atoum,
+	atoum\locale,
+	atoum\adapter,
+	atoum\report\fields\runner\failures
 ;
 
 class macvim extends failures\execute

--- a/classes/report/fields/runner/failures/execute/macos/phpstorm.php
+++ b/classes/report/fields/runner/failures/execute/macos/phpstorm.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures\execute\macos;
+namespace atoum\report\fields\runner\failures\execute\macos;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\report\fields\runner\failures
+	atoum,
+	atoum\locale,
+	atoum\adapter,
+	atoum\report\fields\runner\failures
 ;
 
 class phpstorm extends failures\execute

--- a/classes/report/fields/runner/failures/execute/unix/gedit.php
+++ b/classes/report/fields/runner/failures/execute/unix/gedit.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures\execute\unix;
+namespace atoum\report\fields\runner\failures\execute\unix;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures
+	atoum,
+	atoum\report\fields\runner\failures
 ;
 
 class gedit extends failures\execute

--- a/classes/report/fields/runner/failures/execute/unix/gvim.php
+++ b/classes/report/fields/runner/failures/execute/unix/gvim.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures\execute\unix;
+namespace atoum\report\fields\runner\failures\execute\unix;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures
+	atoum,
+	atoum\report\fields\runner\failures
 ;
 
 class gvim extends failures\execute

--- a/classes/report/fields/runner/failures/execute/unix/phpstorm.php
+++ b/classes/report/fields/runner/failures/execute/unix/phpstorm.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\failures\execute\unix;
+namespace atoum\report\fields\runner\failures\execute\unix;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures
+	atoum,
+	atoum\report\fields\runner\failures
 ;
 
 class phpstorm extends failures\execute

--- a/classes/report/fields/runner/outputs.php
+++ b/classes/report/fields/runner/outputs.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\observable,
-	mageekguy\atoum\report\field
+	atoum\runner,
+	atoum\observable,
+	atoum\report\field
 ;
 
 abstract class outputs extends field

--- a/classes/report/fields/runner/outputs/cli.php
+++ b/classes/report/fields/runner/outputs/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\outputs;
+namespace atoum\report\fields\runner\outputs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\outputs
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\outputs
 ;
 
 class cli extends outputs

--- a/classes/report/fields/runner/php/path.php
+++ b/classes/report/fields/runner/php/path.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php;
+namespace atoum\report\fields\runner\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class path extends report\field

--- a/classes/report/fields/runner/php/path/cli.php
+++ b/classes/report/fields/runner/php/path/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php\path;
+namespace atoum\report\fields\runner\php\path;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\php\path

--- a/classes/report/fields/runner/php/version.php
+++ b/classes/report/fields/runner/php/version.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php;
+namespace atoum\report\fields\runner\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class version extends report\field

--- a/classes/report/fields/runner/php/version/cli.php
+++ b/classes/report/fields/runner/php/version/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\php\version;
+namespace atoum\report\fields\runner\php\version;
 
 use
-	mageekguy\atoum\report,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum\report,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\php\version

--- a/classes/report/fields/runner/result.php
+++ b/classes/report/fields/runner/result.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner;
+namespace atoum\report\fields\runner;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class result extends report\field

--- a/classes/report/fields/runner/result/cli.php
+++ b/classes/report/fields/runner/result/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result;
+namespace atoum\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields
 ;
 
 class cli extends fields\runner\result

--- a/classes/report/fields/runner/result/logo.php
+++ b/classes/report/fields/runner/result/logo.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result;
+namespace atoum\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class logo extends cli

--- a/classes/report/fields/runner/result/notifier.php
+++ b/classes/report/fields/runner/result/notifier.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result;
+namespace atoum\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\result
+	atoum,
+	atoum\report\fields\runner\result
 ;
 
 abstract class notifier extends result

--- a/classes/report/fields/runner/result/notifier/image.php
+++ b/classes/report/fields/runner/result/notifier/image.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result\notifier;
+namespace atoum\report\fields\runner\result\notifier;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields\runner\result\notifier
+	atoum,
+	atoum\exceptions,
+	atoum\report\fields\runner\result\notifier
 ;
 
 abstract class image extends notifier

--- a/classes/report/fields/runner/result/notifier/image/growl.php
+++ b/classes/report/fields/runner/result/notifier/image/growl.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result\notifier\image;
+namespace atoum\report\fields\runner\result\notifier\image;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\logic,
-	mageekguy\atoum\report\fields\runner\result\notifier\image
+	atoum,
+	atoum\exceptions\logic,
+	atoum\report\fields\runner\result\notifier\image
 ;
 
 class growl extends image

--- a/classes/report/fields/runner/result/notifier/image/libnotify.php
+++ b/classes/report/fields/runner/result/notifier/image/libnotify.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result\notifier\image;
+namespace atoum\report\fields\runner\result\notifier\image;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\result\notifier\image
+	atoum,
+	atoum\report\fields\runner\result\notifier\image
 ;
 
 class libnotify extends image

--- a/classes/report/fields/runner/result/notifier/terminal.php
+++ b/classes/report/fields/runner/result/notifier/terminal.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\result\notifier;
+namespace atoum\report\fields\runner\result\notifier;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\result\notifier
+	atoum,
+	atoum\report\fields\runner\result\notifier
 ;
 
 class terminal extends notifier

--- a/classes/report/fields/runner/tap/plan.php
+++ b/classes/report/fields/runner/tap/plan.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tap;
+namespace atoum\report\fields\runner\tap;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report
+	atoum\runner,
+	atoum\report
 ;
 
 class plan extends report\field
@@ -21,7 +21,7 @@ class plan extends report\field
 		return ($this->testMethodNumber <= 0 ? '' : '1..' . $this->testMethodNumber . PHP_EOL);
 	}
 
-	public function handleEvent($event, \mageekguy\atoum\observable $observable)
+	public function handleEvent($event, \atoum\observable $observable)
 	{
 		if (parent::handleEvent($event, $observable) === false)
 		{

--- a/classes/report/fields/runner/tests/coverage.php
+++ b/classes/report/fields/runner/tests/coverage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class coverage extends report\field

--- a/classes/report/fields/runner/tests/coverage/cli.php
+++ b/classes/report/fields/runner/tests/coverage/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\coverage;
+namespace atoum\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\tests\coverage

--- a/classes/report/fields/runner/tests/coverage/phing.php
+++ b/classes/report/fields/runner/tests/coverage/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\coverage;
+namespace atoum\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\runner\tests\coverage\cli

--- a/classes/report/fields/runner/tests/duration.php
+++ b/classes/report/fields/runner/tests/duration.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class duration extends report\field

--- a/classes/report/fields/runner/tests/duration/cli.php
+++ b/classes/report/fields/runner/tests/duration/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\duration;
+namespace atoum\report\fields\runner\tests\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\tests\duration

--- a/classes/report/fields/runner/tests/memory.php
+++ b/classes/report/fields/runner/tests/memory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\runner
+	atoum,
+	atoum\report,
+	atoum\runner
 ;
 
 abstract class memory extends report\field

--- a/classes/report/fields/runner/tests/memory/cli.php
+++ b/classes/report/fields/runner/tests/memory/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\memory;
+namespace atoum\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\runner\tests\memory

--- a/classes/report/fields/runner/tests/memory/phing.php
+++ b/classes/report/fields/runner/tests/memory/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\memory;
+namespace atoum\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\runner\tests\memory\cli

--- a/classes/report/fields/runner/tests/skipped.php
+++ b/classes/report/fields/runner/tests/skipped.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class skipped extends report\field

--- a/classes/report/fields/runner/tests/skipped/cli.php
+++ b/classes/report/fields/runner/tests/skipped/cli.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\skipped;
+namespace atoum\report\fields\runner\tests\skipped;
 
 use
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\skipped
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\skipped
 ;
 
 class cli extends skipped

--- a/classes/report/fields/runner/tests/uncompleted.php
+++ b/classes/report/fields/runner/tests/uncompleted.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class uncompleted extends report\field

--- a/classes/report/fields/runner/tests/uncompleted/cli.php
+++ b/classes/report/fields/runner/tests/uncompleted/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\uncompleted;
+namespace atoum\report\fields\runner\tests\uncompleted;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\tests\uncompleted

--- a/classes/report/fields/runner/tests/void.php
+++ b/classes/report/fields/runner/tests/void.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests;
+namespace atoum\report\fields\runner\tests;
 
 use
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\runner,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class void extends report\field

--- a/classes/report/fields/runner/tests/void/cli.php
+++ b/classes/report/fields/runner/tests/void/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\void;
+namespace atoum\report\fields\runner\tests\void;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\report,
+	atoum\cli\prompt,
+	atoum\cli\colorizer
 ;
 
 class cli extends report\fields\runner\tests\void

--- a/classes/report/fields/test/duration.php
+++ b/classes/report/fields/test/duration.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\observable
+	atoum\test,
+	atoum\report,
+	atoum\observable
 ;
 
 abstract class duration extends report\field

--- a/classes/report/fields/test/duration/cli.php
+++ b/classes/report/fields/test/duration/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\duration;
+namespace atoum\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\test\duration

--- a/classes/report/fields/test/duration/phing.php
+++ b/classes/report/fields/test/duration/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\duration;
+namespace atoum\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\test\duration\cli

--- a/classes/report/fields/test/event.php
+++ b/classes/report/fields/test/event.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\test\cli,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\report,
+	atoum\test\cli,
+	atoum\exceptions
 ;
 
 abstract class event extends report\fields\event

--- a/classes/report/fields/test/event/cli.php
+++ b/classes/report/fields/test/event/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\event;
+namespace atoum\report\fields\test\event;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\cli\progressBar
+	atoum\test,
+	atoum\report,
+	atoum\exceptions,
+	atoum\cli\progressBar
 ;
 
 class cli extends report\fields\test\event

--- a/classes/report/fields/test/event/phing.php
+++ b/classes/report/fields/test/event/phing.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\event;
+namespace atoum\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\report,
+	atoum\exceptions
 ;
 
 class phing extends report\fields\test\event\cli

--- a/classes/report/fields/test/event/tap.php
+++ b/classes/report/fields/test/event/tap.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\event;
+namespace atoum\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\runner,
+	atoum\report,
+	atoum\exceptions
 ;
 
 class tap extends report\fields\event

--- a/classes/report/fields/test/memory.php
+++ b/classes/report/fields/test/memory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report
+	atoum,
+	atoum\test,
+	atoum\report
 ;
 
 abstract class memory extends report\field

--- a/classes/report/fields/test/memory/cli.php
+++ b/classes/report/fields/test/memory/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\memory;
+namespace atoum\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\test\memory

--- a/classes/report/fields/test/memory/phing.php
+++ b/classes/report/fields/test/memory/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\memory;
+namespace atoum\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\test\memory\cli

--- a/classes/report/fields/test/run.php
+++ b/classes/report/fields/test/run.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test;
+namespace atoum\report\fields\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\report
+	atoum,
+	atoum\test,
+	atoum\report
 ;
 
 abstract class run extends report\field

--- a/classes/report/fields/test/run/cli.php
+++ b/classes/report/fields/test/run/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\run;
+namespace atoum\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class cli extends report\fields\test\run

--- a/classes/report/fields/test/run/phing.php
+++ b/classes/report/fields/test/run/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\test\run;
+namespace atoum\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report
 ;
 
 class phing extends report\fields\test\run\cli

--- a/classes/report/writers/asynchronous.php
+++ b/classes/report/writers/asynchronous.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report\writers;
+namespace atoum\report\writers;
 
 use
-	mageekguy\atoum\reports
+	atoum\reports
 ;
 
 interface asynchronous

--- a/classes/report/writers/realtime.php
+++ b/classes/report/writers/realtime.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\report\writers;
+namespace atoum\report\writers;
 
 use
-	mageekguy\atoum\reports
+	atoum\reports
 ;
 
 interface realtime

--- a/classes/reports/asynchronous.php
+++ b/classes/reports/asynchronous.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\reports;
+namespace atoum\reports;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 abstract class asynchronous extends atoum\report

--- a/classes/reports/asynchronous/builder.php
+++ b/classes/reports/asynchronous/builder.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\exceptions,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class builder extends atoum\reports\asynchronous

--- a/classes/reports/asynchronous/clover.php
+++ b/classes/reports/asynchronous/clover.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\score
+	atoum,
+	atoum\exceptions,
+	atoum\score
 ;
 
 class clover extends atoum\reports\asynchronous

--- a/classes/reports/asynchronous/coveralls.php
+++ b/classes/reports/asynchronous/coveralls.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\score,
-	mageekguy\atoum\report
+	atoum,
+	atoum\exceptions,
+	atoum\score,
+	atoum\report
 ;
 
 class coveralls extends atoum\reports\asynchronous

--- a/classes/reports/asynchronous/vim.php
+++ b/classes/reports/asynchronous/vim.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class vim extends reports\asynchronous

--- a/classes/reports/asynchronous/xunit.php
+++ b/classes/reports/asynchronous/xunit.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\reports\asynchronous;
+namespace atoum\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields
+	atoum,
+	atoum\exceptions,
+	atoum\report\fields
 ;
 
 class xunit extends atoum\reports\asynchronous

--- a/classes/reports/realtime.php
+++ b/classes/reports/realtime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\reports;
+namespace atoum\reports;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 abstract class realtime extends atoum\report

--- a/classes/reports/realtime/cli.php
+++ b/classes/reports/realtime/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime;
+namespace atoum\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports\realtime,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class cli extends realtime

--- a/classes/reports/realtime/cli/light.php
+++ b/classes/reports/realtime/cli/light.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime\cli;
+namespace atoum\reports\realtime\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports\realtime,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class light extends realtime

--- a/classes/reports/realtime/nyancat.php
+++ b/classes/reports/realtime/nyancat.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime;
+namespace atoum\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\runner,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\cli\colorizer
+	atoum,
+	atoum\reports\realtime,
+	atoum\report\fields\runner,
+	atoum\report\fields\test,
+	atoum\cli\colorizer,
+	atoum\cli\prompt
 ;
-use mageekguy\atoum\cli\prompt;
 
 class nyancat extends realtime
 {

--- a/classes/reports/realtime/phing.php
+++ b/classes/reports/realtime/phing.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime;
+namespace atoum\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\reports\realtime,
+	atoum\report\fields\test,
+	atoum\report\fields\runner
 ;
 
 class phing extends realtime
@@ -180,12 +180,12 @@ class phing extends realtime
 		$exceptionColorizer = new colorizer('0;35');
 		$exceptionPrompt = clone $secondLevelPrompt;
 		$exceptionPrompt->setColorizer($exceptionColorizer);
-		
+
 		$uncompletedTestColorizer = new colorizer('0;37');
 		$uncompletedTestMethodPrompt = clone $secondLevelPrompt;
 		$uncompletedTestMethodPrompt->setColorizer($uncompletedTestColorizer);
 		$uncompletedTestOutputPrompt = new prompt('  ', $uncompletedTestColorizer);
-		
+
 		$voidTestColorizer = new colorizer('0;34');
 		$voidTestMethodPrompt = clone $secondLevelPrompt;
 		$voidTestMethodPrompt->setColorizer($voidTestColorizer);
@@ -315,14 +315,14 @@ class phing extends realtime
 		;
 
 		$this->addField($runnerVoidField);
-		
+
 		$runnerSkippedField = new runner\tests\skipped\cli();
 		$runnerSkippedField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($skippedTestColorizer)
 			->setMethodPrompt($skippedTestMethodPrompt)
 		;
-		
+
 		$this->addField($runnerSkippedField);
 
 		if ($this->showProgress === true)

--- a/classes/reports/realtime/tap.php
+++ b/classes/reports/realtime/tap.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\reports\realtime;
+namespace atoum\reports\realtime;
 
 use
-	mageekguy\atoum\reports,
-	mageekguy\atoum\report\fields
+	atoum\reports,
+	atoum\report\fields
 ;
 
 class tap extends reports\realtime

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\iterators,
+	atoum\exceptions
 ;
 
 class runner implements observable
 {
-	const atoumVersionConstant = 'mageekguy\atoum\version';
-	const atoumDirectoryConstant = 'mageekguy\atoum\directory';
+	const atoumVersionConstant = 'atoum\version';
+	const atoumDirectoryConstant = 'atoum\directory';
 
 	const runStart = 'runnerStart';
 	const runStop = 'runnerStop';

--- a/classes/runner/score.php
+++ b/classes/runner/score.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\runner;
+namespace atoum\runner;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class score extends atoum\score

--- a/classes/score.php
+++ b/classes/score.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\asserter,
+	atoum\exceptions
 ;
 
 class score

--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\score;
+namespace atoum\score;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\score,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\score,
+	atoum\exceptions
 ;
 
 class coverage implements \countable, \serializable

--- a/classes/script.php
+++ b/classes/script.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\script,
-	mageekguy\atoum\writers,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\script,
+	atoum\writers,
+	atoum\exceptions
 ;
 
 abstract class script
@@ -255,6 +255,25 @@ abstract class script
 
 	public function run(array $arguments = array())
 	{
+		// check old namespace
+		if (defined('mageekguy\atoum\author')
+		||  defined('mageekguy\atoum\directory')
+		||  defined('mageekguy\atoum\mail')
+		||  defined('mageekguy\atoum\repository')
+		||  defined('mageekguy\atoum\running')
+		||  defined('mageekguy\atoum\scripts\runner')
+		||  defined('mageekguy\atoum\version'))
+		{
+			$this
+				->writeWarning(
+					'Damn ! It seems that you use old \mageekguy\atoum\* constants...' . PHP_EOL .
+					'         You should update your atoum environment to use our brand new \atoum\* constants.' . PHP_EOL .
+					'         Your life would be better ! Do not thank us... it\'s with pleasure :)'
+				)
+				->writeMessage('')
+			;
+		}
+
 		$this->adapter->ini_set('log_errors_max_len', 0);
 		$this->adapter->ini_set('log_errors', 'Off');
 		$this->adapter->ini_set('display_errors', 'stderr');

--- a/classes/script/arguments/parser.php
+++ b/classes/script/arguments/parser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\script\arguments;
+namespace atoum\script\arguments;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class parser implements \iteratorAggregate

--- a/classes/script/configurable.php
+++ b/classes/script/configurable.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\script;
+namespace atoum\script;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\system,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\system,
+	atoum\exceptions
 ;
 
 abstract class configurable extends atoum\script

--- a/classes/script/prompt.php
+++ b/classes/script/prompt.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\script;
+namespace atoum\script;
 
 use
-	mageekguy\atoum\writer,
-	mageekguy\atoum\writers,
-	mageekguy\atoum\reader,
-	mageekguy\atoum\readers\std
+	atoum\writer,
+	atoum\writers,
+	atoum\reader,
+	atoum\readers\std
 ;
 
 class prompt

--- a/classes/scripts/builder.php
+++ b/classes/scripts/builder.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\phar,
-	mageekguy\atoum\scripts\builder
+	atoum,
+	atoum\exceptions,
+	atoum\scripts\phar,
+	atoum\scripts\builder
 ;
 
 class builder extends atoum\script\configurable

--- a/classes/scripts/builder/vcs.php
+++ b/classes/scripts/builder/vcs.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\scripts\builder;
+namespace atoum\scripts\builder;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 abstract class vcs

--- a/classes/scripts/builder/vcs/svn.php
+++ b/classes/scripts/builder/vcs/svn.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts\builder\vcs;
+namespace atoum\scripts\builder\vcs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\builder
+	atoum,
+	atoum\exceptions,
+	atoum\scripts\builder
 ;
 
 class svn extends builder\vcs

--- a/classes/scripts/compiler.php
+++ b/classes/scripts/compiler.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\iterators,
+	atoum\exceptions
 ;
 
 class compiler extends atoum\script

--- a/classes/scripts/phar/generator.php
+++ b/classes/scripts/phar/generator.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace mageekguy\atoum\scripts\phar;
+namespace atoum\scripts\phar;
 
 require_once __DIR__ . '/../../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\iterators,
+	atoum\exceptions
 ;
 
 class generator extends atoum\script
 {
-	const phar = 'mageekguy.atoum.phar';
+	const phar = 'atoum.phar';
 
 	protected $originDirectory = null;
 	protected $destinationDirectory = null;

--- a/classes/scripts/phar/stub.php
+++ b/classes/scripts/phar/stub.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts\phar;
+namespace atoum\scripts\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\scripts,
+	atoum\exceptions
 ;
 
 class stub extends scripts\runner

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 require_once __DIR__ . '/../../constants.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli,
-	mageekguy\atoum\php,
-	mageekguy\atoum\writers,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\cli,
+	atoum\php,
+	atoum\writers,
+	atoum\exceptions
 ;
 
 class runner extends atoum\script\configurable
@@ -736,7 +736,7 @@ class runner extends atoum\script\configurable
 							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
 						}
 
-						\mageekguy\atoum\cli::forceTerminal();
+						\atoum\cli::forceTerminal();
 					},
 					array('-ft', '--force-terminal'),
 					null,

--- a/classes/scripts/tagger.php
+++ b/classes/scripts/tagger.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\tagger
+	atoum,
+	atoum\scripts,
+	atoum\exceptions,
+	atoum\scripts\tagger
 ;
 
 class tagger extends atoum\script

--- a/classes/scripts/tagger/engine.php
+++ b/classes/scripts/tagger/engine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts\tagger;
+namespace atoum\scripts\tagger;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\adapter,
+	atoum\exceptions
 ;
 
 class engine

--- a/classes/scripts/treemap.php
+++ b/classes/scripts/treemap.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\scripts;
+namespace atoum\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\scripts\treemap\analyzers
+	atoum,
+	atoum\exceptions,
+	atoum\scripts\treemap\analyzers
 ;
 
 class treemap extends atoum\script\configurable

--- a/classes/scripts/treemap/analyzer.php
+++ b/classes/scripts/treemap/analyzer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\scripts\treemap;
+namespace atoum\scripts\treemap;
 
 interface analyzer
 {

--- a/classes/scripts/treemap/analyzer/generic.php
+++ b/classes/scripts/treemap/analyzer/generic.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\scripts\treemap\analyzer;
+namespace atoum\scripts\treemap\analyzer;
 
 use
-	mageekguy\atoum\scripts\treemap\analyzer
+	atoum\scripts\treemap\analyzer
 ;
 
 class generic implements analyzer

--- a/classes/scripts/treemap/analyzers/size.php
+++ b/classes/scripts/treemap/analyzers/size.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\scripts\treemap\analyzers;
+namespace atoum\scripts\treemap\analyzers;
 
 use
-	mageekguy\atoum\scripts\treemap\analyzer
+	atoum\scripts\treemap\analyzer
 ;
 
 class size implements analyzer

--- a/classes/scripts/treemap/analyzers/sloc.php
+++ b/classes/scripts/treemap/analyzers/sloc.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\scripts\treemap\analyzers;
+namespace atoum\scripts\treemap\analyzers;
 
 use
-	mageekguy\atoum\scripts\treemap\analyzer
+	atoum\scripts\treemap\analyzer
 ;
 
 class sloc implements analyzer

--- a/classes/scripts/treemap/analyzers/token.php
+++ b/classes/scripts/treemap/analyzers/token.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\scripts\treemap\analyzers;
+namespace atoum\scripts\treemap\analyzers;
 
 use
-	mageekguy\atoum\scripts\treemap\analyzer
+	atoum\scripts\treemap\analyzer
 ;
 
 class token implements analyzer

--- a/classes/scripts/treemap/categorizer.php
+++ b/classes/scripts/treemap/categorizer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\scripts\treemap;
+namespace atoum\scripts\treemap;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class categorizer

--- a/classes/superglobals.php
+++ b/classes/superglobals.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class superglobals

--- a/classes/template.php
+++ b/classes/template.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\template,
-	mageekguy\atoum\exceptions
+	atoum\template,
+	atoum\exceptions
 ;
 
 class template extends template\data

--- a/classes/template/data.php
+++ b/classes/template/data.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class data

--- a/classes/template/iterator.php
+++ b/classes/template/iterator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class iterator implements \iterator, \countable

--- a/classes/template/parser.php
+++ b/classes/template/parser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\template\parser
+	atoum,
+	atoum\exceptions,
+	atoum\template\parser
 ;
 
 class parser

--- a/classes/template/parser/exception.php
+++ b/classes/template/parser/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\template\parser;
+namespace atoum\template\parser;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime

--- a/classes/template/tag.php
+++ b/classes/template/tag.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\template;
+namespace atoum\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 class tag extends atoum\template

--- a/classes/test.php
+++ b/classes/test.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\annotations
+	atoum\test,
+	atoum\mock,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\exceptions,
+	atoum\annotations
 ;
 
 abstract class test implements observable, \countable
@@ -32,7 +32,7 @@ abstract class test implements observable, \countable
 	const afterTearDown = 'afterTestTearDown';
 	const runStop = 'testRunStop';
 	const defaultEngine = 'concurrent';
-	const enginesNamespace = '\mageekguy\atoum\test\engines';
+	const enginesNamespace = '\atoum\test\engines';
 
 	private $score = null;
 	private $locale = null;
@@ -1424,7 +1424,7 @@ abstract class test implements observable, \countable
 		{
 			if ($this->xdebugConfig != null)
 			{
-				$engineClass = 'mageekguy\atoum\test\engines\concurrent';
+				$engineClass = 'atoum\test\engines\concurrent';
 			}
 			else
 			{

--- a/classes/test/adapter.php
+++ b/classes/test/adapter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\test;
+namespace atoum\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\test\adapter\invoker
+	atoum,
+	atoum\exceptions,
+	atoum\test\adapter\invoker
 ;
 
 class adapter extends atoum\adapter

--- a/classes/test/adapter/invoker.php
+++ b/classes/test/adapter/invoker.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\adapter;
+namespace atoum\test\adapter;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class invoker implements \arrayAccess, \countable

--- a/classes/test/adapter/storage.php
+++ b/classes/test/adapter/storage.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\adapter;
+namespace atoum\test\adapter;
 
 use
-	mageekguy\atoum\test\adapter
+	atoum\test\adapter
 ;
 
 class storage implements \countable, \iteratorAggregate

--- a/classes/test/asserter/generator.php
+++ b/classes/test/asserter/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\asserter;
+namespace atoum\test\asserter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter
+	atoum,
+	atoum\asserter
 ;
 
 class generator extends asserter\generator

--- a/classes/test/assertion/manager.php
+++ b/classes/test/assertion/manager.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\assertion;
+namespace atoum\test\assertion;
 
 use
-	mageekguy\atoum\test\assertion
+	atoum\test\assertion
 ;
 
 class manager

--- a/classes/test/assertion/manager/exception.php
+++ b/classes/test/assertion/manager/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\assertion\manager;
+namespace atoum\test\assertion\manager;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class exception extends exceptions\runtime {}

--- a/classes/test/engine.php
+++ b/classes/test/engine.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test;
+namespace atoum\test;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 abstract class engine

--- a/classes/test/engines/concurrent.php
+++ b/classes/test/engines/concurrent.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\test\engines;
+namespace atoum\test\engines;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\test,
+	atoum\exceptions
 ;
 
 class concurrent extends test\engine
@@ -74,9 +74,9 @@ class concurrent extends test\engine
 			if ($bootstrapFile !== null)
 			{
 				$phpCode .=
-					'$includer = new mageekguy\atoum\includer();' .
+					'$includer = new atoum\includer();' .
 					'try { $includer->includePath(\'' . $bootstrapFile . '\'); }' .
-					'catch (mageekguy\atoum\includer\exception $exception)' .
+					'catch (atoum\includer\exception $exception)' .
 					'{ die(\'Unable to include bootstrap file \\\'' . $bootstrapFile . '\\\'\'); }'
 				;
 			}
@@ -119,7 +119,7 @@ class concurrent extends test\engine
 
 			$phpCode .=
 				'ob_end_clean();' .
-				'mageekguy\atoum\scripts\runner::disableAutorun();' .
+				'atoum\scripts\runner::disableAutorun();' .
 				'echo serialize($test->runTestMethod(\'' . $this->method . '\')->getScore());'
 			;
 

--- a/classes/test/engines/inline.php
+++ b/classes/test/engines/inline.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\engines;
+namespace atoum\test\engines;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test
+	atoum,
+	atoum\test
 ;
 
 class inline extends test\engine

--- a/classes/test/engines/isolate.php
+++ b/classes/test/engines/isolate.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\engines;
+namespace atoum\test\engines;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\engines
+	atoum,
+	atoum\test\engines
 ;
 
 class isolate extends engines\concurrent

--- a/classes/test/exceptions/runtime.php
+++ b/classes/test/exceptions/runtime.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\exceptions;
+namespace atoum\test\exceptions;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class runtime extends exceptions\runtime {}

--- a/classes/test/exceptions/skip.php
+++ b/classes/test/exceptions/skip.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\exceptions;
+namespace atoum\test\exceptions;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class skip extends exceptions\runtime

--- a/classes/test/exceptions/stop.php
+++ b/classes/test/exceptions/stop.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\exceptions;
+namespace atoum\test\exceptions;
 
 use
-	mageekguy\atoum\exceptions
+	atoum\exceptions
 ;
 
 class stop extends exceptions\runtime {}

--- a/classes/test/generator.php
+++ b/classes/test/generator.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\test;
+namespace atoum\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\fs\path,
-	mageekguy\atoum\template,
-	mageekguy\atoum\test\generator
+	atoum,
+	atoum\fs\path,
+	atoum\template,
+	atoum\test\generator
 ;
 
 class generator

--- a/classes/test/generator/exception.php
+++ b/classes/test/generator/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test\generator;
+namespace atoum\test\generator;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class exception extends atoum\exceptions\runtime {}

--- a/classes/test/mock/generator.php
+++ b/classes/test/mock/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\test\mock;
+namespace atoum\test\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\mock
 ;
 
 class generator extends mock\generator

--- a/classes/test/score.php
+++ b/classes/test/score.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\test;
+namespace atoum\test;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class score extends atoum\score

--- a/classes/tools/diff.php
+++ b/classes/tools/diff.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\tools;
+namespace atoum\tools;
 
 class diff
 {

--- a/classes/tools/diffs/variable.php
+++ b/classes/tools/diffs/variable.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tools\diffs;
+namespace atoum\tools\diffs;
 
 use
-	mageekguy\atoum\tools,
-	mageekguy\atoum\exceptions
+	atoum\tools,
+	atoum\exceptions
 ;
 
 class variable extends tools\diff

--- a/classes/writer.php
+++ b/classes/writer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum\writer\decorator
+	atoum\writer\decorator
 ;
 
 abstract class writer

--- a/classes/writer/decorator.php
+++ b/classes/writer/decorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\writer;
+namespace atoum\writer;
 
 interface decorator
 {

--- a/classes/writers/file.php
+++ b/classes/writers/file.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\writers
+	atoum,
+	atoum\reports,
+	atoum\exceptions,
+	atoum\report\writers
 ;
 
 class file extends atoum\writer implements writers\realtime, writers\asynchronous

--- a/classes/writers/http.php
+++ b/classes/writers/http.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\writers
+	atoum,
+	atoum\reports,
+	atoum\exceptions,
+	atoum\report\writers
 ;
 
 class http extends atoum\writer implements writers\asynchronous

--- a/classes/writers/mail.php
+++ b/classes/writers/mail.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report,
-	mageekguy\atoum\reports
+	atoum,
+	atoum\report,
+	atoum\reports
 ;
 
 class mail extends atoum\writer implements report\writers\asynchronous

--- a/classes/writers/std.php
+++ b/classes/writers/std.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\writers;
+namespace atoum\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\writers
+	atoum,
+	atoum\reports,
+	atoum\exceptions,
+	atoum\report\writers
 ;
 
 abstract class std extends atoum\writer implements writers\realtime, writers\asynchronous

--- a/classes/writers/std/err.php
+++ b/classes/writers/std/err.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\writers\std;
+namespace atoum\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers
+	atoum,
+	atoum\writers
 ;
 
 class err extends writers\std

--- a/classes/writers/std/out.php
+++ b/classes/writers/std/out.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\writers\std;
+namespace atoum\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers
+	atoum,
+	atoum\writers
 ;
 
 class out extends writers\std

--- a/constants.php
+++ b/constants.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 if (defined(__NAMESPACE__ . '\running') === false)
 {

--- a/resources/configurations/builder/config.php.dist
+++ b/resources/configurations/builder/config.php.dist
@@ -1,6 +1,6 @@
 <?php
 
-use \mageekguy\atoum;
+use \atoum;
 
 $builder
 	->setWorkingDirectory('/path/to/working/directory')

--- a/resources/configurations/runner/atoum.php.dist
+++ b/resources/configurations/runner/atoum.php.dist
@@ -10,7 +10,7 @@ More information on documentation:
 [fr] http://docs.atoum.org/fr/chapter3.html#Fichier-de-configuration
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 $report = $script->addDefaultReport();
 

--- a/resources/configurations/runner/builder.php.dist
+++ b/resources/configurations/runner/builder.php.dist
@@ -4,7 +4,7 @@
 Sample atoum configuration file to use with builder.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 $mailer = new atoum\mailers\mail();
 $mailer

--- a/resources/configurations/runner/cli.php.dist
+++ b/resources/configurations/runner/cli.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file.
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 Write all on stdout.

--- a/resources/configurations/runner/clover.php.dist
+++ b/resources/configurations/runner/clover.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file to have code coverage in clover format.
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 This will ad the default CLI report

--- a/resources/configurations/runner/coverage.php.dist
+++ b/resources/configurations/runner/coverage.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file to have code coverage in html format and the tre
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 // HTML
 

--- a/resources/configurations/runner/coveralls.php.dist
+++ b/resources/configurations/runner/coveralls.php.dist
@@ -6,8 +6,8 @@ Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/ru
 */
 
 use
-	\mageekguy\atoum,
-	\mageekguy\atoum\reports
+	\atoum,
+	\atoum\reports
 ;
 
 /*

--- a/resources/configurations/runner/logo.php.dist
+++ b/resources/configurations/runner/logo.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file to have atoum's logo on tests run.
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 This will add the default CLI report

--- a/resources/configurations/runner/vim.php.dist
+++ b/resources/configurations/runner/vim.php.dist
@@ -4,7 +4,7 @@
 Sample atoum configuration file for using atoum with vim.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 Write all on stdout.

--- a/resources/configurations/runner/xunit.php.dist
+++ b/resources/configurations/runner/xunit.php.dist
@@ -5,7 +5,7 @@ Sample atoum configuration file to have tests results in xUnit format.
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum;
 
 /*
 This will ad the default CLI report

--- a/resources/phing/AtoumTask.php
+++ b/resources/phing/AtoumTask.php
@@ -1,18 +1,18 @@
 <?php
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports,
-	mageekguy\atoum\reports\realtime,
-	mageekguy\atoum\report\fields\runner\coverage
+	atoum,
+	atoum\reports,
+	atoum\reports\realtime,
+	atoum\report\fields\runner\coverage
 ;
 
-if (defined('mageekguy\atoum\phing\task\path') === false)
+if (defined('atoum\phing\task\path') === false)
 {
-	define('mageekguy\atoum\phing\task\path', 'phing/Task.php');
+	define('atoum\phing\task\path', 'phing/Task.php');
 }
 
-require_once mageekguy\atoum\phing\task\path;
+require_once atoum\phing\task\path;
 
 class atoumTask extends task
 {
@@ -104,9 +104,9 @@ class atoumTask extends task
 		{
 			require_once $this->atoumAutoloaderPath;
 		}
-		else if (class_exists('mageekguy\atoum\scripts\runner', false) === false)
+		else if (class_exists('atoum\scripts\runner', false) === false)
 		{
-			throw new exception('Unknown class mageekguy\\atoum\\scripts\\runner, consider setting atoumPharPath parameter');
+			throw new exception('Unknown class atoum\\scripts\\runner, consider setting atoumPharPath parameter');
 		}
 
 		atoum\scripts\runner::disableAutorun();

--- a/resources/sonar/maven/pom.xml
+++ b/resources/sonar/maven/pom.xml
@@ -24,7 +24,7 @@
 
         <sonar.atoum.skip>false</sonar.atoum.skip>
         <sonar.atoum.coverage.skip>false</sonar.atoum.coverage.skip>
-        <sonar.atoum.commandLine>mageekguy.atoum.phar</sonar.atoum.commandLine>
+        <sonar.atoum.commandLine>atoum.phar</sonar.atoum.commandLine>
         <sonar.atoum.commandLineArgument></sonar.atoum.commandLineArgument>
         <!-- Change this path to your atoum configuration file -->
         <sonar.atoum.configuration>${basedir}/.atoum.php</sonar.atoum.configuration>

--- a/resources/templates/test/generator/testClass.php
+++ b/resources/templates/test/generator/testClass.php
@@ -3,7 +3,7 @@
 namespace <tpl:testClassNamespace />;
 
 use
-	mageekguy\atoum,
+	atoum,
 	<tpl:fullyQualifiedTestClassName /> as testedClass
 ;
 

--- a/resources/vim/atoum.vmb
+++ b/resources/vim/atoum.vmb
@@ -222,7 +222,7 @@ Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/ru
 */
 
 use
-  \mageekguy\atoum
+  \atoum
 ;
 
 /*

--- a/scripts/builder.php
+++ b/scripts/builder.php
@@ -1,8 +1,8 @@
 <?php
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../classes/autoloader.php';

--- a/scripts/compiler.php
+++ b/scripts/compiler.php
@@ -1,8 +1,8 @@
 <?php
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../classes/autoloader.php';

--- a/scripts/phar/generator.php
+++ b/scripts/phar/generator.php
@@ -1,8 +1,8 @@
 <?php
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../../classes/autoloader.php';

--- a/scripts/phar/resources/stub.php
+++ b/scripts/phar/resources/stub.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\phar
+	atoum,
+	atoum\scripts\phar
 ;
 
 if (extension_loaded('phar') === false)
@@ -12,7 +12,7 @@ if (extension_loaded('phar') === false)
 	throw new \runtimeException('Phar extension is mandatory to use this PHAR');
 }
 
-define(__NAMESPACE__ . '\phar\name', 'mageekguy.atoum.phar');
+define(__NAMESPACE__ . '\phar\name', 'atoum.phar');
 
 \phar::mapPhar(atoum\phar\name);
 

--- a/scripts/runner.php
+++ b/scripts/runner.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace mageekguy\atoum;
+namespace atoum;
 
-use mageekguy\atoum\scripts;
+use atoum\scripts;
 
 require_once __DIR__ . '/../classes/autoloader.php';
 

--- a/scripts/tagger.php
+++ b/scripts/tagger.php
@@ -1,8 +1,8 @@
 <?php
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../classes/autoloader.php';

--- a/scripts/treemap.php
+++ b/scripts/treemap.php
@@ -1,8 +1,8 @@
 <?php
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts
+	atoum,
+	atoum\scripts
 ;
 
 require_once __DIR__ . '/../constants.php';

--- a/tests/units/asserters/template/parser/exception.php
+++ b/tests/units/asserters/template/parser/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\template\parser;
+namespace atoum\tests\units\asserters\template\parser;
 
 use
-	mageekguy\atoum\asserters
+	atoum\asserters
 ;
 
 class exception extends asserters\exception

--- a/tests/units/classes/adapter.php
+++ b/tests/units/classes/adapter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
 	atoum,

--- a/tests/units/classes/annotations/extractor.php
+++ b/tests/units/classes/annotations/extractor.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\annotations;
+namespace atoum\tests\units\annotations;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\annotations
+	atoum,
+	atoum\annotations
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/asserter.php
+++ b/tests/units/classes/asserter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 require __DIR__ . '/../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserters,
-	mock\mageekguy\atoum\asserter as sut
+	atoum,
+	atoum\asserters,
+	mock\atoum\asserter as sut
 ;
 
 class asserter extends atoum\test
@@ -41,7 +41,7 @@ class asserter extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new atoum\asserter\generator()))
 			->then
-				->object($integerAsserter = $asserter->integer($integer = rand(1, PHP_INT_MAX)))->isInstanceOf('mageekguy\atoum\asserters\integer')
+				->object($integerAsserter = $asserter->integer($integer = rand(1, PHP_INT_MAX)))->isInstanceOf('atoum\asserters\integer')
 				->integer($integerAsserter->getValue())->isEqualTo($integer)
 				->object($integerAsserter->getGenerator())->isIdenticalTo($generator)
 		;
@@ -118,7 +118,7 @@ class asserter extends atoum\test
 	{
 		$this
 			->if($asserter = new sut(new atoum\asserter\generator()))
-			->and($asserter->setLocale($locale = new \mock\mageekguy\atoum\locale()))
+			->and($asserter->setLocale($locale = new \mock\atoum\locale()))
 			->then
 				->string($asserter->getTypeOf(true))->isEqualTo('boolean(true)')
 				->mock($locale)->call('_')->withArguments('boolean(%s)')->once()

--- a/tests/units/classes/asserter/generator.php
+++ b/tests/units/classes/asserter/generator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserter;
+namespace atoum\tests\units\asserter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter\generator as testedClass
+	atoum,
+	atoum\asserter\generator as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -33,9 +33,9 @@ class generator extends atoum\test
 			->if($generator = new testedClass())
 			->then
 				->exception(function() use ($generator, & $asserter) { $generator->{$asserter = uniqid()}; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Asserter \'' . $asserter . '\' does not exist')
-				->object($generator->variable)->isInstanceOf('mageekguy\atoum\asserters\variable')
+				->object($generator->variable)->isInstanceOf('atoum\asserters\variable')
 		;
 	}
 
@@ -57,9 +57,9 @@ class generator extends atoum\test
 			->if($generator = new testedClass())
 			->then
 				->exception(function() use ($generator, & $asserter) { $generator->{$asserter = uniqid()}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Asserter \'' . $asserter . '\' does not exist')
-				->object($generator->variable(uniqid()))->isInstanceOf('mageekguy\atoum\asserters\variable')
+				->object($generator->variable(uniqid()))->isInstanceOf('atoum\asserters\variable')
 		;
 	}
 
@@ -134,7 +134,7 @@ class generator extends atoum\test
 			->and($generator->setAdapter($adapter = new atoum\test\adapter()))
 			->and($adapter->class_exists = true)
 			->then
-				->string($generator->getAsserterClass($asserter = uniqid()))->isEqualTo('mageekguy\atoum\asserters\\' . $asserter)
+				->string($generator->getAsserterClass($asserter = uniqid()))->isEqualTo('atoum\asserters\\' . $asserter)
 				->string($generator->getAsserterClass('\\' . $asserter))->isEqualTo('\\' . $asserter)
 			->if($generator->setAlias($alias = uniqid(), $asserter))
 			->then

--- a/tests/units/classes/asserters/adapter.php
+++ b/tests/units/classes/asserters/adapter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\adapter as sut
+	atoum,
+	atoum\php,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters\adapter as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -16,7 +16,7 @@ class adapter extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -42,7 +42,7 @@ class adapter extends atoum\test
 			->then
 				->assert('Set the asserter with something else than an adapter throw an exception')
 					->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not a test adapter'), $asserter->getTypeOf($value)))
 					->string($asserter->getAdapter())->isEqualTo($value)
 				->assert('It is possible to set the asserter with an adapter')
@@ -79,10 +79,10 @@ class adapter extends atoum\test
 	public function testCall()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->call(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -99,15 +99,15 @@ class adapter extends atoum\test
 	public function testWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -123,15 +123,15 @@ class adapter extends atoum\test
 	public function testWithAnyArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -149,15 +149,15 @@ class adapter extends atoum\test
 	public function testWithoutAnyArgument()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\adapter(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -173,7 +173,7 @@ class adapter extends atoum\test
 			->and($asserter = new sut(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, $mock) { $asserter->beforeMethodCall(uniqid(), $mock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -213,7 +213,7 @@ class adapter extends atoum\test
 			->and($asserter = new sut(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, $mock) { $asserter->afterMethodCall(uniqid(), $mock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 				->if($asserter->setWith($adapter = new test\adapter()))
 				->then
@@ -256,7 +256,7 @@ class adapter extends atoum\test
 			->and($asserter = new sut(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -299,7 +299,7 @@ class adapter extends atoum\test
 			->and($asserter = new sut(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
@@ -338,17 +338,17 @@ class adapter extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($firstArgument = uniqid()))
@@ -357,7 +357,7 @@ class adapter extends atoum\test
 			->if($adapter->md5($secondArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
@@ -367,7 +367,7 @@ class adapter extends atoum\test
 			->if($asserter->withArguments(uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -378,23 +378,23 @@ class adapter extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($firstArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
 			->if($adapter->md5($secondArgument = uniqid()))
 			->then
@@ -402,19 +402,19 @@ class adapter extends atoum\test
 			->if($adapter->md5($thirdArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
 			->and($adapter->md5($arg))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					 ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($asserter->withArguments(uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -425,28 +425,28 @@ class adapter extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($firstArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
 			->if($adapter->md5($secondArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
 			->if($adapter->md5($thirdArgument = uniqid()))
 			->then
@@ -454,19 +454,19 @@ class adapter extends atoum\test
 			->if($adapter->md5($fourthArgument = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArgument)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
 			->and($adapter->md5($arg))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($asserter->withArguments(uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -477,17 +477,17 @@ class adapter extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
 			->if($adapter->md5(uniqid()))
 			->then
@@ -499,7 +499,7 @@ class adapter extends atoum\test
 			->and($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($arg))
@@ -508,7 +508,7 @@ class adapter extends atoum\test
 			->if($asserter->withArguments(uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -519,23 +519,23 @@ class adapter extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($asserter->call('md5'))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($call = new php\call('md5'))
 			->and($adapter->md5($arg = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($adapter->md5($otherArg = uniqid()))
 			->then
@@ -543,23 +543,23 @@ class adapter extends atoum\test
 			->if($adapter->md5($anOtherArg = uniqid()))
 			->then
 				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($anOtherArg)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($adapter->md5($usedArg = uniqid()))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($adapter->md5($arg))
 			->then
@@ -567,7 +567,7 @@ class adapter extends atoum\test
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $anAnotherLine, $asserter) { $anAnotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg))  . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
 		;
 	}
@@ -578,12 +578,12 @@ class adapter extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
 			->if($call = new php\call('md5'))
 			->and($asserter->call('md5'))
@@ -592,7 +592,7 @@ class adapter extends atoum\test
 			->if($adapter->md5($usedArg = uniqid()))
 			->then
 					->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($adapter->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
@@ -601,12 +601,12 @@ class adapter extends atoum\test
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($adapter->md5($arg))
 			->then
 				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($asserter->withArguments(uniqid()))
 			->then

--- a/tests/units/classes/asserters/adapter/call/adapter.php
+++ b/tests/units/classes/asserters/adapter/call/adapter.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\adapter\call;
+namespace atoum\tests\units\asserters\adapter\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\adapter\call
+	atoum,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\adapter\call
 ;
 
 class adapter extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\php\call');
+		$this->testedClass->extends('atoum\php\call');
 	}
 
 	public function test__construct()
@@ -40,7 +40,7 @@ class adapter extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\adapter($adapterAsserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), new test\adapter(), uniqid()))
+			->if($call = new call\adapter($adapterAsserter = new \mock\atoum\asserters\adapter(new asserter\generator()), new test\adapter(), uniqid()))
 			->and($adapterAsserter->getMockController()->call = $adapterAsserter)
 			->then
 				->object($call->call($arg = uniqid()))->isIdenticalTo($adapterAsserter)
@@ -49,7 +49,7 @@ class adapter extends atoum\test
 			->if($unknownFunction = uniqid())
 			->then
 				->exception(function() use ($call, $unknownFunction) { $call->{$unknownFunction}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Method ' . get_class($adapterAsserter) . '::' . $unknownFunction . '() does not exist')
 		;
 	}

--- a/tests/units/classes/asserters/adapter/call/mock.php
+++ b/tests/units/classes/asserters/adapter/call/mock.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\adapter\call;
+namespace atoum\tests\units\asserters\adapter\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\adapter\call
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\adapter\call
 ;
 
 class mock extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\php\call');
+		$this->testedClass->extends('atoum\php\call');
 	}
 
 	public function test__construct()
@@ -39,7 +39,7 @@ class mock extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\mock($adapterAsserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), new \mock\dummy(), uniqid()))
+			->if($call = new call\mock($adapterAsserter = new \mock\atoum\asserters\adapter(new asserter\generator()), new \mock\dummy(), uniqid()))
 			->and($adapterAsserter->getMockController()->call = $adapterAsserter)
 			->then
 				->object($call->call($arg = uniqid()))->isIdenticalTo($adapterAsserter)
@@ -48,7 +48,7 @@ class mock extends atoum\test
 			->if($unknownMethod = uniqid())
 			->then
 				->exception(function() use ($call, $unknownMethod) { $call->{$unknownMethod}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Method ' . get_class($adapterAsserter) . '::' . $unknownMethod . '() does not exist')
 		;
 	}
@@ -56,7 +56,7 @@ class mock extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($call = new call\mock(new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), $mockAggregator = new \mock\dummy(), $function = uniqid()))
+			->if($call = new call\mock(new \mock\atoum\asserters\adapter(new asserter\generator()), $mockAggregator = new \mock\dummy(), $function = uniqid()))
 			->then
 				->castToString($call)->isEqualTo(get_class($mockAggregator) . '::' . $function . '()')
 		;

--- a/tests/units/classes/asserters/boolean.php
+++ b/tests/units/classes/asserters/boolean.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\boolean as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\boolean as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class boolean extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -45,7 +45,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isTrue(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not true'), $asserter) . PHP_EOL . $diff->setExpected(true)->setActual(false))
 			->if($asserter->setWith(true))
 			->then
@@ -54,7 +54,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isTrue; })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not true'), $asserter) . PHP_EOL . $diff->setExpected(true)->setActual(false))
 		;
 	}
@@ -74,7 +74,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isFalse(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not false'), $asserter) . PHP_EOL . $diff->setExpected(false)->setActual(true))
 			->if($asserter->setWith(false))
 			->then
@@ -83,7 +83,7 @@ class boolean extends atoum\test
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isFalse; })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not false'), $asserter) . PHP_EOL . $diff->setExpected(false)->setActual(true))
 		;
 	}
@@ -95,7 +95,7 @@ class boolean extends atoum\test
 			->then
 				->assert('Set the asserter with something else than a boolean throw an exception')
 					->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not a boolean'), $asserter->getTypeOf($value)))
 				->assert('The asserter was returned when it set with a boolean')
 					->string($asserter->getValue())->isEqualTo($value)

--- a/tests/units/classes/asserters/castToString.php
+++ b/tests/units/classes/asserters/castToString.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\castToString as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\castToString as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class castToString extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\string');
+		$this->testedClass->isSubclassOf('atoum\asserters\string');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class castToString extends atoum\test
 			->then
 				->assert('Set the asserter with something else than an object throw an exception')
 					->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not an object'), $asserter->getTypeOf($value)))
 					->integer($asserter->getValue())->isEqualTo($value)
 					->variable($asserter->getCharlist())->isNull()

--- a/tests/units/classes/asserters/dateInterval.php
+++ b/tests/units/classes/asserters/dateInterval.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\dateInterval as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\dateInterval as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class dateInterval extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\object');
+		$this->testedClass->isSubclassOf('atoum\asserters\object');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class dateInterval extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->assert('Set the asserter with something else than a date interval trown an exception')
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of \\dateInterval'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->assert('The asserter was returned when it set with a date time')
@@ -52,16 +52,16 @@ class dateInterval extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 				->exception(function() use ($asserter) { $asserter->isGreaterThan(new \DateInterval('P1D')); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Interval is undefined')
 			->if($asserter->setWith(new \DateInterval('P1Y')))
 			->then
 				->object($asserter->isGreaterThan(new \DateInterval('P1M')))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $interval) { $asserter->isGreaterThan($interval = new \DateInterval('P2Y')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not greater than ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 				->exception(function() use ($asserter, & $interval) { $asserter->isGreaterThan($interval = new \DateInterval('P1Y')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not greater than ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 		;
 	}
@@ -71,14 +71,14 @@ class dateInterval extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 				->exception(function() use ($asserter) { $asserter->isGreaterThanOrEqualTo(new \DateInterval('P1D')); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Interval is undefined')
 			->if($asserter->setWith(new \DateInterval('P1Y')))
 			->then
 				->object($asserter->isGreaterThanOrEqualTo(new \DateInterval('P1M')))->isIdenticalTo($asserter)
 				->object($asserter->isGreaterThanOrEqualTo(new \DateInterval('P1Y')))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $interval) { $asserter->isGreaterThanOrEqualTo($interval = new \DateInterval('P2Y')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not greater than or equal to ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 		;
 	}
@@ -89,7 +89,7 @@ class dateInterval extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isZero(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Interval is undefined')
 			->if($asserter->setWith(new \DateInterval('P0Y')))
 			->then
@@ -97,7 +97,7 @@ class dateInterval extends atoum\test
 			->if($asserter->setWith($interval = new \DateInterval('P1Y')))
 			->then
 				->exception(function() use ($asserter) { $asserter->isZero(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not equal to zero')
 		;
 	}
@@ -107,16 +107,16 @@ class dateInterval extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 				->exception(function() use ($asserter) { $asserter->isLessThan(new \DateInterval('P1D')); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Interval is undefined')
 			->if($asserter->setWith(new \dateInterval('P2D')))
 			->then
 				->object($asserter->isLessThan(new \dateInterval('P1M')))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $interval) { $asserter->isLessThan($interval = new \dateInterval('P1D')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not less than ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 				->exception(function() use ($asserter, & $interval) { $asserter->isLessThan($interval = new \dateInterval('P2D')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not less than ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 		;
 	}
@@ -126,14 +126,14 @@ class dateInterval extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 				->exception(function() use ($asserter) { $asserter->isLessThanOrEqualTo(new \DateInterval('P1D')); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Interval is undefined')
 			->if($asserter->setWith(new \dateInterval('P2D')))
 			->then
 				->object($asserter->isLessThanOrEqualTo(new \dateInterval('P1M')))->isIdenticalTo($asserter)
 				->object($asserter->isLessThanOrEqualTo(new \dateInterval('P2D')))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $interval) { $asserter->isLessThanOrEqualTo($interval = new \dateInterval('P1D')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not less than or equal to ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 		;
 	}
@@ -143,16 +143,16 @@ class dateInterval extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 				->exception(function() use ($asserter) { $asserter->isEqualTo(new \dateInterval('P1D')); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Interval is undefined')
 			->if($asserter->setWith(new \DateInterval('P1D')))
 				->then
 				->object($asserter->isEqualTo(new \DateInterval('P1D')))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $interval) { $asserter->isEqualTo($interval = new \dateInterval('PT1S')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not equal to ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 				->exception(function() use ($asserter, & $interval) { $asserter->isEqualTo($interval = new \dateInterval('P2D')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage('Interval ' . $asserter . ' is not equal to ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 		;
 	}

--- a/tests/units/classes/asserters/dateTime.php
+++ b/tests/units/classes/asserters/dateTime.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\dateTime as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\dateTime as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class dateTime extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\object');
+		$this->testedClass->isSubclassOf('atoum\asserters\object');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class dateTime extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->assert('Set the asserter with something else than a date time trown an exception')
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of \\dateTime'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->assert('The asserter was returned when it set with a date time')
@@ -52,12 +52,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('now', $timezone = new \DateTimezone('Europe/Paris'))))
 			->then
 				->exception(function() use (& $line, & $requiredTimezone, $asserter) { $line = __LINE__; $asserter->hasTimezone($requiredTimezone = new \DateTimezone('Europe/London')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Timezone is %s instead of %s'), $timezone->getName(), $requiredTimezone->getName()))
 				->object($asserter->hasTimezone($dateTime->getTimezone()))->isIdenticalTo($asserter);
 		;
@@ -68,15 +68,15 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasYear(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasYear(1981); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Year is %s instead of %s'), 1976, 1981))
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasYear(76); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Year is %s instead of %s'), 1976, 76))
 				->object($asserter->hasYear('1976'))->isIdenticalTo($asserter)
 				->object($asserter->hasYear(1976))->isIdenticalTo($asserter)
@@ -88,12 +88,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasMonth(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('1976-09-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasMonth(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Month is %02d instead of %02d'), 9, 1))
 				->object($asserter->hasMonth(9))->isIdenticalTo($asserter)
 			->if($asserter->setWith($dateTime = new \DateTime('1980-08-14')))
@@ -109,12 +109,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasDay(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasDay(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Day is %02d instead of %02d'), 6, 1))
 				->object($asserter->hasDay('06'))->isIdenticalTo($asserter)
 				->object($asserter->hasDay('6'))->isIdenticalTo($asserter)
@@ -128,12 +128,12 @@ class dateTime extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasDate(1976, 10, 6); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('1976-10-06')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasDate(1980, 8, 14); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Date is %s instead of %s'), '1976-10-06', '1980-08-14'))
 				->object($asserter->hasDate(1976, 10, 6))->isIdenticalTo($asserter)
 				->object($asserter->hasDate('1976', '10', '6'))->isIdenticalTo($asserter)
@@ -146,12 +146,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasHours(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('01:02:03')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasHours(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Hours are %02d instead of %02d'), 1, 2))
 				->object($asserter->hasHours('01'))->isIdenticalTo($asserter)
 				->object($asserter->hasHours('1'))->isIdenticalTo($asserter)
@@ -164,12 +164,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasMinutes(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('01:02:03')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasMinutes(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Minutes are %02d instead of %02d'), 2, 1))
 				->object($asserter->hasMinutes('02'))->isIdenticalTo($asserter)
 				->object($asserter->hasMinutes('2'))->isIdenticalTo($asserter)
@@ -182,12 +182,12 @@ class dateTime extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use ($asserter) { $asserter->hasSeconds(rand(0, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('01:02:03')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasSeconds(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Seconds are %02d instead of %02d'), 3, 1))
 				->object($asserter->hasSeconds('03'))->isIdenticalTo($asserter)
 				->object($asserter->hasSeconds('3'))->isIdenticalTo($asserter)
@@ -201,12 +201,12 @@ class dateTime extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasTime(1, 2, 3); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('01:02:03')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasTime(4, 5, 6); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Time is %s instead of %s'), '01:02:03', '04:05:06'))
 				->object($asserter->hasTime('01', '02', '03'))->isIdenticalTo($asserter)
 				->object($asserter->hasTime('1', '2', '3'))->isIdenticalTo($asserter)
@@ -220,12 +220,12 @@ class dateTime extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasDateAndTime(1981, 2, 13, 1, 2, 3); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Instance of \\dateTime is undefined')
 			->if($asserter->setWith($dateTime = new \DateTime('1981-02-13 01:02:03')))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->hasDateAndTime(1900, 1, 1, 4, 5, 6); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Datetime is %s instead of %s'), '1981-02-13 01:02:03', '1900-01-01 04:05:06'))
 				->object($asserter->hasDateAndTime('1981', '02', '13', '01', '02', '03'))->isIdenticalTo($asserter)
 				->object($asserter->hasDateAndTime('1981', '2', '13', '1', '2', '3'))->isIdenticalTo($asserter)

--- a/tests/units/classes/asserters/error.php
+++ b/tests/units/classes/asserters/error.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\error as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\error as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class error extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserter');
+		$this->testedClass->extends('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -24,7 +24,7 @@ class error extends atoum\test
 			->then
 				->object($asserter->getGenerator())->isEqualTo(new asserter\generator())
 				->object($asserter->getLocale())->isIdenticalTo($asserter->getGenerator()->getLocale())
-				->object($asserter->getScore())->isInstanceOf('mageekguy\atoum\test\score')
+				->object($asserter->getScore())->isInstanceOf('atoum\test\score')
 				->variable($asserter->getMessage())->isNull()
 				->variable($asserter->getType())->isNull()
 			->if($asserter = new sut($generator = new asserter\generator(), $score = new atoum\test\score()))
@@ -93,7 +93,7 @@ class error extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use (& $line, $asserter) { $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('error does not exist'))
 			->if($asserter->getScore()->addError(uniqid(), uniqid(), uniqid(), rand(1, PHP_INT_MAX), rand(0, PHP_INT_MAX), uniqid(), uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -102,7 +102,7 @@ class error extends atoum\test
 			->if($asserter->setWith($message = uniqid(), null))
 			->then
 				->exception(function() use (& $line, $asserter) { $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('error with message \'%s\' does not exist'), $message))
 			->if($asserter->getScore()->addError(uniqid(), uniqid(), uniqid(), rand(1, PHP_INT_MAX), rand(0, PHP_INT_MAX), $message, uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -111,7 +111,7 @@ class error extends atoum\test
 			->if($asserter->setWith($message = uniqid(), $type = E_USER_ERROR))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('error of type %s with message \'%s\' does not exist'), sut::getAsString($type), $message))
 			->if($asserter->getScore()->addError(uniqid(), uniqid(), uniqid(), rand(1, PHP_INT_MAX), $type, $message, uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -120,7 +120,7 @@ class error extends atoum\test
 			->if($asserter->setWith(null, $type = E_USER_ERROR))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exists(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('error of type %s does not exist'), sut::getAsString($type)))
 			->if($asserter->getScore()->addError(uniqid(), uniqid(), uniqid(), rand(1, PHP_INT_MAX), $type, uniqid(), uniqid(), rand(1, PHP_INT_MAX)))
 			->then
@@ -211,7 +211,7 @@ class error extends atoum\test
 				->object($asserter->setScore())->isIdenticalTo($asserter)
 				->object($asserter->getScore())
 					->isNotIdenticalTo($score)
-					->isInstanceOf('mageekguy\atoum\score')
+					->isInstanceOf('atoum\score')
 		;
 	}
 }

--- a/tests/units/classes/asserters/exception.php
+++ b/tests/units/classes/asserters/exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\exception as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\exception as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class exception extends atoum\test
 			->then
 				->assert('It is impossible to set asserter with something else than an exception')
 					->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not an exception'), $asserter->getTypeOf($value)))
 					->string($asserter->getValue())->isEqualTo($value)
 				->assert('The asserter was returned when it set with an exception')
@@ -51,7 +51,7 @@ class exception extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Exception is undefined')
 			->if($asserter->setWith(new \exception()))
 			->then
@@ -60,11 +60,11 @@ class exception extends atoum\test
 				->object($asserter->isInstanceOf('\exception'))->isIdenticalTo($asserter)
 				->object($asserter->isInstanceOf('exception'))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->isInstanceOf(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
-					->hasMessage('Argument of mageekguy\atoum\asserters\exception::isInstanceOf() must be a \exception instance or an exception class name')
-				->exception(function() use ($asserter) { $asserter->isInstanceOf('mageekguy\atoum\exceptions\runtime'); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of mageekguy\atoum\exceptions\runtime'), $asserter))
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
+					->hasMessage('Argument of atoum\asserters\exception::isInstanceOf() must be a \exception instance or an exception class name')
+				->exception(function() use ($asserter) { $asserter->isInstanceOf('atoum\exceptions\runtime'); })
+					->isInstanceOf('atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('%s is not an instance of atoum\exceptions\runtime'), $asserter))
 		;
 	}
 
@@ -80,7 +80,7 @@ class exception extends atoum\test
 			->if($asserter->setWith(new atoum\exceptions\runtime(uniqid(), $code = rand(2, PHP_INT_MAX))))
 			->then
 				->exception(function() use ($asserter, & $otherCode) { $asserter->hasCode($otherCode = 1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('code is %d instead of %d'), $code, $otherCode))
 			->object($asserter->hasCode($code))->isIdenticalTo($asserter)
 		;
@@ -98,7 +98,7 @@ class exception extends atoum\test
 			->if($asserter->setWith(new atoum\exceptions\runtime($message = uniqid())))
 			->then
 				->exception(function() use ($asserter, & $otherMessage) { $asserter->hasMessage($otherMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('message \'%s\' is not identical to \'%s\''), $message, $otherMessage))
 				->object($asserter->hasMessage($message))->isIdenticalTo($asserter)
 		;
@@ -116,17 +116,17 @@ class exception extends atoum\test
 			->if($asserter->setWith(new atoum\exceptions\runtime('', 0)))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasNestedException(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('exception does not contain any nested exception'))
 				->exception(function() use ($asserter) { $asserter->hasNestedException(new \exception()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('exception does not contain this nested exception'))
 			->if($asserter->setWith(new atoum\exceptions\runtime('', 0, $nestedException = new \exception())))
 			->then
 				->object($asserter->hasNestedException())->isIdenticalTo($asserter)
 				->object($asserter->hasNestedException($nestedException))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->hasNestedException(new \exception()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('exception does not contain this nested exception'))
 		;
 	}
@@ -137,18 +137,18 @@ class exception extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->message; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Exception is undefined')
 			->if($asserter->setWith(new atoum\exceptions\runtime('', 0)))
 			->then
 				->object($string = $asserter->message)
-					->isInstanceOf('mageekguy\atoum\asserters\string')
+					->isInstanceOf('atoum\asserters\string')
 				->string($string->getValue())
 					->isEqualTo('')
 			->if($asserter->setWith(new atoum\exceptions\runtime('Exception message', 0)))
 			->then
 				->object($string = $asserter->message)
-					->isInstanceOf('mageekguy\atoum\asserters\string')
+					->isInstanceOf('atoum\asserters\string')
 				->string($string->getValue())
 					->isEqualTo('Exception message')
 		;

--- a/tests/units/classes/asserters/extension.php
+++ b/tests/units/classes/asserters/extension.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\extension as sut // use sut here instead of testedClass because atoum\asserters\testedClass exists !
+	atoum,
+	atoum\asserter,
+	atoum\asserters\extension as sut // use sut here instead of testedClass because atoum\asserters\testedClass exists !
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class extension extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserter');
+		$this->testedClass->extends('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -94,7 +94,7 @@ class extension extends atoum\test
 						$asserter->isLoaded();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Name of PHP extension is undefined')
 			->if($asserter->setAdapter($adapter = new atoum\test\adapter()))
 			->and($adapter->extension_loaded = false)
@@ -104,7 +104,7 @@ class extension extends atoum\test
 						$asserter->isLoaded();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\exceptions\skip')
+					->isInstanceOf('atoum\test\exceptions\skip')
 					->hasMessage('PHP extension \'' . $extensionName . '\' is not loaded')
 			->if($adapter->extension_loaded = true)
 			->then

--- a/tests/units/classes/asserters/float.php
+++ b/tests/units/classes/asserters/float.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\float as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\float as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class float extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\integer');
+		$this->testedClass->isSubclassOf('atoum\asserters\integer');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class float extends atoum\test
 		$this
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = uniqid()); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
+				->isInstanceOf('atoum\asserter\exception')
 				->hasMessage(sprintf($generator->getLocale()->_('%s is not a float'), $asserter->getTypeOf($value)))
 			->string($asserter->getValue())->isEqualTo($value)
 			->object($asserter->setWith($value = (float) rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($asserter)
@@ -51,13 +51,13 @@ class float extends atoum\test
 			->then
 				->object($asserter->isEqualTo($value))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $notFloat) { $asserter->isEqualTo($notFloat = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Argument of ' . get_class($asserter) . '::isEqualTo() must be a float')
 			->if($diff = new diffs\variable())
 			->and($diff->setExpected(- $value)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isEqualTo(- $value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf(- $value)) . PHP_EOL . $diff)
 		;
 	}
@@ -70,10 +70,10 @@ class float extends atoum\test
 			->then
 				->object($asserter->isGreaterThan(1.1))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $notFloat) { $asserter->isGreaterThan($notFloat = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Argument of ' . get_class($asserter) . '::isGreaterThan() must be a float')
 				->exception(function() use ($asserter, & $greaterValue) { $asserter->isGreaterThan($greaterValue = 1.3); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than %s'), $asserter, $asserter->getTypeOf($greaterValue)))
 		;
 	}
@@ -86,10 +86,10 @@ class float extends atoum\test
 			->then
 				->object($asserter->isLessThan(1.3))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $notFloat) { $asserter->isLessThan($notFloat = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Argument of ' . get_class($asserter) . '::isLessThan() must be a float')
 				->exception(function() use ($asserter, & $lessValue) { $asserter->isLessThan($lessValue = 1.1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not less than %s'), $asserter, $asserter->getTypeOf($lessValue)))
 		;
 	}
@@ -103,10 +103,10 @@ class float extends atoum\test
 				->object($asserter->isGreaterThanOrEqualTo(1.1))->isIdenticalTo($asserter)
 				->object($asserter->isGreaterThanOrEqualTo($value))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $notFloat) { $asserter->isGreaterThanOrEqualTo($notFloat = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Argument of ' . get_class($asserter) . '::isGreaterThanOrEqualTo() must be a float')
 				->exception(function() use ($asserter, & $greaterValue) { $asserter->isGreaterThanOrEqualTo($greaterValue = 1.3); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than or equal to %s'), $asserter, $asserter->getTypeOf($greaterValue)))
 		;
 	}
@@ -120,10 +120,10 @@ class float extends atoum\test
 				->object($asserter->isLessThanOrEqualTo(1.3))->isIdenticalTo($asserter)
 				->object($asserter->isLessThanOrEqualTo($value))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $notFloat) { $asserter->isLessThanOrEqualTo($notFloat = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Argument of ' . get_class($asserter) . '::isLessThanOrEqualTo() must be a float')
 				->exception(function() use ($asserter, & $lessValue) { $asserter->isLessThanOrEqualTo($lessValue = 1.1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not less than or equal to %s'), $asserter, $asserter->getTypeOf($lessValue)))
 		;
 	}
@@ -145,7 +145,7 @@ class float extends atoum\test
 					->and($diff->setExpected($testValue)->setActual($value))
 					->then
 						->exception(function() use ($asserter, $testValue, $epsilon) { $asserter->isNearlyEqualTo($testValue, $epsilon); })
-							->isInstanceOf('mageekguy\atoum\asserter\exception')
+							->isInstanceOf('atoum\asserter\exception')
 							->hasMessage(sprintf($generator->getLocale()->_('%s is not nearly equal to %s with epsilon %s'), $asserter, $asserter->getTypeOf($testValue), $epsilon) . PHP_EOL . $diff);
 			}
 

--- a/tests/units/classes/asserters/hash.php
+++ b/tests/units/classes/asserters/hash.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\hash as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\hash as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class hash extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\string');
+		$this->testedClass->isSubclassOf('atoum\asserters\string');
 	}
 
 	public function testIsSha1()
@@ -33,14 +33,14 @@ class hash extends atoum\test
 			->and($diff->setExpected( $newvalue )->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha1(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setExpected($newvalue)->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha1(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
@@ -60,14 +60,14 @@ class hash extends atoum\test
 			->and($diff->setExpected( $newvalue )->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha256(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setExpected($newvalue)->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha256(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
@@ -87,14 +87,14 @@ class hash extends atoum\test
 			->and($diff->setExpected( $newvalue )->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha512(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setExpected($newvalue)->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isSha512(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
@@ -114,14 +114,14 @@ class hash extends atoum\test
 			->and($diff->setExpected( $newvalue )->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isMd5(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('%s should be a string of %d characters'), $asserter, strlen($value)))
 			->if($asserter->setWith($newvalue = 'z'.substr($value, 1) ))
 			->and($diff = new diffs\variable())
 			->and($diff->setExpected($newvalue)->setActual($value))
 			->then
 				->exception(function() use ($asserter, & $line) { $line = __LINE__; $asserter->isMd5(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}

--- a/tests/units/classes/asserters/integer.php
+++ b/tests/units/classes/asserters/integer.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\integer as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\integer as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class integer extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -36,7 +36,7 @@ class integer extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an integer'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->object($asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($asserter)
@@ -55,7 +55,7 @@ class integer extends atoum\test
 			->and($diff->setExpected(- $value)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isEqualTo(- $value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf(- $value)) . PHP_EOL . $diff)
 		;
 	}
@@ -71,13 +71,13 @@ class integer extends atoum\test
 			->and($diff->setExpected(PHP_INT_MAX)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isGreaterThan(PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than %s'), $asserter, $asserter->getTypeOf(PHP_INT_MAX)))
 			->if($diff = new diffs\variable())
 			->and($diff->setExpected($value)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isGreaterThan($value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -93,13 +93,13 @@ class integer extends atoum\test
 			->and($diff->setExpected(- PHP_INT_MAX)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLessThan(- PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not less than %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 			->if($diff = new diffs\variable())
 			->and($diff->setExpected($value)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLessThan($value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not less than %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -116,7 +116,7 @@ class integer extends atoum\test
 			->and($diff->setExpected(PHP_INT_MAX)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $line = __LINE__; $asserter->isGreaterThanOrEqualTo(PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not greater than or equal to %s'), $asserter, $asserter->getTypeOf(PHP_INT_MAX)))
 		;
 	}
@@ -133,7 +133,7 @@ class integer extends atoum\test
 			->and($diff->setExpected(- PHP_INT_MAX)->setActual($value))
 			->then
 				->exception(function() use ($asserter, $value) { $asserter->isLessThanOrEqualTo(- PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not less than or equal to %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 		;
 	}

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\mock as sut
+	atoum,
+	atoum\php,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters\mock as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -23,7 +23,7 @@ class mock extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -43,13 +43,13 @@ class mock extends atoum\test
 	public function testReset()
 	{
 		$this
-			->if($mockController = new \mock\mageekguy\atoum\mock\controller())
+			->if($mockController = new \mock\atoum\mock\controller())
 			->and($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->variable($asserter->getMock())->isNull()
 				->object($asserter->reset())->isIdenticalTo($asserter)
 				->variable($asserter->getMock())->isNull()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\score()))
+			->if($asserter->setWith($mock = new \mock\atoum\score()))
 			->and($mock->setMockController($mockController))
 			->and($this->resetMock($mockController))
 			->then
@@ -67,9 +67,9 @@ class mock extends atoum\test
 			->and($adapter->class_exists = true)
 			->then
 				->exception(function() use ($asserter, & $mock) { $asserter->setWith($mock = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a mock'), $asserter->getTypeOf($mock)))
-				->object($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\mock($adapter)))->isIdenticalTo($asserter)
+				->object($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\mock($adapter)))->isIdenticalTo($asserter)
 				->object($asserter->getMock())->isIdenticalTo($mock)
 		;
 	}
@@ -80,18 +80,18 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 				->then
 					->exception(function() use ($asserter) { $asserter->wasCalled(); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic')
+						->isInstanceOf('atoum\exceptions\logic')
 						->hasMessage('Mock is undefined')
 				->if($adapter = new atoum\test\adapter())
 				->and($adapter->class_exists = true)
-				->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\mock($adapter)))
+				->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\mock($adapter)))
 				->and($mock->getMockController()->resetCalls())
 				->then
 					->exception(function() use ($asserter) { $asserter->wasCalled(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is not called'), get_class($mock)))
 					->exception(function() use ($asserter, & $failMessage) { $asserter->wasCalled($failMessage = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($failMessage)
 				->if($mock->getMockController()->{$method = __FUNCTION__} = function() {})
 				->and($mock->{$method}())
@@ -106,11 +106,11 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->wasNotCalled(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\mock($adapter)))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\mock($adapter)))
 			->and($mock->getMockController()->resetCalls())
 			->then
 				->object($asserter->wasNotCalled())->isIdenticalTo($asserter)
@@ -118,7 +118,7 @@ class mock extends atoum\test
 			->and($mock->{$method}())
 			->then
 				->exception(function() use ($asserter, & $failMessage) { $asserter->wasNotCalled($failMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage)
 		;
 	}
@@ -129,9 +129,9 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeMethodCall(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->object($asserter->beforeMethodCall('foo'))->isEqualTo($beforeMethodCall = new sut\call\mock($asserter, $mock, 'foo'))
 				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
@@ -148,7 +148,7 @@ class mock extends atoum\test
 				->array($asserter->getBeforeMethodCalls())->isEmpty()
 				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
 				->array($asserter->getBeforeMethodCalls())->isEmpty()
-			->if($asserter->setWith(new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith(new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall(uniqid()))
 			->then
 				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
@@ -171,9 +171,9 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterMethodCall(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->object($asserter->afterMethodCall('foo'))->isEqualTo($afterMethodCall = new sut\call\mock($asserter, $mock, 'foo'))
 				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
@@ -190,7 +190,7 @@ class mock extends atoum\test
 				->array($asserter->getAfterMethodCalls())->isEmpty()
 				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
 				->array($asserter->getAfterMethodCalls())->isEmpty()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->afterMethodCall($function = uniqid()))
 			->then
 				->array($asserter->getAfterMethodCalls())->isNotEmpty()
@@ -213,9 +213,9 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->then
 				->object($asserter->beforeFunctionCall('foo', $adapter))->isEqualTo($beforeFunctionCall = new sut\call\adapter($asserter, $adapter, 'foo'))
@@ -233,7 +233,7 @@ class mock extends atoum\test
 				->array($asserter->getBeforeFunctionCalls())->isEmpty()
 				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
 				->array($asserter->getBeforeFunctionCalls())->isEmpty()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->and($asserter->beforeFunctionCall($function = uniqid(), $adapter))
 			->then
@@ -257,9 +257,9 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->then
 				->object($asserter->afterFunctionCall('foo', $adapter))->isEqualTo($afterFunctionCall = new sut\call\adapter($asserter, $adapter, 'foo'))
@@ -277,7 +277,7 @@ class mock extends atoum\test
 				->array($asserter->getAfterFunctionCalls())->isEmpty()
 				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
 				->array($asserter->getAfterFunctionCalls())->isEmpty()
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->and($asserter->afterFunctionCall($function = uniqid(), $adapter))
 			->then
@@ -298,12 +298,12 @@ class mock extends atoum\test
 	public function testCall()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->call(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter)
 			->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
@@ -318,15 +318,15 @@ class mock extends atoum\test
 	public function testWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -342,15 +342,15 @@ class mock extends atoum\test
 	public function testWithAtLeastArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -364,15 +364,15 @@ class mock extends atoum\test
 	public function testWithAnyArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -390,15 +390,15 @@ class mock extends atoum\test
 	public function testWithoutAnyArgument()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new \mock\atoum\asserters\mock(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
@@ -413,17 +413,17 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->and($mock->foo($usedArg = uniqid()))
@@ -432,7 +432,7 @@ class mock extends atoum\test
 			->if($mock->foo($otherUsedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($usedArg = uniqid()))
@@ -442,14 +442,14 @@ class mock extends atoum\test
 			->if($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($mock->foo(uniqid()))
 				->object($asserter->once())->isIdenticalTo($asserter)
@@ -459,7 +459,7 @@ class mock extends atoum\test
 			->and($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called before method %s'), $asserter->getCall(), current($asserter->getBeforeMethodCalls())))
 			*/
 			->if($mock->getMockController()->resetCalls())
@@ -468,24 +468,24 @@ class mock extends atoum\test
 			->then
 				->object($asserter->once())->isIdenticalTo($asserter)
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->afterMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			/*
 			->if($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getAfterMethodCalls())))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->foo(uniqid()))
 			->and($mock->bar(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called after method %s'), $asserter->getCall(), current($asserter->getAfterMethodCalls())))
 			*/
 			->if($mock->getMockController()->resetCalls())
@@ -494,12 +494,12 @@ class mock extends atoum\test
 			->then
 				->object($asserter->once())->isIdenticalTo($asserter)
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
 			->and($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
 		;
 	}
@@ -510,23 +510,23 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($secondArg = uniqid()))
 			->then
@@ -534,18 +534,18 @@ class mock extends atoum\test
 			->if($mock->foo($thirdArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($mock->foo($usedArg))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($usedArg))
 			->then
@@ -553,23 +553,23 @@ class mock extends atoum\test
 			->if($mock->foo($usedArg))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
 			->if($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($mock->foo($usedArg = uniqid()))
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo(uniqid()))
 				->object($asserter->twice())->isIdenticalTo($asserter)
@@ -578,36 +578,36 @@ class mock extends atoum\test
 			->and($mock->bar(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($usedArg = uniqid()))
 			->and($mock->bar(uniqid()))
 			->then
 				->object($asserter->twice())->isIdenticalTo($asserter)
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->afterMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->bar(uniqid()))
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo(uniqid()))
 			->then
 				->object($asserter->twice())->isIdenticalTo($asserter)
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
 			->and($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
 			->and($mock->foo(uniqid()))
 			->if($mock->bar($arg))
@@ -622,28 +622,28 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($secondArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
 			->if($mock->foo($thirdArg = uniqid()))
 			->then
@@ -651,23 +651,23 @@ class mock extends atoum\test
 			->if($mock->foo($fourthArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
 			->if($mock->foo($usedArg))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($usedArg))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($usedArg))
 			->then
@@ -675,29 +675,29 @@ class mock extends atoum\test
 			->if($mock->foo($usedArg))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
 			->if($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
 			->if($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($usedArg))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo(uniqid()))
 			->then
@@ -707,53 +707,53 @@ class mock extends atoum\test
 			->and($mock->bar(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
 			->if($mock->foo($secondArg = uniqid()))
 			->and($mock->bar(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
 			->if($mock->foo(uniqid()))
 			->and($mock->bar(uniqid()))
 			->then
 				->object($asserter->thrice())->isIdenticalTo($asserter)
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->afterMethodCall('bar')->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
 			->if($mock->getMockController()->resetCalls())
 			->and($mock->bar(uniqid()))
 			->and($mock->foo($firstArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
 			->if($mock->bar(uniqid()))
 			->and($mock->foo($secondArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
 			->if($mock->foo(uniqid()))
 			->then
 				->object($asserter->thrice())->isIdenticalTo($asserter)
 			->if($asserter = new sut($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
 			->and($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
 			->if($mock->foo(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
 			->and($mock->foo(uniqid()))
 			->if($mock->bar($arg))
@@ -769,17 +769,17 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
 			->if($mock->foo(uniqid()))
 			->then
@@ -791,7 +791,7 @@ class mock extends atoum\test
 			->and($asserter->withArguments($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->if( $mock->foo($usedArg))
@@ -800,7 +800,7 @@ class mock extends atoum\test
 			->if($asserter->withArguments($otherArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 		;
 	}
@@ -811,23 +811,23 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($call = new php\call('foo', null, $mock))
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($otherUsedArg = uniqid()))
 			->then
@@ -835,23 +835,23 @@ class mock extends atoum\test
 			->if($mock->foo($anOtherUsedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($anOtherUsedArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
 			->if($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($mock->foo($arg))
 			->then
@@ -859,29 +859,29 @@ class mock extends atoum\test
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg)) . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
 			->if($call = new php\call('fooWithSeveralArguments', null, $mock))
 			->and($asserter->call('fooWithSeveralArguments'))
 			->then
 				->object($asserter->exactly(0))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->exactly(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
 			->if($mock->fooWithSeveralArguments(1, 2, 3, 4, 5))
 				->exception(function() use ($asserter) { $asserter->exactly(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array(1, 2, 3, 4, 5)))
 				->object($asserter->exactly(1))->isIdenticalTo($asserter)
 				->object($asserter->withArguments(1, 2, 3, 4, 5)->exactly(1))->isIdenticalTo($asserter)
 				->object($asserter->withAtLeastArguments(array(1 => 2, 3 => 4))->exactly(1))->isIdenticalTo($asserter)
 				->object($asserter->withAtLeastArguments(array(1 => 2, 3 => rand(6, PHP_INT_MAX)))->exactly(0))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->withAtLeastArguments(array(1 => 2, 3 => 4))->exactly(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array(1, 2, 3, 4, 5)))
 				->object($asserter->withIdenticalArguments(1, 2, 3, 4, 5)->exactly(1))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->withAtLeastIdenticalArguments(array(1 => '2', 3 => 4))->exactly(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array(1, 2, 3, 4, 5)))
 		;
 	}
@@ -892,12 +892,12 @@ class mock extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->if($asserter->setWith($mock = new \mock\atoum\tests\units\asserters\dummy()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called method is undefined')
 			->if($asserter->call('foo'))
 			->then
@@ -906,7 +906,7 @@ class mock extends atoum\test
 			->and($mock->foo($usedArg = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
 			->if($mock->getMockController()->resetCalls())
 			->and($asserter->withArguments($arg = uniqid()))
@@ -915,17 +915,17 @@ class mock extends atoum\test
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
 			->if($mock->foo($arg))
 			->then
 				->exception(function() use ($asserter, & $message) { $asserter->never($message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 			->if($asserter->withArguments(uniqid()))
 			->then

--- a/tests/units/classes/asserters/mock/call/adapter.php
+++ b/tests/units/classes/asserters/mock/call/adapter.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\mock\call;
+namespace atoum\tests\units\asserters\mock\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\mock\call
+	atoum,
+	atoum\test,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\mock\call
 ;
 
 class adapter extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\php\call');
+		$this->testedClass->extends('atoum\php\call');
 	}
 
 	public function test__construct()
@@ -40,7 +40,7 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($call = new call\adapter(
-					$mockAsserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()),
+					$mockAsserter = new \mock\atoum\asserters\mock(new asserter\generator()),
 					new test\adapter(),
 					uniqid()
 				)
@@ -56,7 +56,7 @@ class adapter extends atoum\test
 							$call->{$unknownFunction}();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method ' . get_class($mockAsserter) . '::' . $unknownFunction . '() does not exist')
 		;
 	}

--- a/tests/units/classes/asserters/mock/call/mock.php
+++ b/tests/units/classes/asserters/mock/call/mock.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters\mock\call;
+namespace atoum\tests\units\asserters\mock\call;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters,
-	mageekguy\atoum\asserters\mock\call\mock as testedClass
+	atoum,
+	atoum\asserter,
+	atoum\asserters,
+	atoum\asserters\mock\call\mock as testedClass
 ;
 
 class dummy
@@ -20,7 +20,7 @@ class mock extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\php\call');
+		$this->testedClass->extends('atoum\php\call');
 	}
 
 	public function test__construct()
@@ -28,7 +28,7 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					$mockAsserter = new asserters\mock(new asserter\generator()),
-					$mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mockAggregator = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					$function = uniqid()
 				)
 			)
@@ -44,8 +44,8 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					$mockAsserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mockAsserter = new \mock\atoum\asserters\mock(new asserter\generator()),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
@@ -60,7 +60,7 @@ class mock extends atoum\test
 							$call->{$unknownMethod}();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method ' . get_class($mockAsserter) . '::' . $unknownMethod . '() does not exist')
 		;
 	}
@@ -70,7 +70,7 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					new asserters\mock(new asserter\generator()),
-					$mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mockAggregator = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					$function = uniqid()
 				)
 			)
@@ -84,7 +84,7 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					new asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
@@ -101,7 +101,7 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					new asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
@@ -118,11 +118,11 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					new asserters\mock(new asserter\generator()),
-					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
 			)
-			->and($mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy())
+			->and($mockAggregator = new \mock\atoum\tests\units\asserters\mock\call\dummy())
 			->then
 				->object($call->on($mockAggregator))->isIdenticalTo($call)
 				->object($call->getObject())->isIdenticalTo($mockAggregator)
@@ -134,13 +134,13 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					new asserters\mock(new asserter\generator()),
-					$mock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mock = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					'foo'
 				)
 			)
 			->then
 				->variable($call->getFirstCall())->isNull()
-			->if($otherMock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy())
+			->if($otherMock = new \mock\atoum\tests\units\asserters\mock\call\dummy())
 			->and($otherMock->foo())
 			->then
 				->variable($call->getFirstCall())->isNull()
@@ -156,13 +156,13 @@ class mock extends atoum\test
 		$this
 			->if($call = new testedClass(
 					new asserters\mock(new asserter\generator()),
-					$mock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
+					$mock = new \mock\atoum\tests\units\asserters\mock\call\dummy(),
 					'foo'
 				)
 			)
 			->then
 				->variable($call->getLastCall())->isNull()
-			->if($otherMock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy())
+			->if($otherMock = new \mock\atoum\tests\units\asserters\mock\call\dummy())
 			->and($otherMock->foo())
 			->then
 				->variable($call->getLastCall())->isNull()

--- a/tests/units/classes/asserters/mysqlDateTime.php
+++ b/tests/units/classes/asserters/mysqlDateTime.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\mysqlDateTime as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\mysqlDateTime as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class mysqlDateTime extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\dateTime');
+		$this->testedClass->isSubclassOf('atoum\asserters\dateTime');
 	}
 
 	public function testSetWith()
@@ -23,7 +23,7 @@ class mysqlDateTime extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not in format Y-m-d H:i:s'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 			->object($asserter->setWith($value = '1976-10-06 14:05:54'))->isIdenticalTo($asserter)

--- a/tests/units/classes/asserters/object.php
+++ b/tests/units/classes/asserters/object.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\object as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\object as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class object extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\variable');
+		$this->testedClass->isSubclassOf('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -35,14 +35,14 @@ class object extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->toString; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 				->exception(function() use ($asserter, & $property) { $asserter->{$property = uniqid()}; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Asserter \'' . $property . '\' does not exist')
 			->if($asserter->setWith($this))
 			->then
-				->object($asserter->toString)->isInstanceOf('mageekguy\atoum\asserters\castToString')
+				->object($asserter->toString)->isInstanceOf('atoum\asserters\castToString')
 		;
 	}
 
@@ -52,7 +52,7 @@ class object extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an object'), $asserter->getTypeOf($value)))
 				->string($asserter->getValue())->isEqualTo($value)
 				->object($asserter->setWith($value = $this))->isIdenticalTo($asserter)
@@ -68,12 +68,12 @@ class object extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($this))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has size %d, expected size %d'), $asserter, sizeof($this), 0))
 				->object($asserter->hasSize(sizeof($this)))->isIdenticalTo($asserter);
 		;
@@ -85,12 +85,12 @@ class object extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($this))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has size %d'), $asserter, sizeof($this)))
 			->if($asserter->setWith(new \arrayIterator()))
 			->then
@@ -104,12 +104,12 @@ class object extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isCloneOf($asserter); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($test = $this))
 			->then
 				->exception(function() use ($asserter, $test) { $asserter->isCloneOf($test); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a clone of %s'), $asserter, $asserter->getTypeOf($test)))
 			->if($clonedTest = clone $test)
 			->then
@@ -123,11 +123,11 @@ class object extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->toString(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Object is undefined')
 			->if($asserter->setWith($this))
 			->then
-				->object($asserter->toString())->isInstanceOf('mageekguy\atoum\asserters\castToString')
+				->object($asserter->toString())->isInstanceOf('atoum\asserters\castToString')
 		;
 	}
 }

--- a/tests/units/classes/asserters/output.php
+++ b/tests/units/classes/asserters/output.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\output as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\output as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class output extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserters\string');
+		$this->testedClass->extends('atoum\asserters\string');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/asserters/phpArray.php
+++ b/tests/units/classes/asserters/phpArray.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\phpArray as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\phpArray as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -16,7 +16,7 @@ class phpArray extends atoum\test
 	public function testClass()
 	{
 		$this->testedClass
-			->extends('mageekguy\atoum\asserters\variable')
+			->extends('atoum\asserters\variable')
 			->implements('arrayAccess')
 		;
 	}
@@ -39,7 +39,7 @@ class phpArray extends atoum\test
 	public function test__get()
 	{
 		$this
-			->if($asserter = new sut($generator = new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut($generator = new \mock\atoum\asserter\generator()))
 			->then
 				->object($asserter->object)->isIdenticalTo($asserter)
 				->object($asserter->getInnerAsserter())->isEqualTo($generator->object)
@@ -61,11 +61,11 @@ class phpArray extends atoum\test
 			->then
 				->object($asserter->phpArray[0][0][1]->isEqualTo(array('foo', 'bar')))->isIdenticalTo($asserter)
 				->object($asserter->string[1]->isEqualTo('foobar'))->isIdenticalTo($asserter)
-			->if($asserter = new sut($generator = new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut($generator = new \mock\atoum\asserter\generator()))
 			->and($asserter->setWith(array($array1 = array('foo', 'bar'), $array2 = array(1, new \mock\object()))))
 			->then
-				->object($asserter->phpArray[0]->string[0]->isEqualTo('foo'))->isInstanceOf('mageekguy\atoum\asserters\phpArray')
-				->object($asserter->phpArray[1]->isEqualTo($array2))->isInstanceOf('mageekguy\atoum\asserters\phpArray')
+				->object($asserter->phpArray[0]->string[0]->isEqualTo('foo'))->isInstanceOf('atoum\asserters\phpArray')
+				->object($asserter->phpArray[1]->isEqualTo($array2))->isInstanceOf('atoum\asserters\phpArray')
 		;
 	}
 
@@ -128,7 +128,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not an array'), $asserter->getTypeOf($value)))
 				->object($asserter->setWith($value = array()))->isIdenticalTo($asserter)
 				->array($asserter->getValue())->isEqualTo($value)
@@ -153,25 +153,25 @@ class phpArray extends atoum\test
 	public function testOffsetGet()
 	{
 		$this
-			->if($asserter = new sut($generator = new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut($generator = new \mock\atoum\asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter[2]; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(1, 2, $object = new \mock\object(), clone $object)))
 			->then
 				->exception(function() use ($asserter) { $asserter[2]; })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Value %s at key %s is not an array'), $asserter->getTypeOf($object), 2))
 				->object($asserter->integer[0])->isIdenticalTo($asserter)
-			->if($asserter = new sut($generator = new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut($generator = new \mock\atoum\asserter\generator()))
 			->and($asserter->setWith(array(1, 2, $object = new \mock\object(), clone $object)))
 			->then
 				->object($asserter->object[2]->isIdenticalTo($object))->isIdenticalTo($asserter)
 				->object($asserter->object[2]->isIdenticalTo($object))->isIdenticalTo($asserter)
 				->object($asserter->object[3]->isCloneOf($object))->isIdenticalTo($asserter)
 				->object($asserter->object[2])->isIdenticalTo($asserter)
-			->if($asserter = new sut(new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut(new \mock\atoum\asserter\generator()))
 			->and($asserter->setWith($array = array($integer = rand(1, PHP_INT_MAX), 2, $innerArray = array(3, 4, 5, $object))))
 			->then
 				->object($asserter[2])
@@ -184,9 +184,9 @@ class phpArray extends atoum\test
 				->object($asserter->object[2][3]->isIdenticalTo($object)->integer[0]->isEqualTo($integer))->isIdenticalTo($asserter)
 				->object($asserter->object[2][3]->isIdenticalTo($object)->integer($integer)->isEqualTo($integer))
 					->isNotIdenticalTo($asserter)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->exception(function() use ($asserter) { $asserter->object[2][4]; })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has no key %s'), $asserter->getTypeOf($asserter->getInnerValue()), $asserter->getTypeOf(4)))
 		;
 	}
@@ -194,10 +194,10 @@ class phpArray extends atoum\test
 	public function testOffsetSet()
 	{
 		$this
-			->if($asserter = new sut(new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut(new \mock\atoum\asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter[rand(0, PHP_INT_MAX)] = rand(0, PHP_INT_MAX); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Tested array is read only')
 		;
 	}
@@ -205,10 +205,10 @@ class phpArray extends atoum\test
 	public function testOffsetUnset()
 	{
 		$this
-			->if($asserter = new sut(new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut(new \mock\atoum\asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { unset($asserter[rand(0, PHP_INT_MAX)]); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is read only')
 		;
 	}
@@ -216,7 +216,7 @@ class phpArray extends atoum\test
 	public function testOffsetExists()
 	{
 		$this
-			->if($asserter = new sut(new \mock\mageekguy\atoum\asserter\generator()))
+			->if($asserter = new sut(new \mock\atoum\asserter\generator()))
 			->then
 				->boolean(isset($asserter[rand(0, PHP_INT_MAX)]))->isFalse()
 			->if($asserter->setWith(array()))
@@ -240,15 +240,15 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->exception(function() use ($asserter, & $size) { $asserter->hasSize($size = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has not size %d'), $asserter, $size))
 				->exception(function() use ($asserter, & $size, & $message) { $asserter->hasSize($size = rand(1, PHP_INT_MAX), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->hasSize(0))->isIdenticalTo($asserter)
 		;
@@ -260,15 +260,15 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not empty'), $asserter))
 				->exception(function() use ($asserter, & $message) { $asserter->isEmpty($message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 			->if($asserter->setWith(array()))
 			->then
@@ -282,15 +282,15 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array()))
 				->then
 					->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is empty'), $asserter))
 					->exception(function() use ($asserter, & $message) { $asserter->isNotEmpty($message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 				->if($asserter->setWith(array(uniqid())))
 				->then
@@ -304,7 +304,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->atKey(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid(), uniqid(), $data = rand(1, PHP_INT_MAX), uniqid(), uniqid())))
 				->object($asserter->atKey(0))->isIdenticalTo($asserter)
@@ -314,10 +314,10 @@ class phpArray extends atoum\test
 				->object($asserter->atKey(3))->isIdenticalTo($asserter)
 				->object($asserter->atKey(4))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $key) { $asserter->atKey($key = rand(5, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key)))
 				->exception(function() use ($asserter, & $key, & $message) { $asserter->atKey($key = rand(5, PHP_INT_MAX), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 		;
 	}
@@ -328,17 +328,17 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid(), uniqid(), $data = rand(1, PHP_INT_MAX), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter, & $notInArray) { $asserter->contains($notInArray = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not contain %s'), $asserter, $asserter->getTypeOf($notInArray)))
 				->object($asserter->contains($data))->isIdenticalTo($asserter)
 				->object($asserter->contains((string) $data))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $data) { $asserter->atKey(0)->contains($data); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not contain %s at key %s'), $asserter, $asserter->getTypeOf($data), $asserter->getTypeOf(0)))
 				->object($asserter->contains($data))->isIdenticalTo($asserter)
 				->object($asserter->atKey(2)->contains($data))->isIdenticalTo($asserter)
@@ -351,35 +351,35 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notContains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(uniqid(), uniqid(), $inArray = uniqid(), uniqid(), uniqid())))
 			->then
 				->object($asserter->notContains(uniqid()))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $inArray) { $asserter->notContains($inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s'), $asserter, $asserter->getTypeOf($inArray)))
 				->exception(function() use ($asserter, $inArray, & $message) { $asserter->notContains($inArray, $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->exception(function() use($asserter, $inArray){ $asserter->notContains((string) $inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s'), $asserter, $asserter->getTypeOf((string) $inArray)))
 				->exception(function() use($asserter, $inArray, & $message){ $asserter->notContains((string) $inArray, $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->atKey(0)->notContains($inArray))->isIdenticalTo($asserter)
 				->object($asserter->atKey(1)->notContains($inArray))->isIdenticalTo($asserter)
 				->object($asserter->atKey(3)->notContains($inArray))->isIdenticalTo($asserter)
 				->object($asserter->atKey(4)->notContains($inArray))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $inArray) { $asserter->notContains($inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s'), $asserter, $asserter->getTypeOf($inArray)))
 				->exception(function() use ($asserter, $inArray) { $asserter->atKey(2)->notContains($inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s at key %s'), $asserter, $asserter->getTypeOf($inArray), $asserter->getTypeOf(2)))
 				->exception(function() use ($asserter, $inArray) { $asserter->atKey('2')->notContains($inArray); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s contains %s at key %s'), $asserter, $asserter->getTypeOf($inArray), $asserter->getTypeOf('2')))
         ;
 	}
@@ -390,24 +390,24 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->and($asserter->setWith(array(1, 2, 3, 4, 5, '3')))
 			->then
 				->exception(function() use ($asserter) {$asserter->strictlyContains('1'); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not strictly contain %s'), $asserter, $asserter->getTypeOf('1')))
 				->exception(function() use ($asserter, & $message) {$asserter->strictlyContains('1', $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->strictlyContains(1))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->atKey(0)->strictlyContains(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not strictly contain %s at key %s'), $asserter, $asserter->getTypeOf(2), $asserter->getTypeOf(0)))
 				->object($asserter->strictlyContains(2))->isIdenticalTo($asserter)
 				->object($asserter->atKey(2)->strictlyContains(3))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->atKey(2)->strictlyContains('3'); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not strictly contain %s at key %s'), $asserter, $asserter->getTypeOf('3'), $asserter->getTypeOf(2)))
 		;
 	}
@@ -418,15 +418,15 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(1, 2, 3, 4, 5, '6')))
 			->then
 				->exception(function() use ($asserter) {$asserter->strictlyNotContains(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s strictly contains %s'), $asserter, $asserter->getTypeOf(1)))
 				->exception(function() use ($asserter, & $message) {$asserter->strictlyNotContains(1, $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->strictlyNotContains('1'))->isIdenticalTo($asserter)
 				->object($asserter->atKey(1)->strictlyNotContains(1))->isIdenticalTo($asserter)
@@ -434,13 +434,13 @@ class phpArray extends atoum\test
 				->object($asserter->atKey(3)->strictlyNotContains(1))->isIdenticalTo($asserter)
 				->object($asserter->atKey(4)->strictlyNotContains(1))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->strictlyNotContains(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s strictly contains %s'), $asserter, $asserter->getTypeOf(1)))
 				->exception(function() use ($asserter) { $asserter->atKey(0)->strictlyNotContains(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s strictly contains %s at key %s'), $asserter, $asserter->getTypeOf(1), $asserter->getTypeOf(0)))
 				->exception(function() use ($asserter) { $asserter->atKey('0')->strictlyNotContains(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s strictly contains %s at key %s'), $asserter, $asserter->getTypeOf(1), $asserter->getTypeOf('0')))
 		;
 	}
@@ -451,21 +451,21 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 				->then
 					->exception(function() use ($asserter) { $asserter->containsValues(array(6)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array(6))))
 					->exception(function() use ($asserter, & $message) { $asserter->containsValues(array(6), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->exception(function() use ($asserter) { $asserter->containsValues(array('6')); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain values %s'), $asserter, $asserter->getTypeOf(array('6'))))
 					->exception(function() use ($asserter, & $message) { $asserter->containsValues(array('6'), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->object($asserter->containsValues(array(1)))->isIdenticalTo($asserter)
 					->object($asserter->containsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
@@ -479,18 +479,18 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 			->then
 				->exception(function() use ($asserter) { $asserter->notContainsValues(array(1, 6)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should not contain values %s'), $asserter, $asserter->getTypeOf(array(1))))
 				->exception(function() use ($asserter, & $message) { $asserter->notContainsValues(array(1, 6), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->exception(function() use ($asserter, & $message) { $asserter->notContainsValues(array('1', '6'), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->containsValues(array(1)))->isIdenticalTo($asserter)
 				->object($asserter->containsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
@@ -504,29 +504,29 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 				->then
 					->exception(function() use ($asserter) { $asserter->strictlyContainsValues(array(6)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(6))))
 					->exception(function() use ($asserter, & $message) { $asserter->strictlyContainsValues(array(6), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->exception(function() use ($asserter) { $asserter->strictlyContainsValues(array('6')); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s does not contain strictly values %s'), $asserter, $asserter->getTypeOf(array('6'))))
 					->exception(function() use ($asserter, & $message) { $asserter->strictlyContainsValues(array('6'), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->exception(function() use ($asserter, & $message) { $asserter->strictlyContainsValues(array('1'), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->object($asserter->strictlyContainsValues(array(1)))->isIdenticalTo($asserter)
 					->object($asserter->strictlyContainsValues(array(1, 2, 4)))->isIdenticalTo($asserter)
 					 ->exception(function() use ($asserter, & $message) { $asserter->strictlyContainsValues(array('1', 2, '4'), $message = uniqid()); })
-						 ->isInstanceOf('mageekguy\atoum\asserter\exception')
+						 ->isInstanceOf('atoum\asserter\exception')
 						 ->hasMessage($message)
 		;
 	}
@@ -537,18 +537,18 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 				->if($asserter->setWith(array(1, 2, 3, 4, 5)))
 				->then
 					->exception(function() use ($asserter) { $asserter->strictlyNotContainsValues(array(1)); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s should not contain strictly values %s'), $asserter, $asserter->getTypeOf(array(1))))
 					->exception(function() use ($asserter, & $message) { $asserter->strictlyNotContainsValues(array(1), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->exception(function() use ($asserter, & $message) { $asserter->strictlyNotContainsValues(array(1, '2', 3), $message = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($message)
 					->object($asserter->strictlyNotContainsValues(array('1')))->isIdenticalTo($asserter)
 					->object($asserter->strictlyNotContainsValues(array(6, 7, '2', 8)))->isIdenticalTo($asserter)
@@ -561,15 +561,15 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasKey(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->exception(function() use ($asserter, & $key) { $asserter->hasKey($key = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf($key)))
 				->exception(function() use ($asserter, & $key, & $message) { $asserter->hasKey($key = rand(1, PHP_INT_MAX), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
@@ -579,10 +579,10 @@ class phpArray extends atoum\test
 				->object($asserter->hasKey(3))->isIdenticalTo($asserter)
 				->object($asserter->hasKey(4))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) { $asserter->hasKey(5); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has no key %s'), $asserter, $asserter->getTypeOf(5)))
 				->exception(function() use ($asserter, & $message) { $asserter->hasKey(5, $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 		;
 	}
@@ -593,7 +593,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
@@ -601,10 +601,10 @@ class phpArray extends atoum\test
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->notHasKey(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s has a key %s'), $asserter, $asserter->getTypeOf(0)))
 				->exception(function() use ($asserter, & $message) { $asserter->notHasKey(0, $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->notHasKey(5))->isIdenticalTo($asserter)
 		;
@@ -616,7 +616,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
@@ -625,10 +625,10 @@ class phpArray extends atoum\test
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->notHasKeys(array(0, 'premier', 2)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should not have keys %s'), $asserter, $asserter->getTypeOf(array(0, 2))))
 				->exception(function() use ($asserter, & $message) { $asserter->notHasKeys(array(0, 'premier', 2), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->notHasKeys(array(5, '6')))->isIdenticalTo($asserter)
 		;
@@ -640,23 +640,23 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasKeys(array(rand(0, PHP_INT_MAX))); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasKeys(array(0)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array(0))))
 				->exception(function() use ($asserter, & $message) { $asserter->hasKeys(array(0), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 			->if($asserter->setWith(array(uniqid(), uniqid(), uniqid(), uniqid(), uniqid())))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasKeys(array(0, 'first', 2, 'second')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s should have keys %s'), $asserter, $asserter->getTypeOf(array('first', 'second'))))
 				->exception(function() use ($asserter, & $message) { $asserter->hasKeys(array(0, 'first', 2, 'second'), $message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($message)
 				->object($asserter->hasKeys(array(0, 2, 4)))->isIdenticalTo($asserter)
 		;
@@ -668,18 +668,18 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->keys; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->object($array = $asserter->keys)
-					->isInstanceOf('mageekguy\atoum\asserters\phpArray')
+					->isInstanceOf('atoum\asserters\phpArray')
 				->array($array->getValue())
 					->isEqualTo(array())
 			->if($asserter->setWith(array($key1 = uniqid() => uniqid(), $key2 = uniqid() => uniqid())))
 			->then
 				->object($array = $asserter->keys)
-					->isInstanceOf('mageekguy\atoum\asserters\phpArray')
+					->isInstanceOf('atoum\asserters\phpArray')
 				->array($array->getValue())
 					->isEqualTo(array($key1, $key2))
 		;
@@ -691,18 +691,18 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->size; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
 				->object($integer = $asserter->size)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(0)
 			->if($asserter->setWith(array(uniqid(), uniqid())))
 			->then
 				->object($integer = $asserter->size)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(2)
 		;
@@ -714,7 +714,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEqualTo(array()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
@@ -725,13 +725,13 @@ class phpArray extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use (& $line, $asserter, & $notEqualValue) { $line = __LINE__; $asserter->isEqualTo($notEqualValue = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf($notEqualValue)) . PHP_EOL . $diff->setExpected($notEqualValue)->setActual($asserter->getValue()))
 			->if($asserter->integer)
 			->then
 				->object($asserter->isEqualTo($array))->isIdenticalTo($asserter)
 				->exception(function() use (& $line, $asserter, & $notEqualValue) { $line = __LINE__; $asserter->isEqualTo($notEqualValue = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf($notEqualValue)) . PHP_EOL . $diff->setExpected($notEqualValue)->setActual($asserter->getValue()))
 			->if($asserter->integer[2])
 			->then
@@ -741,7 +741,7 @@ class phpArray extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $expectedValue) { $asserter->isEqualTo($expectedValue = rand(4, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter->getTypeOf($asserter->getInnerValue()), $asserter->getTypeOf($expectedValue)) . PHP_EOL . $diff->setExpected($expectedValue)->setActual(3))
 		;
 	}
@@ -752,7 +752,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEqualTo(array()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array()))
 			->then
@@ -764,7 +764,7 @@ class phpArray extends atoum\test
 			->then
 				->object($asserter->isNotEqualTo(array()))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $array) { $asserter->isNotEqualTo($array); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is equal to %s'), $asserter, $asserter->getTypeOf($array)))
 			->if($asserter->integer[2])
 			->then
@@ -773,7 +773,7 @@ class phpArray extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $expectedValue) { $asserter->isEqualTo($expectedValue = rand(4, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter->getTypeOf($asserter->getInnerValue()), $asserter->getTypeOf($expectedValue)) . PHP_EOL . $diff->setExpected($expectedValue)->setActual(3))
 		;
 	}
@@ -784,7 +784,7 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isIdenticalTo(new \mock\object()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith(array($object = new \mock\object(), 2)))
 			->then
@@ -792,10 +792,10 @@ class phpArray extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $notIdenticalValue, $object) { $asserter->isIdenticalTo($notIdenticalValue = array(clone $object, 2)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not identical to %s'), $asserter, $asserter->getTypeOf($notIdenticalValue)) . PHP_EOL . $diff->setExpected($notIdenticalValue)->setActual($asserter->getValue()))
 				->exception(function() use ($asserter, & $notIdenticalValue, $object) { $asserter->isIdenticalTo($notIdenticalValue = array($object, '2')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not identical to %s'), $asserter, $asserter->getTypeOf($notIdenticalValue)) . PHP_EOL . $diff->setExpected($notIdenticalValue)->setActual($asserter->getValue()))
 			->if($asserter->integer)
 			->then
@@ -805,7 +805,7 @@ class phpArray extends atoum\test
 				->object($asserter->isEqualTo(2))->isIdenticalTo($asserter)
 				->object($asserter->isEqualTo(2)->isNotEqualTo(5))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, & $expectedValue) { $asserter->isEqualTo($expectedValue = rand(3, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter->getTypeOf($asserter->getInnerValue()), $asserter->getTypeOf($expectedValue)) . PHP_EOL . $diff->setExpected($expectedValue)->setActual(2))
 		;
 	}
@@ -816,13 +816,13 @@ class phpArray extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotIdenticalTo(new \mock\object()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Array is undefined')
 			->if($asserter->setWith($array = array(1, 2)))
 			->then
 				->object($asserter->isNotIdenticalTo(array('1', 2)))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $array) { $asserter->isNotIdenticalTo($array); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is identical to %s'), $asserter, $asserter->getTypeOf($array)))
 			->if($asserter->integer)
 			->then
@@ -834,7 +834,7 @@ class phpArray extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $expectedValue) { $asserter->isEqualTo($expectedValue = rand(3, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter->getTypeOf($asserter->getInnerValue()), $asserter->getTypeOf($expectedValue)) . PHP_EOL . $diff->setExpected($expectedValue)->setActual(2))
 		;
 	}

--- a/tests/units/classes/asserters/phpClass.php
+++ b/tests/units/classes/asserters/phpClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\phpClass as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\phpClass as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -21,7 +21,7 @@ class phpClass extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserter');
+		$this->testedClass->extends('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -54,7 +54,7 @@ class phpClass extends atoum\test
 				->object($asserter->setReflectionClassInjector(function($class) use (& $reflectionClass) { return ($reflectionClass = new \mock\reflectionClass($class)); }))->isIdenticalTo($asserter)
 				->object($asserter->getReflectionClass($class = uniqid()))->isIdenticalTo($reflectionClass)
 				->exception(function() use ($asserter) { $asserter->setReflectionClassInjector(function() {}); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Reflection class injector must take one argument')
 		;
 	}
@@ -73,7 +73,7 @@ class phpClass extends atoum\test
 			->if($asserter->setReflectionClassInjector(function($class) use (& $reflectionClass) { return uniqid(); }))
 			->then
 				->exception(function() use ($asserter) { $asserter->getReflectionClass(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Reflection class injector must return a \reflectionClass instance')
 		;
 	}
@@ -88,7 +88,7 @@ class phpClass extends atoum\test
 			->and($class = uniqid())
 			->then
 				->exception(function() use ($asserter, $class) { $asserter->setWith($class); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class \'%s\' does not exist'), $class))
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
@@ -117,7 +117,7 @@ class phpClass extends atoum\test
 			->and($mockController->getParentClass = $parentClass = new \mock\reflectionClass($parent, $parentMockController))
 			->then
 				->exception(function() use ($asserter, $parent) { $asserter->hasParent($parent); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not the parent of class %s'), $parent, $class))
 			->if($parentMockController->getName = $parent)
 			->then
@@ -148,7 +148,7 @@ class phpClass extends atoum\test
 			->and($reflectionClass->getMockController()->getParentClass = function() use ($parentClass) { return $parentClass; })
 			->then
 				->exception(function() use ($asserter) { $asserter->hasNoParent(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('class %s has parent %s'), $className, $parentClass))
 		;
 	}
@@ -173,7 +173,7 @@ class phpClass extends atoum\test
 			->and($mockController->isSubclassOf = false)
 			->then
 				->exception(function() use ($asserter, $parentClass) { $asserter->isSubclassOf($parentClass); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s is not a sub-class of %s'), $class, $parentClass))
 			->if($mockController->isSubclassOf = true)
 			->then
@@ -201,7 +201,7 @@ class phpClass extends atoum\test
 			->and($mockController->isSubclassOf = false)
 			->then
 				->exception(function() use ($asserter, $parentClass) { $asserter->extends($parentClass); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s is not a sub-class of %s'), $class, $parentClass))
 			->if($mockController->isSubclassOf = true)
 			->then
@@ -229,7 +229,7 @@ class phpClass extends atoum\test
 			->and($mockController->implementsInterface = false)
 			->then
 				->exception(function() use ($asserter, $interface) { $asserter->hasInterface($interface); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s does not implement interface %s'), $class, $interface))
 			->if($mockController->implementsInterface = true)
 			->then
@@ -257,7 +257,7 @@ class phpClass extends atoum\test
 			->and($mockController->implementsInterface = false)
 			->then
 				->exception(function() use ($asserter, $interface) { $asserter->implements($interface); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s does not implement interface %s'), $class, $interface))
 			->if($mockController->implementsInterface = true)
 			->then
@@ -284,7 +284,7 @@ class phpClass extends atoum\test
 			->and($mockController->isAbstract = false)
 			->then
 				->exception(function() use ($asserter) { $asserter->isAbstract(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Class %s is not abstract'), $class))
 			->if($mockController->isAbstract = true)
 			->then
@@ -312,7 +312,7 @@ class phpClass extends atoum\test
 			)
 			->then
 				->exception(function() use ($asserter, $method) { $asserter->hasMethod($method); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Method %s::%s() does not exist'), $class, $method))
 			->if($reflectionClassController->hasMethod = true)
 			->then

--- a/tests/units/classes/asserters/phpFunction.php
+++ b/tests/units/classes/asserters/phpFunction.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 require __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php,
-	mageekguy\atoum\asserters\phpFunction as sut
+	atoum,
+	atoum\php,
+	atoum\asserters\phpFunction as sut
 ;
 
 class phpFunction extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserter');
+		$this->testedClass->extends('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -112,22 +112,22 @@ class phpFunction extends atoum\test
 			->and($this->function->function_exists = false)
 			->then
 				->exception(function() use ($asserter) { $asserter->isCalled(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Function is undefined')
 			->if($asserter->setNamespace($namespace = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isCalled(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Function is undefined')
 			->if($asserter->setFunction($function = uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isCalled(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Function \'' . $asserter->getFullyQualifiedFunctionName() . '\' does not exist')
 			->if($this->function->function_exists = true)
 			->then
 				->exception(function() use ($asserter) { $asserter->isCalled(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($asserter->getLocale()->_('function %s is called 0 time'), $asserter))
 			->if(php\mocker::getAdapter()->addCall($asserter->getFullyQualifiedFunctionName()))
 			->then

--- a/tests/units/classes/asserters/sizeOf.php
+++ b/tests/units/classes/asserters/sizeOf.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\sizeOf as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\sizeOf as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class sizeOf extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\integer');
+		$this->testedClass->isSubclassOf('atoum\asserters\integer');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/asserters/stream.php
+++ b/tests/units/classes/asserters/stream.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters\stream as sut
+	atoum,
+	atoum\asserter,
+	atoum\asserters\stream as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class stream extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserter');
+		$this->testedClass->extends('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -48,14 +48,14 @@ class stream extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isRead(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Stream is undefined')
 			->if($streamController = atoum\mock\stream::get($streamName = uniqid()))
 			->and($streamController->file_get_contents = uniqid())
 			->and($asserter->setWith($streamName))
 			->then
 				->exception(function() use ($asserter) { $asserter->isRead(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage = sprintf($generator->getLocale()->_('stream %s is not read'), $streamController))
 				->when(function() use ($streamName) { file_get_contents('atoum://' . $streamName); })
 					->object($asserter->isRead())->isIdenticalTo($asserter)
@@ -68,14 +68,14 @@ class stream extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isWrited(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Stream is undefined')
 			->if($streamController = atoum\mock\stream::get($streamName = uniqid()))
 			->and($streamController->file_put_contents = strlen($contents = uniqid()))
 			->and($asserter->setWith($streamName))
 			->then
 				->exception(function() use ($asserter) { $asserter->isWrited(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage = sprintf($generator->getLocale()->_('stream %s is not writed'), $streamController))
 			->when(function() use ($streamName, $contents) { file_put_contents('atoum://' . $streamName, $contents); })
 				->object($asserter->isWrited())->isIdenticalTo($asserter)
@@ -84,7 +84,7 @@ class stream extends atoum\test
 			->and($asserter->setWith($streamController))
 			->then
 				->exception(function() use ($asserter) { $asserter->isWrited(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage = sprintf($generator->getLocale()->_('stream %s is not writed'), $streamController))
 			->when(function() use ($streamController, $contents) { file_put_contents($streamController, $contents); })
 				->object($asserter->isWrited())->isIdenticalTo($asserter)

--- a/tests/units/classes/asserters/string.php
+++ b/tests/units/classes/asserters/string.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\string as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\string as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class string extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserters\variable');
+		$this->testedClass->extends('atoum\asserters\variable');
 	}
 
 	public function test__construct()
@@ -71,7 +71,7 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use (& $line, $asserter, & $value) { $line = __LINE__; $asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a string'), $asserter->getTypeOf($value)))
 				->integer($asserter->getValue())->isEqualTo($value)
 				->variable($asserter->getCharlist())->isNull()
@@ -91,13 +91,13 @@ class string extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEqualTo(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($firstString = uniqid()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $secondString) { $asserter->isEqualTo($secondString = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('strings are not equals') . PHP_EOL . $diff->setExpected($secondString)->setActual($firstString))
 			->object($asserter->isEqualTo($firstString))->isIdenticalTo($asserter)
 		;
@@ -110,19 +110,19 @@ class string extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEqualToContentsOfFile(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($firstString = uniqid()))
 			->and($adapter->file_get_contents = false)
 			->then
 				->exception(function() use ($asserter, & $path) { $asserter->isEqualToContentsOfFile($path = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Unable to get contents of file %s'), $path))
 			->if($adapter->file_get_contents = $fileContents = uniqid())
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $path) { $asserter->isEqualToContentsOfFile($path); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('string is not equals to contents of file %s'), $path) . PHP_EOL . $diff->setExpected($fileContents)->setActual($firstString))
 			->if($adapter->file_get_contents = $firstString)
 			->then
@@ -136,13 +136,13 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = uniqid()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('strings are not equals') . PHP_EOL . $diff->setExpected('')->setActual($string))
 			->if($asserter->setWith(''))
 			->then
@@ -156,13 +156,13 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('string is empty'))
 			->if($asserter->setWith($string = uniqid()))
 			->then
@@ -176,13 +176,13 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLength(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $requiredLength) { $asserter->hasLength($requiredLength = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not %d'), $asserter->getTypeOf(''), $requiredLength))
 				->object($asserter->hasLength(0))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = uniqid()))
@@ -197,13 +197,13 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLengthGreaterThan(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith('Chuck Norris'))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $requiredLength) { $asserter->hasLengthGreaterThan($requiredLength = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not greater than %d'), $asserter->getTypeOf('Chuck Norris'), $requiredLength))
 				->object($asserter->hasLengthGreaterThan(0))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = uniqid()))
@@ -218,13 +218,13 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLengthLessThan(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith('Chuck Norris'))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $requiredLength) { $asserter->hasLengthLessThan($requiredLength = 10); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not less than %d'), $asserter->getTypeOf('Chuck Norris'), $requiredLength))
 				->object($asserter->hasLengthLessThan(20))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = uniqid()))
@@ -239,20 +239,20 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = __METHOD__))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $fragment) { $asserter->contains($fragment = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
 				->object($asserter->contains($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith(uniqid() . $string . uniqid()))
 			->then
 				->object($asserter->contains($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->contains($fragment = strtoupper($string)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
 		;
 	}
@@ -263,12 +263,12 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notContains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = 'FreeAgent scans the field'))
 			->then
 				->exception(function() use ($asserter, & $fragment) { $asserter->notContains($fragment = 'Agent'); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String contains %s'), $fragment))
 				->object($asserter->notContains('coach'))->isIdenticalTo($asserter)
 		;
@@ -280,25 +280,25 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->startWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = __METHOD__))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $fragment) { $asserter->startWith($fragment = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not start with %s'), $fragment))
 				->object($asserter->startWith($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith(uniqid() . $string))
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->startWith($string); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not start with %s'), $string))
 			->if($asserter->setWith($string . uniqid()))
 			->then
 				->object($asserter->startWith($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->startWith($fragment = strtoupper($string)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not start with %s'), $fragment))
 		;
 	}
@@ -309,12 +309,12 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notStartWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = __METHOD__))
 			->then
 				->exception(function() use ($asserter, & $fragment) { $asserter->notStartWith($fragment = __NAMESPACE__); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String start with %s'), $fragment))
 				->object($asserter->notStartWith(uniqid()))->isIdenticalTo($asserter)
 		;
@@ -326,25 +326,25 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->endWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = __METHOD__))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $fragment) { $asserter->endWith($fragment = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not end with %s'), $fragment))
 				->object($asserter->endWith($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string . uniqid()))
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->endWith($string); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not end with %s'), $string))
 			->if($asserter->setWith(uniqid() . $string))
 			->then
 				->object($asserter->endWith($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->endWith($fragment = strtoupper($string)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not end with %s'), $fragment))
 		;
 	}
@@ -355,13 +355,13 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notEndWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = __METHOD__))
 			->and($fragment = __FUNCTION__)
 			->then
 				->exception(function() use ($asserter, $fragment) { $asserter->notEndWith($fragment); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String end with %s'), $fragment))
 				->object($asserter->notEndWith(uniqid()))->isIdenticalTo($asserter)
 		;
@@ -373,18 +373,18 @@ class string extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->length; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->then
 				->object($integer = $asserter->length)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(0)
 			->if($asserter->setWith($str = uniqid()))
 			->then
 				->object($integer = $asserter->length)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(strlen($str))
 		;

--- a/tests/units/classes/asserters/testedClass.php
+++ b/tests/units/classes/asserters/testedClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	atoum,
+	atoum\asserter,
+	atoum\asserters
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class testedClass extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserters\phpClass');
+		$this->testedClass->isSubclassOf('atoum\asserters\phpClass');
 	}
 
 	public function testSetWith()
@@ -23,7 +23,7 @@ class testedClass extends atoum\test
 			->if($asserter = new asserters\testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->setWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\badMethodCall')
+					->isInstanceOf('atoum\exceptions\logic\badMethodCall')
 					->hasMessage('Unable to call method ' . get_class($asserter) . '::setWith()')
 		;
 	}

--- a/tests/units/classes/asserters/utf8String.php
+++ b/tests/units/classes/asserters/utf8String.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\utf8String as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\utf8String as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -16,7 +16,7 @@ class utf8String extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\asserters\string');
+		$this->testedClass->extends('atoum\asserters\string');
 	}
 
 	public function test__construct()
@@ -48,7 +48,7 @@ class utf8String extends atoum\test
 			->if($adapter->extension_loaded = false)
 			->then
 				->exception(function() use ($adapter) { new sut(new asserter\generator(), $adapter); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('mbstring PHP extension is mandatory to use utf8String asserter')
 		;
 	}
@@ -72,13 +72,13 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter, & $value) { $asserter->setwith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-					->isinstanceof('mageekguy\atoum\asserter\exception')
+					->isinstanceof('atoum\asserter\exception')
 					->hasmessage(sprintf($generator->getlocale()->_('%s is not a string'), $asserter->gettypeof($value)))
 				->exception(function() use ($asserter, & $value) { $asserter->setwith("\xf0\x28\x8c\xbc"); })
-					->isinstanceof('mageekguy\atoum\asserter\exception')
+					->isinstanceof('atoum\asserter\exception')
 					->hasmessage(sprintf($generator->getlocale()->_('\'%s\' is not an UTF-8 string'), "\xf0\x28\x8c\xbc"))
 				->exception(function() use ($asserter, & $value) { $asserter->setwith("\xf8\xa1\xa1\xa1\xa1"); })
-					->isinstanceof('mageekguy\atoum\asserter\exception')
+					->isinstanceof('atoum\asserter\exception')
 					->hasmessage(sprintf($generator->getlocale()->_('\'%s\' is not an UTF-8 string'), "\xf8\xa1\xa1\xa1\xa1"))
 				->object($asserter->setWith(uniqid()))->isIdenticalTo($asserter)
 		;
@@ -91,14 +91,14 @@ class utf8String extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEqualTo(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($firstString = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->and($secondString = $this->getRandomUtf8String())
 			->then
 				->exception(function() use ($asserter, $secondString) { $asserter->isEqualTo($secondString); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('strings are not equals') . PHP_EOL . $diff->setExpected($secondString)->setActual($firstString))
 			->object($asserter->isEqualTo($firstString))->isIdenticalTo($asserter)
 		;
@@ -111,19 +111,19 @@ class utf8String extends atoum\test
 			->then
 				->boolean($asserter->wasSet())->isFalse()
 				->exception(function() use ($asserter) { $asserter->isEqualToContentsOfFile(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($firstString = $this->getRandomUtf8String()))
 			->and($adapter->file_get_contents = false)
 			->then
 				->exception(function() use ($asserter, & $path) { $asserter->isEqualToContentsOfFile($path = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('Unable to get contents of file %s'), $path))
 			->if($adapter->file_get_contents = $fileContents = $this->getRandomUtf8String())
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $path) { $asserter->isEqualToContentsOfFile($path); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('string is not equals to contents of file %s'), $path) . PHP_EOL . $diff->setExpected($fileContents)->setActual($firstString))
 			->if($adapter->file_get_contents = $firstString)
 			->then
@@ -137,13 +137,13 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('strings are not equals') . PHP_EOL . $diff->setExpected('')->setActual($string))
 			->if($asserter->setWith(''))
 			->then
@@ -157,13 +157,13 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($generator->getLocale()->_('string is empty'))
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->then
@@ -177,13 +177,13 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLength(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $requiredLength) { $asserter->hasLength($requiredLength = rand(1, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not %d'), $asserter->getTypeOf(''), $requiredLength))
 				->object($asserter->hasLength(0))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
@@ -198,13 +198,13 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLengthGreaterThan(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->hasLengthGreaterThan(mb_strlen($string, 'UTF-8')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not greater than %d'), $asserter->getTypeOf($string), mb_strlen($string, 'UTF-8')))
 				->object($asserter->hasLengthGreaterThan(0))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
@@ -219,13 +219,13 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->hasLengthLessThan(rand(0, PHP_INT_MAX)); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->hasLengthLessThan(mb_strlen($string, 'UTF-8')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('length of %s is not less than %d'), $asserter->getTypeOf($string), mb_strlen($string, 'UTF-8')))
 				->object($asserter->hasLengthLessThan(20))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
@@ -240,27 +240,27 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->contains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->and($fragment = $this->getRandomUtf8String())
 			->then
 				->exception(function() use ($asserter, $fragment) { $asserter->contains($fragment); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
 				->object($asserter->contains($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith($this->getRandomUtf8String() . $string . $this->getRandomUtf8String()))
 			->then
 				->object($asserter->contains($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->contains($fragment = mb_strtoupper($string, 'UTF-8')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not contain %s'), $fragment))
 				->exception(function() use ($asserter) {
 							$asserter->contains("\xf0\x28\x8c\xbc");
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Fragment \'' . "\xf0\x28\x8c\xbc" . '\' is not an UTF-8 string')
 		;
 	}
@@ -271,20 +271,20 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notContains(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = 'FreeAgent scans the field'))
 			->and($fragment = 'Agent')
 			->then
 				->exception(function() use ($asserter, $fragment) { $asserter->notContains($fragment); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String contains %s'), $fragment))
 				->object($asserter->notContains('coach'))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter) {
 							$asserter->notContains("\xf0\x28\x8c\xbc");
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Fragment \'' . "\xf0\x28\x8c\xbc" . '\' is not an UTF-8 string')
 		;
 	}
@@ -295,26 +295,26 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->startWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->and($fragment = $this->getRandomUtf8String())
 			->then
 				->exception(function() use ($asserter, $fragment) { $asserter->startWith($fragment); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not start with %s'), $fragment))
 				->object($asserter->startWith($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith(uniqid() . $string))
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->startWith($string); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not start with %s'), $string))
 			->if($asserter->setWith($string . uniqid()))
 			->then
 				->object($asserter->startWith($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->startWith($fragment = mb_strtoupper($string, 'UTF-8')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not start with %s'), $fragment))
 		;
 	}
@@ -325,12 +325,12 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notStartWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->notStartWith($string); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String start with %s'), $string))
 				->object($asserter->notStartWith(uniqid()))->isIdenticalTo($asserter)
 		;
@@ -342,26 +342,26 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->endWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->and($diff = new diffs\variable())
 			->and($fragment = $this->getRandomUtf8String())
 			->then
 				->exception(function() use ($asserter, $fragment) { $asserter->endWith($fragment); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not end with %s'), $fragment))
 				->object($asserter->endWith($string))->isIdenticalTo($asserter)
 			->if($asserter->setWith($string . uniqid()))
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->endWith($string); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not end with %s'), $string))
 			->if($asserter->setWith(uniqid() . $string))
 			->then
 				->object($asserter->endWith($string))->isIdenticalTo($asserter)
 				->exception(function() use ($asserter, $string, & $fragment) { $asserter->endWith($fragment = mb_strtoupper($string, 'UTF-8')); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String does not end with %s'), $fragment))
 		;
 	}
@@ -372,12 +372,12 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->notEndWith(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith($string = $this->getRandomUtf8String()))
 			->then
 				->exception(function() use ($asserter, $string) { $asserter->notEndWith($string); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($this->getLocale()->_('String end with %s'), $string))
 				->object($asserter->notEndWith(uniqid()))->isIdenticalTo($asserter)
 		;
@@ -389,24 +389,24 @@ class utf8String extends atoum\test
 			->if($asserter = new sut($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->length; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Value is undefined')
 			->if($asserter->setWith(''))
 			->then
 				->object($integer = $asserter->length)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(0)
 			->if($asserter->setWith($str = uniqid()))
 			->then
 				->object($integer = $asserter->length)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(strlen($str))
 			->if($asserter->setWith($str = $this->getRandomUtf8String()))
 			->then
 				->object($integer = $asserter->length)
-					->isInstanceOf('mageekguy\atoum\asserters\integer')
+					->isInstanceOf('atoum\asserters\integer')
 				->integer($integer->getValue())
 					->isEqualTo(mb_strlen($str, 'UTF-8'))
 		;

--- a/tests/units/classes/asserters/variable.php
+++ b/tests/units/classes/asserters/variable.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\asserters;
+namespace atoum\tests\units\asserters;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\asserter,
-	mageekguy\atoum\tools\diffs,
-	mageekguy\atoum\asserters\variable as sut
+	atoum,
+	atoum\asserter,
+	atoum\tools\diffs,
+	atoum\asserters\variable as sut
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class variable extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\asserter');
+		$this->testedClass->isSubclassOf('atoum\asserter');
 	}
 
 	public function test__construct()
@@ -131,14 +131,14 @@ class variable extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use (& $line, $asserter, & $notEqualValue) { $line = __LINE__; $asserter->isEqualTo($notEqualValue = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not equal to %s'), $asserter, $asserter->getTypeOf($notEqualValue)) . PHP_EOL . $diff->setExpected($notEqualValue)->setActual($asserter->getValue()))
 			->if($asserter->setWith(1))
 			->and($otherDiff = new diffs\variable())
 			->then
 				->object($asserter->isEqualTo('1'))->isIdenticalTo($asserter)
 				->exception(function() use (& $otherLine, $asserter, & $otherNotEqualValue, & $otherFailMessage) { $otherLine = __LINE__; $asserter->isEqualTo($otherNotEqualValue = uniqid(), $otherFailMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($otherFailMessage . PHP_EOL . $otherDiff->setExpected($otherNotEqualValue)->setActual($asserter->getValue()))
 		;
 	}
@@ -156,10 +156,10 @@ class variable extends atoum\test
 				->then
 					->object($asserter->isNotEqualTo(uniqid()))->isIdenticalTo($asserter)
 					->exception(function() use ($asserter, $value) { $asserter->isNotEqualTo($value); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage(sprintf($generator->getLocale()->_('%s is equal to %s'), $asserter, $asserter->getTypeOf($value)))
 					->exception(function() use ($asserter, $value, & $failMessage) { $asserter->isNotEqualTo($value, $failMessage = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->isInstanceOf('atoum\asserter\exception')
 						->hasMessage($failMessage)
 		;
 	}
@@ -179,10 +179,10 @@ class variable extends atoum\test
 			->if($diff = new diffs\variable())
 			->then
 				->exception(function() use ($asserter, & $notIdenticalValue, $value) { $asserter->isIdenticalTo($notIdenticalValue = (string) $value); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not identical to %s'), $asserter, $asserter->getTypeOf($notIdenticalValue)) . PHP_EOL . $diff->setExpected($notIdenticalValue)->setActual($asserter->getValue()))
 				->exception(function() use ($asserter, $notIdenticalValue, & $failMessage) { $asserter->isIdenticalTo($notIdenticalValue, $failMessage = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage($failMessage . PHP_EOL . $diff->setExpected($notIdenticalValue)->setActual($asserter->getValue()))
 		;
 	}
@@ -200,7 +200,7 @@ class variable extends atoum\test
 			->then
 			->object($asserter->isNotIdenticalTo(uniqid()))->isIdenticalTo($asserter)
 			->exception(function() use ($asserter, & $notIdenticalValue, $value) { $asserter->isNotIdenticalTo($value); })
-				->isInstanceOf('mageekguy\atoum\asserter\exception')
+				->isInstanceOf('atoum\asserter\exception')
 				->hasMessage(sprintf($generator->getLocale()->_('%s is identical to %s'), $asserter, $asserter->getTypeOf($value)))
 		;
 	}
@@ -220,22 +220,22 @@ class variable extends atoum\test
 			->if($asserter->setWith(''))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 			->if($asserter->setWith(uniqid()))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 			->if($asserter->setWith(0))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 			->if($asserter->setWith(false))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not null'), $asserter))
 		;
 	}
@@ -255,7 +255,7 @@ class variable extends atoum\test
 			->if($asserter->setWith(null))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotNull(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is null'), $asserter))
 		;
 	}
@@ -285,7 +285,7 @@ class variable extends atoum\test
 			->if($notReference = uniqid())
 			->then
 				->exception(function() use ($asserter, $notReference) { $asserter->isReferenceTo($notReference); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a reference to %s'), $asserter, $asserter->getTypeOf($notReference)))
 			->if($value = new \exception())
 			->and($reference = $value)
@@ -297,7 +297,7 @@ class variable extends atoum\test
 			->if($notReference = new \exception())
 			->then
 				->exception(function() use ($asserter, $notReference) { $asserter->isReferenceTo($notReference); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not a reference to %s'), $asserter, $asserter->getTypeOf($notReference)))
 		;
 	}
@@ -317,7 +317,7 @@ class variable extends atoum\test
 			->if($asserter->setWith(false))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotFalse(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is false'), $asserter))
 		;
 	}
@@ -337,7 +337,7 @@ class variable extends atoum\test
 			->if($asserter->setWith(true))
 			->then
 				->exception(function() use ($asserter) { $asserter->isNotTrue(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->isInstanceOf('atoum\asserter\exception')
 					->hasMessage(sprintf($generator->getLocale()->_('%s is true'), $asserter))
 		;
 	}

--- a/tests/units/classes/autoloader.php
+++ b/tests/units/classes/autoloader.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\autoloader as testedClass
+	atoum,
+	atoum\autoloader as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -14,6 +14,7 @@ class autoloader extends atoum\test
 	public function testClassConstants()
 	{
 		$this
+			->integer(testedClass::version)->isEqualTo(1)
 			->string(testedClass::defaultCacheFileName)->isEqualTo('%s.atoum.cache')
 			->string(testedClass::defaultFileSuffix)->isEqualTo('.php')
 		;
@@ -27,7 +28,7 @@ class autoloader extends atoum\test
 				->array($autoloader->getClasses())->isEmpty()
 				->variable($autoloader->getCacheFileForInstance())->isEqualTo(testedClass::getCacheFile())
 				->array($autoloader->getDirectories())->isEqualTo(array(
-						'mageekguy\atoum\\' => array(
+						'atoum\\' => array(
 							array(
 								atoum\directory . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR,
 								testedClass::defaultFileSuffix
@@ -35,8 +36,8 @@ class autoloader extends atoum\test
 						)
 					)
 				)
-				->array($autoloader->getNamespaceAliases())->isEqualTo(array('atoum\\' => 'mageekguy\\atoum\\'))
-				->array($autoloader->getClassAliases())->isEqualTo(array('atoum' => 'mageekguy\\atoum\\test', 'mageekguy\\atoum' => 'mageekguy\\atoum\\test'))
+				->array($autoloader->getNamespaceAliases())->isEqualTo(array('mageekguy\\atoum\\' => 'atoum\\'))
+				->array($autoloader->getClassAliases())->isEqualTo(array('atoum' => 'atoum\\test'))
 		;
 	}
 
@@ -47,26 +48,26 @@ class autoloader extends atoum\test
 			->then
 				->object($autoloader->addNamespaceAlias($alias = uniqid(), $target = uniqid()))->isIdenticalTo($autoloader)
 				->array($autoloader->getNamespaceAliases())->isEqualTo(array(
-						'atoum\\' => 'mageekguy\\atoum\\',
+						'mageekguy\\atoum\\' => 'atoum\\',
 						$alias . '\\' => $target . '\\'
 					)
 				)
 				->object($autoloader->addNamespaceAlias($alias, $target))->isIdenticalTo($autoloader)
 				->array($autoloader->getNamespaceAliases())->isEqualTo(array(
-						'atoum\\' => 'mageekguy\\atoum\\',
+						'mageekguy\\atoum\\' => 'atoum\\',
 						$alias . '\\' => $target . '\\'
 					)
 				)
 				->object($autoloader->addNamespaceAlias('\\' . ($otherAlias = uniqid()), '\\' . ($otherTarget = uniqid())))->isIdenticalTo($autoloader)
 				->array($autoloader->getNamespaceAliases())->isEqualTo(array(
-						'atoum\\' => 'mageekguy\\atoum\\',
+						'mageekguy\\atoum\\' => 'atoum\\',
 						$alias . '\\' => $target . '\\',
 						$otherAlias . '\\' => $otherTarget . '\\'
 					)
 				)
 				->object($autoloader->addNamespaceAlias('\\' . ($anOtherAlias = uniqid()) . '\\', '\\' . ($anOtherTarget = uniqid()) . '\\'))->isIdenticalTo($autoloader)
 				->array($autoloader->getNamespaceAliases())->isEqualTo(array(
-						'atoum\\' => 'mageekguy\\atoum\\',
+						'mageekguy\\atoum\\' => 'atoum\\',
 						$alias . '\\' => $target . '\\',
 						$otherAlias . '\\' => $otherTarget . '\\',
 						$anOtherAlias . '\\' => $anOtherTarget . '\\'
@@ -74,7 +75,7 @@ class autoloader extends atoum\test
 				)
 				->object($autoloader->addNamespaceAlias('FOO', ($fooTarget = uniqid())))->isIdenticalTo($autoloader)
 				->array($autoloader->getNamespaceAliases())->isEqualTo(array(
-						'atoum\\' => 'mageekguy\\atoum\\',
+						'mageekguy\\atoum\\' => 'atoum\\',
 						$alias . '\\' => $target . '\\',
 						$otherAlias . '\\' => $otherTarget . '\\',
 						$anOtherAlias . '\\' => $anOtherTarget . '\\',
@@ -91,30 +92,26 @@ class autoloader extends atoum\test
 			->then
 				->object($autoloader->addClassAlias($alias = uniqid(), $target = uniqid()))->isIdenticalTo($autoloader)
 				->array($autoloader->getClassAliases())->isEqualTo(array(
-						'atoum' => 'mageekguy\\atoum\\test',
-						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						'atoum' => 'atoum\\test',
 						$alias => $target
 					)
 				)
 				->object($autoloader->addClassAlias($alias, $target))->isIdenticalTo($autoloader)
 				->array($autoloader->getClassAliases())->isEqualTo(array(
-						'atoum' => 'mageekguy\\atoum\\test',
-						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						'atoum' => 'atoum\\test',
 						$alias => $target
 					)
 				)
 				->object($autoloader->addClassAlias('\\' . ($otherAlias = uniqid()), '\\' . ($otherTarget = uniqid())))->isIdenticalTo($autoloader)
 				->array($autoloader->getClassAliases())->isEqualTo(array(
-						'atoum' => 'mageekguy\\atoum\\test',
-						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						'atoum' => 'atoum\\test',
 						$alias => $target,
 						$otherAlias => $otherTarget
 					)
 				)
 				->object($autoloader->addClassAlias('\\' . ($anOtherAlias = uniqid()) . '\\', '\\' . ($anOtherTarget = uniqid()) . '\\'))->isIdenticalTo($autoloader)
 				->array($autoloader->getClassAliases())->isEqualTo(array(
-						'atoum' => 'mageekguy\\atoum\\test',
-						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						'atoum' => 'atoum\\test',
 						$alias => $target,
 						$otherAlias => $otherTarget,
 						$anOtherAlias => $anOtherTarget
@@ -122,8 +119,7 @@ class autoloader extends atoum\test
 				)
 				->object($autoloader->addClassAlias('FOO', '\\' . ($fooTarget = uniqid()) . '\\'))->isIdenticalTo($autoloader)
 				->array($autoloader->getClassAliases())->isEqualTo(array(
-						'atoum' => 'mageekguy\\atoum\\test',
-						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						'atoum' => 'atoum\\test',
 						$alias => $target,
 						$otherAlias => $otherTarget,
 						$anOtherAlias => $anOtherTarget,

--- a/tests/units/classes/cli.php
+++ b/tests/units/classes/cli.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';

--- a/tests/units/classes/cli/colorizer.php
+++ b/tests/units/classes/cli/colorizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\cli;
+namespace atoum\tests\units\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli
+	atoum,
+	atoum\cli
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -13,7 +13,7 @@ class colorizer extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->implements('mageekguy\atoum\writer\decorator');
+		$this->testedClass->implements('atoum\writer\decorator');
 	}
 
 	public function test__construct()
@@ -110,7 +110,7 @@ class colorizer extends atoum\test
 	public function testColorize()
 	{
 		$this
-			->if($colorizer = new cli\colorizer(null, null, $cli = new \mock\mageekguy\atoum\cli()))
+			->if($colorizer = new cli\colorizer(null, null, $cli = new \mock\atoum\cli()))
 			->and($this->calling($cli)->isTerminal = true)
 			->then
 				->string($colorizer->colorize($string = uniqid()))->isEqualTo($string)
@@ -139,7 +139,7 @@ class colorizer extends atoum\test
 	public function testDecorate()
 	{
 		$this
-			->if($colorizer = new cli\colorizer(null, null, $cli = new \mock\mageekguy\atoum\cli()))
+			->if($colorizer = new cli\colorizer(null, null, $cli = new \mock\atoum\cli()))
 			->and($this->calling($cli)->isTerminal = true)
 			->then
 				->string($colorizer->decorate($string = uniqid()))->isEqualTo($string)

--- a/tests/units/classes/cli/progressBar.php
+++ b/tests/units/classes/cli/progressBar.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\cli;
+namespace atoum\tests\units\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli,
-	mageekguy\atoum\mock
+	atoum,
+	atoum\cli,
+	atoum\mock
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -54,7 +54,7 @@ class progressBar extends atoum\test
 	public function testRefresh()
 	{
 		$this
-			->if($cli = new \mock\mageekguy\atoum\cli())
+			->if($cli = new \mock\atoum\cli())
 			->and($cli->getMockController()->isTerminal = true)
 			->and($progressBar = new cli\progressBar(0, $cli))
 			->then

--- a/tests/units/classes/cli/prompt.php
+++ b/tests/units/classes/cli/prompt.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\cli;
+namespace atoum\tests\units\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli
+	atoum,
+	atoum\cli
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -17,7 +17,7 @@ class prompt extends atoum\test
 
 		$this->assert
 			->string($prompt->getValue())->isEmpty()
-			->object($prompt->getColorizer())->isInstanceOf('mageekguy\atoum\cli\colorizer')
+			->object($prompt->getColorizer())->isInstanceOf('atoum\cli\colorizer')
 			->variable($prompt->getColorizer()->getForeground())->isNull()
 			->variable($prompt->getColorizer()->getBackground())->isNull()
 		;
@@ -26,7 +26,7 @@ class prompt extends atoum\test
 
 		$this->assert
 			->string($prompt->getValue())->isEqualTo($value)
-			->object($prompt->getColorizer())->isInstanceOf('mageekguy\atoum\cli\colorizer')
+			->object($prompt->getColorizer())->isInstanceOf('atoum\cli\colorizer')
 			->variable($prompt->getColorizer()->getForeground())->isNull()
 			->variable($prompt->getColorizer()->getBackground())->isNull()
 		;

--- a/tests/units/classes/configurator.php
+++ b/tests/units/classes/configurator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -25,10 +25,10 @@ class configurator extends atoum\test
 	{
 		$this
 			->assert
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($runner->getMockController()->setBootstrapFile = function() {})
-				->and($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
-				->and($this->calling($script)->addDefaultReport = $report = new \mock\mageekguy\atoum\report())
+				->and($script = new \mock\atoum\scripts\runner(uniqid()))
+				->and($this->calling($script)->addDefaultReport = $report = new \mock\atoum\report())
 				->and($script->setRunner($runner))
 				->and($configurator = new atoum\configurator($script))
 				->then
@@ -43,10 +43,10 @@ class configurator extends atoum\test
 					->object($configurator->addDefaultReport())->isIdenticalTo($report)
 					->mock($script)->call('addDefaultReport')->once()
 				->exception(function() use ($configurator, & $method) { $configurator->{$method = uniqid()}(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Method \'' . $method . '\' is unavailable')
 				->exception(function() use ($configurator) { $configurator->setPhpPath(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Method \'setPhpPath\' is unavailable')
 		;
 	}

--- a/tests/units/classes/exceptions/logic.php
+++ b/tests/units/classes/exceptions/logic.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions;
+namespace atoum\tests\units\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,7 +18,7 @@ class logic extends atoum\test
 		$this->assert
 			->object($logicExcepion)
 				->isInstanceOf('logicException')
-				->isInstanceOf('mageekguy\atoum\exception')
+				->isInstanceOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/logic/badMethodCall.php
+++ b/tests/units/classes/exceptions/logic/badMethodCall.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions\logic;
+namespace atoum\tests\units\exceptions\logic;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\logic
+	atoum,
+	atoum\exceptions\logic
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class badMethodCall extends atoum\test
 			->testedClass
 				->isSubclassOf('logicException')
 				->isSubclassOf('badMethodCallException')
-				->isSubclassOf('mageekguy\atoum\exception')
+				->isSubclassOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/logic/invalidArgument.php
+++ b/tests/units/classes/exceptions/logic/invalidArgument.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions\logic;
+namespace atoum\tests\units\exceptions\logic;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\logic
+	atoum,
+	atoum\exceptions\logic
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class invalidArgument extends atoum\test
 			->testedClass
 				->isSubclassOf('logicException')
 				->isSubclassOf('invalidArgumentException')
-				->isSubclassOf('mageekguy\atoum\exception')
+				->isSubclassOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/runtime.php
+++ b/tests/units/classes/exceptions/runtime.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions;
+namespace atoum\tests\units\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,7 +18,7 @@ class runtime extends atoum\test
 		$this->assert
 			->object($runtimeExcepion)
 				->isInstanceOf('runtimeException')
-				->isInstanceOf('mageekguy\atoum\exception')
+				->isInstanceOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/exceptions/runtime/unexpectedValue.php
+++ b/tests/units/classes/exceptions/runtime/unexpectedValue.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\exceptions\runtime;
+namespace atoum\tests\units\exceptions\runtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions\runtime
+	atoum,
+	atoum\exceptions\runtime
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -19,7 +19,7 @@ class unexpectedValue extends atoum\test
 			->object($unexpectedValueException)
 				->isInstanceOf('runtimeException')
 				->isInstanceOf('unexpectedValueException')
-				->isInstanceOf('mageekguy\atoum\exception')
+				->isInstanceOf('atoum\exception')
 		;
 	}
 }

--- a/tests/units/classes/fs/path.php
+++ b/tests/units/classes/fs/path.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\fs;
+namespace atoum\tests\units\fs;
 
 require_once __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\fs\path as testedClass
+	atoum,
+	atoum\fs\path as testedClass
 ;
 
 // See http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx for more informations
@@ -631,7 +631,7 @@ class path extends atoum\test
 				->if($path = new testedClass('/an/invalid/path', '/', $adapter))
 				->then
 					->exception(function() use ($path) { $path->getRealPath(); })
-						->isInstanceOf('mageekguy\atoum\fs\path\exception')
+						->isInstanceOf('atoum\fs\path\exception')
 						->hasMessage('Unable to get real path for \'' . $path . '\'')
 		;
 	}
@@ -713,7 +713,7 @@ class path extends atoum\test
 			->if($adapter->mkdir = false)
 			->then
 				->exception(function() use ($path) { $path->createParentDirectory(); })
-					->isInstanceOf('mageekguy\atoum\fs\path\exception')
+					->isInstanceOf('atoum\fs\path\exception')
 					->hasMessage('Unable to create directory \'/a\'')
 			->if($adapter->file_exists = true)
 			->and($this->resetAdapter($adapter))
@@ -739,7 +739,7 @@ class path extends atoum\test
 			->if($adapter->file_put_contents = false)
 			->then
 				->exception(function() use ($path, & $data) { $path->putContents($data = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\fs\path\exception')
+					->isInstanceOf('atoum\fs\path\exception')
 					->hasMessage('Unable to put data \'' . $data . '\' in file \'' . $path . '\'')
 		;
 	}

--- a/tests/units/classes/fs/path/exception.php
+++ b/tests/units/classes/fs/path/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\fs\path;
+namespace atoum\tests\units\fs\path;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -12,6 +12,6 @@ class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\exceptions\runtime');
+		$this->testedClass->extends('atoum\exceptions\runtime');
 	}
 }

--- a/tests/units/classes/fs/path/factory.php
+++ b/tests/units/classes/fs/path/factory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\fs\path;
+namespace atoum\tests\units\fs\path;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\fs\path,
-	mageekguy\atoum\fs\path\factory as testedClass
+	atoum,
+	atoum\fs\path,
+	atoum\fs\path\factory as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';

--- a/tests/units/classes/includer.php
+++ b/tests/units/classes/includer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\includer as testedClass
+	atoum,
+	atoum\mock\stream,
+	atoum\includer as testedClass
 ;
 
 require __DIR__ . '/../runner.php';
@@ -61,7 +61,7 @@ class includer extends atoum\test
 			->and($unknownFile = stream::get())
 			->then
 				->exception(function() use ($includer, $unknownFile) { $includer->includePath($unknownFile); })
-					->isInstanceOf('mageekguy\atoum\includer\exception')
+					->isInstanceOf('atoum\includer\exception')
 					->hasMessage('Unable to include \'' . $unknownFile . '\'')
 				->array($includer->getErrors())->isNotEmpty()
 				->adapter($adapter)

--- a/tests/units/classes/iterators/filters/recursives/atoum/source.php
+++ b/tests/units/classes/iterators/filters/recursives/atoum/source.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\filters\recursives\atoum;
+namespace atoum\tests\units\iterators\filters\recursives\atoum;
 
 require __DIR__ . '/../../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\iterators\filters\recursives
+	atoum,
+	atoum\mock,
+	atoum\iterators\filters\recursives
 ;
 
 class source extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\iterators\filters\recursives\dot');
+		$this->testedClass->extends('atoum\iterators\filters\recursives\dot');
 	}
 
 	public function test__accept()

--- a/tests/units/classes/iterators/filters/recursives/closure.php
+++ b/tests/units/classes/iterators/filters/recursives/closure.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\filters\recursives;
+namespace atoum\tests\units\iterators\filters\recursives;
 
 require __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators\filters\recursives\closure as testedClass
+	atoum,
+	atoum\iterators\filters\recursives\closure as testedClass
 ;
 
 class closure extends atoum\test

--- a/tests/units/classes/iterators/filters/recursives/dot.php
+++ b/tests/units/classes/iterators/filters/recursives/dot.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\filters\recursives;
+namespace atoum\tests\units\iterators\filters\recursives;
 
 require __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\iterators\filters\recursives
+	atoum,
+	atoum\mock,
+	atoum\iterators\filters\recursives
 ;
 
 class dot extends atoum\test

--- a/tests/units/classes/iterators/filters/recursives/extension.php
+++ b/tests/units/classes/iterators/filters/recursives/extension.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\filters\recursives;
+namespace atoum\tests\units\iterators\filters\recursives;
 
 require __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\iterators\filters\recursives
+	atoum,
+	atoum\mock,
+	atoum\iterators\filters\recursives
 ;
 
 class extension extends atoum\test

--- a/tests/units/classes/iterators/recursives/atoum/source.php
+++ b/tests/units/classes/iterators/recursives/atoum/source.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\recursives\atoum;
+namespace atoum\tests\units\iterators\recursives\atoum;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\mock\stream
+	atoum,
+	atoum\iterators,
+	atoum\mock\stream
 ;
 
 class source extends atoum\test

--- a/tests/units/classes/iterators/recursives/directory/factory.php
+++ b/tests/units/classes/iterators/recursives/directory/factory.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\iterators\recursives\directory;
+namespace atoum\tests\units\iterators\recursives\directory;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\iterators\filters,
-	mageekguy\atoum\iterators\recursives\directory\factory as testedClass
+	atoum,
+	atoum\iterators\filters,
+	atoum\iterators\recursives\directory\factory as testedClass
 ;
 
 class factory extends atoum\test

--- a/tests/units/classes/locale.php
+++ b/tests/units/classes/locale.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';

--- a/tests/units/classes/mailers/mail.php
+++ b/tests/units/classes/mailers/mail.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mailers;
+namespace atoum\tests\units\mailers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mailers
+	atoum,
+	atoum\mailers
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class mail extends atoum\test
 	{
 		$this->assert
 			->class($this->getTestedClassName())
-				->isSubClassOf('mageekguy\atoum\mailer')
+				->isSubClassOf('atoum\mailer')
 			->string(mailers\mail::eol)->isEqualTo("\r\n")
 		;
 	}
@@ -145,7 +145,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('To is undefined')
 		;
 
@@ -153,7 +153,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Subject is undefined')
 		;
 
@@ -161,7 +161,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('From is undefined')
 		;
 
@@ -169,7 +169,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Reply to is undefined')
 		;
 
@@ -177,7 +177,7 @@ class mail extends atoum\test
 
 		$this->assert
 			->exception(function() use ($mail) { $mail->send(uniqid()); })
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('X-mailer is undefined')
 		;
 

--- a/tests/units/classes/mock/controller.php
+++ b/tests/units/classes/mock/controller.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock;
+namespace atoum\tests\units\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\test\adapter\invoker,
-	mageekguy\atoum\mock\controller as testedClass
+	atoum,
+	atoum\mock,
+	atoum\test\adapter\invoker,
+	atoum\mock\controller as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -27,7 +27,7 @@ class controller extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\test\adapter');
+		$this->testedClass->extends('atoum\test\adapter');
 	}
 
 	public function test__construct()
@@ -73,7 +73,7 @@ class controller extends atoum\test
 				->string($mockController->invoke(strtoupper($otherMethod)))->isEqualTo($otherReturn)
 				->array($mockController->getCalls($otherMethod))->hasSize(2)
 				->array($mockController->getCalls(strtoupper($otherMethod)))->hasSize(2)
-			->if($mockController->control(new \mock\mageekguy\atoum\tests\units\mock\foo()))
+			->if($mockController->control(new \mock\atoum\tests\units\mock\foo()))
 			->then
 				->boolean(isset($mockController->__call))->isTrue()
 				->string($mockController->invoke($method))->isEqualTo($return)
@@ -82,7 +82,7 @@ class controller extends atoum\test
 				->array($mockController->getCalls(strtoupper($method)))->hasSize(2)
 				->variable($mockController->getCalls('__call'))->isNull()
 				->variable($mockController->getCalls(strtoupper('__call')))->isNull()
-			->if($mockController->control($mock = new \mock\mageekguy\atoum\tests\units\mock\foo()))
+			->if($mockController->control($mock = new \mock\atoum\tests\units\mock\foo()))
 			->and($mockController->bar = function() {})
 			->and($mock->bar($arg = uniqid(), $otherArg = uniqid()))
 			->then
@@ -100,33 +100,33 @@ class controller extends atoum\test
 	{
 		$this
 			->if($mockController = new testedClass())
-			->and($mockController->control($mock = new \mock\mageekguy\atoum\tests\units\mock\foo()))
+			->and($mockController->control($mock = new \mock\atoum\tests\units\mock\foo()))
 			->and($mockController->doSomething = function() use (& $public) { $this->public = $public = uniqid(); })
 			->and($mock->doSomething())
 			->then
 				->string($mock->public)->isEqualTo($public)
 			->if($mockController = new testedClass())
 			->and($mockController->__construct = function() use (& $public) { $this->public = $public = uniqid(); })
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo())
+			->and($mock = new \mock\atoum\tests\units\mock\foo())
 			->then
 				->string($mock->public)->isEqualTo($public)
 			->if($mockController = new testedClass())
 			->and($mockController->__construct = function() use (& $public) { $this->public = $public = uniqid(); })
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo($mockController))
+			->and($mock = new \mock\atoum\tests\units\mock\foo($mockController))
 			->then
 				->string($mock->public)->isEqualTo($public)
 			->if($mockController->disableAutoBind())
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo($mockController))
+			->and($mock = new \mock\atoum\tests\units\mock\foo($mockController))
 			->then
 				->variable($mock->public)->isNull()
 			->if(testedClass::disableAutoBindForNewMock())
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo($mockController))
+			->and($mock = new \mock\atoum\tests\units\mock\foo($mockController))
 			->then
 				->variable($mock->public)->isNull()
 			->if($mockController = new testedClass())
 			->and($mockController->__construct = function() use (& $public) { $this->public = $public = uniqid(); })
 			->and($mockController->enableAutoBind())
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo($mockController))
+			->and($mock = new \mock\atoum\tests\units\mock\foo($mockController))
 			->then
 				->string($mock->public)->isEqualTo($public)
 		;
@@ -146,7 +146,7 @@ class controller extends atoum\test
 				->boolean($mockController->autoBindIsEnabled())->isTrue()
 			->if($mockController->disableAutoBind())
 			->and($mockController->doSomething = function() { return $this; })
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo($mockController))
+			->and($mock = new \mock\atoum\tests\units\mock\foo($mockController))
 			->then
 				->object($mockController->enableAutoBind())->isIdenticalTo($mockController)
 				->boolean($mockController->autoBindIsEnabled())->isTrue()
@@ -168,7 +168,7 @@ class controller extends atoum\test
 				->boolean($mockController->autoBindIsEnabled())->isFalse()
 			->if($mockController->enableAutoBind())
 			->and($mockController->doSomething = function() { return $this; })
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\foo($mockController))
+			->and($mock = new \mock\atoum\tests\units\mock\foo($mockController))
 			->then
 				->object($mockController->disableAutoBind())->isIdenticalTo($mockController)
 				->boolean($mockController->autoBindIsEnabled())->isFalse()
@@ -197,15 +197,15 @@ class controller extends atoum\test
 		$this
 			->if($mockController = new testedClass())
 			->then
-				->object($mockController->{uniqid()})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($mockController->{uniqid()})->isInstanceOf('atoum\test\adapter\invoker')
 			->if($mockController->{$method = uniqid()} = $function = function() {})
 			->then
-				->object($mockController->{uniqid()})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($mockController->{uniqid()})->isInstanceOf('atoum\test\adapter\invoker')
 				->object($mockController->{$method}->getClosure())->isIdenticalTo($function)
 				->object($mockController->{strtoupper($method)}->getClosure())->isIdenticalTo($function)
 			->if($mockController->{$otherMethod = uniqid()} = $return = uniqid())
 			->then
-				->object($mockController->{uniqid()})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($mockController->{uniqid()})->isInstanceOf('atoum\test\adapter\invoker')
 				->object($mockController->{$method}->getClosure())->isIdenticalTo($function)
 				->object($mockController->{strtoupper($method)}->getClosure())->isIdenticalTo($function)
 				->object($mockController->{$otherMethod}->getClosure())->isInstanceOf('closure')
@@ -301,7 +301,7 @@ class controller extends atoum\test
 	{
 		$this
 			->if($mockController = new testedClass())
-			->and($mockController->control(new \mock\mageekguy\atoum\tests\units\mock\foo()))
+			->and($mockController->control(new \mock\atoum\tests\units\mock\foo()))
 			->then
 				->object($mockController->methodsMatching('/Else$/i'))->isEqualTo($mockController->getIterator())
 				->array($mockController->getIterator()->getMethods())->isEqualTo(array('dosomethingelse'))
@@ -313,7 +313,7 @@ class controller extends atoum\test
 	public function testDoNothing()
 	{
 		$this
-			->if($mock = new \mock\mageekguy\atoum\tests\units\mock\foo())
+			->if($mock = new \mock\atoum\tests\units\mock\foo())
 			->and($this->calling($mock)->doSomething->doNothing())
 			->then
 				->variable($mock->doSomething())->isNull()
@@ -323,7 +323,7 @@ class controller extends atoum\test
 	public function testDoSomething()
 	{
 		$this
-			->if($mock = new \mock\mageekguy\atoum\tests\units\mock\foo())
+			->if($mock = new \mock\atoum\tests\units\mock\foo())
 			->and($this->calling($mock)->doSomething->doNothing())
 			->and($this->calling($mock)->doSomething->doSomething())
 			->then
@@ -356,7 +356,7 @@ class controller extends atoum\test
 			->and($mockController->{$method = uniqid()} = uniqid())
 			->then
 				->exception(function() use ($mockController, $aMock) { $mockController->control($aMock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Method \'' . get_class($aMock) . '::' . $method . '()\' does not exist')
 			->if($mockController->disableMethodChecking())
 			->and($mockController->{uniqid()} = uniqid())
@@ -402,7 +402,7 @@ class controller extends atoum\test
 						$mockController->invoke($method, array());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Method ' . $method . '() is not under control')
 			->if($return = uniqid())
 			->and($mockController->test = function() use ($return) { return $return; })
@@ -553,10 +553,10 @@ class controller extends atoum\test
 						)
 					)
 			->if($mockController = new testedClass())
-			->and($mockController->control($mock = new \mock\mageekguy\atoum\tests\units\mock\bar()))
+			->and($mockController->control($mock = new \mock\atoum\tests\units\mock\bar()))
 			->then
 				->exception(function() use ($mockController) { $mockController->foo = uniqid(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Method \'mock\\' . __NAMESPACE__ . '\bar::foo()\' does not exist')
 		;
 	}
@@ -589,7 +589,7 @@ class controller extends atoum\test
 				->array($mockController->getCalls())->isEmpty()
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
-			->and($mock = new \mock\mageekguy\atoum\tests\units\mock\controller($adapter))
+			->and($mock = new \mock\atoum\tests\units\mock\controller($adapter))
 			->and($mockController->control($mock))
 			->and($mockController->{$method = __FUNCTION__} = function() {})
 			->and($mockController->invoke($method, array()))

--- a/tests/units/classes/mock/controller/iterator.php
+++ b/tests/units/classes/mock/controller/iterator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\controller;
+namespace atoum\tests\units\mock\controller;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\controller\iterator as testedClass
+	atoum,
+	atoum\mock,
+	atoum\mock\controller\iterator as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -44,7 +44,7 @@ class iterator extends atoum\test
 	{
 		$this
 			->if($iterator = new testedClass($controller = new mock\controller()))
-			->and($controller->control($mock = new \mock\mageekguy\atoum\tests\units\mock\controller\foo()))
+			->and($controller->control($mock = new \mock\atoum\tests\units\mock\controller\foo()))
 			->and($iterator->return = $return = uniqid())
 			->then
 				->boolean(isset($controller->__construct))->isFalse()
@@ -72,7 +72,7 @@ class iterator extends atoum\test
 				->exception(function() use ($controller) { $controller->doSomething->invoke(); })->isIdenticalTo($exception)
 				->exception(function() use ($controller) { $controller->doSomethingElse->invoke(); })->isIdenticalTo($exception)
 			->exception(function() use ($iterator) { $iterator->{uniqid()} = uniqid(); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 		;
 	}
 
@@ -120,7 +120,7 @@ class iterator extends atoum\test
 			->if($iterator = new testedClass($controller = new mock\controller()))
 			->then
 				->array($iterator->getMethods())->isEmpty()
-			->if($controller->control($mock = new \mock\mageekguy\atoum\tests\units\mock\controller\foo()))
+			->if($controller->control($mock = new \mock\atoum\tests\units\mock\controller\foo()))
 			->then
 				->array($iterator->getMethods())->isEqualTo(array('dosomething', 'dosomethingelse'))
 			->if($iterator->addFilter(function($method) { return true; }))
@@ -141,7 +141,7 @@ class iterator extends atoum\test
 			->if($iterator = new testedClass($controller = new mock\controller()))
 			->then
 				->object($iterator->getIterator())->isEqualTo(new \arrayIterator($iterator->getMethods()))
-			->if($controller->control(new \mock\mageekguy\atoum\tests\units\mock\controller\foo()))
+			->if($controller->control(new \mock\atoum\tests\units\mock\controller\foo()))
 			->then
 				->object($iterator->getIterator())->isEqualTo(new \arrayIterator($iterator->getMethods()))
 		;

--- a/tests/units/classes/mock/controller/linker.php
+++ b/tests/units/classes/mock/controller/linker.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\controller;
+namespace atoum\tests\units\mock\controller;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\controller,
-	mageekguy\atoum\mock\controller\linker as testedClass
+	atoum,
+	atoum\mock\controller,
+	atoum\mock\controller\linker as testedClass
 ;
 
 require __DIR__ . '../../../../runner.php';
@@ -19,7 +19,7 @@ class linker extends atoum\test
 			->and(controller::setLinker($linker))
 			->then
 				->if($mock = new \mock\foo())
-				->and($controller = new \mock\mageekguy\atoum\mock\controller())
+				->and($controller = new \mock\atoum\mock\controller())
 				->then
 					->object($linker->link($controller, $mock))->isIdenticalTo($linker)
 					->mock($controller)->call('control')->withArguments($mock)->once()
@@ -68,13 +68,13 @@ class linker extends atoum\test
 			->given($linker = new testedClass())
 			->and(controller::setLinker($linker))
 			->then
-				->if($linker->link($controller = new \mock\mageekguy\atoum\mock\controller(), $mock = new \mock\foo()))
+				->if($linker->link($controller = new \mock\atoum\mock\controller(), $mock = new \mock\foo()))
 				->then
 					->object($linker->unlink($controller))->isIdenticalTo($linker)
 					->variable($linker->getMock($controller))->isNull()
 					->variable($linker->getController($mock))->isNull()
 					->object($mock->getMockController())->isNotIdenticalTo($controller)
-				->if($linker->link($controller = new \mock\mageekguy\atoum\mock\controller(), $mock))
+				->if($linker->link($controller = new \mock\atoum\mock\controller(), $mock))
 				->and($linker->link($otherController = new controller(), $otherMock = new \mock\foo()))
 				->then
 					->object($linker->unlink($controller))->isIdenticalTo($linker)
@@ -93,7 +93,7 @@ class linker extends atoum\test
 			->given($linker = new testedClass())
 			->and(controller::setLinker($linker))
 			->then
-				->if($linker->link($controller = new \mock\mageekguy\atoum\mock\controller(), $mock = new \mock\foo()))
+				->if($linker->link($controller = new \mock\atoum\mock\controller(), $mock = new \mock\foo()))
 				->then
 					->object($linker->reset())->isIdenticalTo($linker)
 					->variable($linker->getController($mock))->isNull()

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock;
+namespace atoum\tests\units\mock;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\generator as testedClass
+	atoum,
+	atoum\mock,
+	atoum\mock\generator as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -33,7 +33,7 @@ class generator extends atoum\test
 				->object($generator->getAdapter())->isIdenticalTo($adapter)
 				->object($generator->setAdapter())->isIdenticalTo($generator)
 				->object($generator->getAdapter())
-					->isInstanceOf('mageekguy\atoum\adapter')
+					->isInstanceOf('atoum\adapter')
 					->isNotIdenticalTo($adapter)
 					->isEqualTo(new atoum\adapter())
 		;
@@ -177,14 +177,14 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($unknownClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $unknownClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $unknownClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -258,15 +258,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -324,15 +324,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -404,15 +404,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -484,7 +484,7 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
 					"\t" . '' . $overloadedMethod . PHP_EOL .
@@ -492,7 +492,7 @@ class generator extends atoum\test
 					"\t\t" . '$arguments = array_merge(array(' . $argument . '), array_slice(func_get_args(), 1, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -551,15 +551,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -615,15 +615,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -678,14 +678,14 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -739,15 +739,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -798,15 +798,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' implements \\' . $realClass . ', \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' implements \\' . $realClass . ', \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -830,15 +830,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' implements \\iteratorAggregate, \\' . $realClass . ', \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' implements \\iteratorAggregate, \\' . $realClass . ', \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -898,7 +898,7 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' implements \\' . $realClass . ', \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' implements \\' . $realClass . ', \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
 					"\t" . 'public static function ' . $methodName . '()' . PHP_EOL .
@@ -906,11 +906,11 @@ class generator extends atoum\test
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'return call_user_func_array(array(\'parent\', \'' . $methodName . '\'), $arguments);' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -933,7 +933,7 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' implements \\iteratorAggregate, \\' . $realClass . ', \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' implements \\iteratorAggregate, \\' . $realClass . ', \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
 					"\t" . 'public static function ' . $methodName . '()' . PHP_EOL .
@@ -950,11 +950,11 @@ class generator extends atoum\test
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'return $this->getMockController()->invoke(\'getIterator\', $arguments);' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1007,14 +1007,14 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1081,15 +1081,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($className))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $className . ' extends \\' . $className . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $className . ' extends \\' . $className . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1117,13 +1117,13 @@ class generator extends atoum\test
 			->if($generator = new testedClass())
 			->then
 				->exception(function() use ($generator) { $generator->generate(''); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Class name \'\' is invalid')
 				->exception(function() use ($generator) { $generator->generate('\\'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Class name \'\\\' is invalid')
 				->exception(function() use ($generator, & $class) { $generator->generate($class = ('\\' . uniqid() . '\\')); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Class name \'' . $class . '\' is invalid')
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = false)
@@ -1134,13 +1134,13 @@ class generator extends atoum\test
 				->object($generator->generate($class))->isIdenticalTo($generator)
 				->class('\mock\\' . $class)
 					->hasNoParent()
-					->hasInterface('mageekguy\atoum\mock\aggregator')
+					->hasInterface('atoum\mock\aggregator')
 			->if($class = '\\' . uniqid('unknownClass'))
 			->then
 				->object($generator->generate($class))->isIdenticalTo($generator)
 				->class('\mock' . $class)
 					->hasNoParent()
-					->hasInterface('mageekguy\atoum\mock\aggregator')
+					->hasInterface('atoum\mock\aggregator')
 			->if($adapter->class_exists = true)
 			->and($class = uniqid())
 			->then
@@ -1148,7 +1148,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'\mock\\' . $class . '\' already exists')
 			->if($class = '\\' . uniqid())
 			->then
@@ -1156,7 +1156,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'\mock' . $class . '\' already exists')
 			->if($class = uniqid())
 			->and($adapter->class_exists = function($arg) use ($class) { return $arg === '\\' . $class; })
@@ -1171,7 +1171,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'\\' . $class . '\' is final, unable to mock it')
 			->if($class = '\\' . uniqid())
 			->and($adapter->class_exists = function($arg) use ($class) { return $arg === $class; })
@@ -1180,7 +1180,7 @@ class generator extends atoum\test
 						$generator->generate($class);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Class \'' . $class . '\' is final, unable to mock it')
 			->if($reflectionClassController->isFinal = false)
 			->and($generator = new testedClass())
@@ -1188,7 +1188,7 @@ class generator extends atoum\test
 				->object($generator->generate(__CLASS__))->isIdenticalTo($generator)
 				->class('\mock\\' . __CLASS__)
 					->hasParent(__CLASS__)
-					->hasInterface('mageekguy\atoum\mock\aggregator')
+					->hasInterface('atoum\mock\aggregator')
 			->if($generator = new testedClass())
 			->and($generator->shunt('__construct'))
 			->then
@@ -1313,15 +1313,15 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($className))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $className . ' extends \\' . $className . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $className . ' extends \\' . $className . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct($a = null, $b = null, $c = null, \mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct($a = null, $b = null, $c = null, \atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array($a, $b, $c), array_slice(func_get_args(), 3, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1409,14 +1409,14 @@ class generator extends atoum\test
 			->then
 				->string($generator->getMockedClassCode($className))->isEqualTo(
 					'namespace mock {' . PHP_EOL .
-					'final class ' . $className . ' extends \\' . $className . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $className . ' extends \\' . $className . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1497,15 +1497,15 @@ class generator extends atoum\test
 			->then
 			->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
 				'namespace mock {' . PHP_EOL .
-					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\mock\aggregator' . PHP_EOL .
 					'{' . PHP_EOL .
 					$this->getMockControllerMethods() .
-					"\t" . 'public function __construct(callable $callback, \mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . 'public function __construct(callable $callback, \atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . '$arguments = array_merge(array($callback), array_slice(func_get_args(), 1, -1));' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t\t" . '$mockController = \atoum\mock\controller::get();' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1536,20 +1536,20 @@ class generator extends atoum\test
 		return
 			"\t" . 'public function getMockController()' . PHP_EOL .
 			"\t" . '{' . PHP_EOL .
-			"\t\t" . '$mockController = \mageekguy\atoum\mock\controller::getForMock($this);' . PHP_EOL .
+			"\t\t" . '$mockController = \atoum\mock\controller::getForMock($this);' . PHP_EOL .
 			"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
-			"\t\t\t" . '$this->setMockController($mockController = new \mageekguy\atoum\mock\controller());' . PHP_EOL .
+			"\t\t\t" . '$this->setMockController($mockController = new \atoum\mock\controller());' . PHP_EOL .
 			"\t\t" . '}' . PHP_EOL .
 			"\t\t" . 'return $mockController;' . PHP_EOL .
 			"\t" . '}' . PHP_EOL .
-			"\t" . 'public function setMockController(\mageekguy\atoum\mock\controller $controller)' . PHP_EOL .
+			"\t" . 'public function setMockController(\atoum\mock\controller $controller)' . PHP_EOL .
 			"\t" . '{' . PHP_EOL .
 			"\t\t" . 'return $controller->control($this);' . PHP_EOL .
 			"\t" . '}' . PHP_EOL .
 			"\t" . 'public function resetMockController()' . PHP_EOL .
 			"\t" . '{' . PHP_EOL .
-			"\t\t" . '\mageekguy\atoum\mock\controller::getForMock($this)->reset();' . PHP_EOL .
+			"\t\t" . '\atoum\mock\controller::getForMock($this)->reset();' . PHP_EOL .
 			"\t\t" . 'return $this;' . PHP_EOL .
 			"\t" . '}' . PHP_EOL
 		;

--- a/tests/units/classes/mock/php/method.php
+++ b/tests/units/classes/mock/php/method.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\php;
+namespace atoum\tests\units\mock\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\php
+	atoum,
+	atoum\mock\php
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -35,7 +35,7 @@ class method extends atoum\test
 						$method->returnReference();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Constructor can not return a reference')
 		;
 	}

--- a/tests/units/classes/mock/php/method/argument.php
+++ b/tests/units/classes/mock/php/method/argument.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\php\method;
+namespace atoum\tests\units\mock\php\method;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\php
+	atoum,
+	atoum\mock\php
 ;
 
 require_once __DIR__ . '/../../../../runner.php';

--- a/tests/units/classes/mock/stream.php
+++ b/tests/units/classes/mock/stream.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock;
+namespace atoum\tests\units\mock;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\mock\stream as testedClass
+	atoum\test,
+	atoum\adapter,
+	atoum\mock\stream as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -37,33 +37,33 @@ class stream extends test
 			->and($adapter->stream_get_wrappers = array())
 			->and($adapter->stream_wrapper_register = true)
 			->then
-				->object($streamController = testedClass::get($stream = uniqid()))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($streamController = testedClass::get($stream = uniqid()))->isInstanceOf('atoum\mock\stream\controller')
 				->string($streamController->getPath())->isEqualTo(testedClass::defaultProtocol . '://' . testedClass::setDirectorySeparator($stream))
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'atoum\mock\stream')->once()
 			->if($adapter->stream_get_wrappers = array(testedClass::defaultProtocol))
 			->then
-				->object($streamController = testedClass::get())->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($streamController = testedClass::get())->isInstanceOf('atoum\mock\stream\controller')
 				->string($streamController->getPath())->match('#^' . testedClass::defaultProtocol . '://\w+$#')
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'atoum\mock\stream')->once()
 				->object(testedClass::get($stream))->isIdenticalTo($streamController = testedClass::get($stream))
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'atoum\mock\stream')->once()
 				->object(testedClass::get($otherStream = ($protocol = uniqid()) . '://' . uniqid()))->isNotIdenticalTo($streamController)
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments($protocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments($protocol, 'atoum\mock\stream')->once()
 			->if($adapter->stream_get_wrappers = array(testedClass::defaultProtocol, $protocol))
 			->then
 				->object(testedClass::get($otherStream))->isIdenticalTo(testedClass::get($otherStream))
 				->object(testedClass::get($otherStream))->isIdenticalTo(testedClass::get($otherStream))
 				->adapter($adapter)
-					->call('stream_wrapper_register')->withArguments($protocol, 'mageekguy\atoum\mock\stream')->once()
+					->call('stream_wrapper_register')->withArguments($protocol, 'atoum\mock\stream')->once()
 			->if($adapter->stream_get_wrappers = array())
 			->and($adapter->stream_wrapper_register = false)
 			->then
 				->exception(function() use ($protocol) { testedClass::get($protocol . '://' . uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to register ' . $protocol . ' stream')
 		;
 	}
@@ -77,9 +77,9 @@ class stream extends test
 			->and($stream = testedClass::get())
 			->then
 				->string($stream . '\\' . uniqid())->match('#^' . $stream . preg_quote('\\') . '[^' . preg_quote('\\') . ']+$#')
-				->object($subStream = testedClass::getSubStream($stream))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($subStream = testedClass::getSubStream($stream))->isInstanceOf('atoum\mock\stream\controller')
 				->castToString($subStream)->match('#^' . $stream . preg_quote(DIRECTORY_SEPARATOR) . '[^' . preg_quote(DIRECTORY_SEPARATOR) . ']+$#')
-				->object($subStream = testedClass::getSubStream($stream, $basename = uniqid()))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($subStream = testedClass::getSubStream($stream, $basename = uniqid()))->isInstanceOf('atoum\mock\stream\controller')
 				->castToString($subStream)->match('#^' . $stream . preg_quote(DIRECTORY_SEPARATOR) . $basename . '$#')
 		;
 	}

--- a/tests/units/classes/mock/stream/controller.php
+++ b/tests/units/classes/mock/stream/controller.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\stream;
+namespace atoum\tests\units\mock\stream;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\dependence,
-	mageekguy\atoum\dependencies,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\mock\stream\controller as testedClass
+	atoum,
+	atoum\test,
+	atoum\dependence,
+	atoum\dependencies,
+	atoum\mock\stream,
+	atoum\mock\stream\controller as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -18,7 +18,7 @@ class controller extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\test\adapter')
+			->testedClass->isSubclassOf('atoum\test\adapter')
 		;
 	}
 
@@ -117,7 +117,7 @@ class controller extends atoum\test
 							$streamController->{$method};
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -277,7 +277,7 @@ class controller extends atoum\test
 							$streamController->{$method} = uniqid();
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -423,7 +423,7 @@ class controller extends atoum\test
 							isset($streamController->{$method});
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -679,7 +679,7 @@ class controller extends atoum\test
 						unset($streamController->{$method});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}
@@ -763,7 +763,7 @@ class controller extends atoum\test
 							$streamController->invoke($method);
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Method streamWrapper::' . $method . '() does not exist')
 		;
 	}

--- a/tests/units/classes/mock/stream/invoker.php
+++ b/tests/units/classes/mock/stream/invoker.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\stream;
+namespace atoum\tests\units\mock\stream;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\mock\stream
+	atoum\test,
+	atoum\mock\stream
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -13,7 +13,7 @@ class invoker extends test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\test\adapter\invoker');
+		$this->testedClass->isSubclassOf('atoum\test\adapter\invoker');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/mock/streams/fs/controller.php
+++ b/tests/units/classes/mock/streams/fs/controller.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\streams\fs;
+namespace atoum\tests\units\mock\streams\fs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\dependence,
-	mageekguy\atoum\dependencies,
-	mageekguy\atoum\mock\stream,
-	mock\mageekguy\atoum\mock\streams\fs\controller as testedClass
+	atoum,
+	atoum\test,
+	atoum\dependence,
+	atoum\dependencies,
+	atoum\mock\stream,
+	mock\atoum\mock\streams\fs\controller as testedClass
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -17,7 +17,7 @@ class controller extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\mock\stream\controller');
+		$this->testedClass->extends('atoum\mock\stream\controller');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/mock/streams/fs/controller/factory.php
+++ b/tests/units/classes/mock/streams/fs/controller/factory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\streams\fs\controller;
+namespace atoum\tests\units\mock\streams\fs\controller;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\streams\fs\controller,
-	mageekguy\atoum\mock\streams\fs\controller\factory as testedClass
+	atoum,
+	atoum\mock\streams\fs\controller,
+	atoum\mock\streams\fs\controller\factory as testedClass
 ;
 
 require __DIR__ . '/../../../../../runner.php';

--- a/tests/units/classes/mock/streams/fs/directory.php
+++ b/tests/units/classes/mock/streams/fs/directory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\streams\fs;
+namespace atoum\tests\units\mock\streams\fs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\mock\streams\fs\directory as testedClass
+	atoum,
+	atoum\mock\stream,
+	atoum\mock\streams\fs\directory as testedClass
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -14,7 +14,7 @@ class directory extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\mock\stream');
+		$this->testedClass->extends('atoum\mock\stream');
 	}
 
 	public function testMkdir()

--- a/tests/units/classes/mock/streams/fs/directory/controller.php
+++ b/tests/units/classes/mock/streams/fs/directory/controller.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\streams\fs\directory;
+namespace atoum\tests\units\mock\streams\fs\directory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\streams\fs\directory\controller as testedClass
+	atoum,
+	atoum\mock\streams\fs\directory\controller as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -13,7 +13,7 @@ class controller extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\mock\streams\fs\controller');
+		$this->testedClass->extends('atoum\mock\streams\fs\controller');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/mock/streams/fs/file.php
+++ b/tests/units/classes/mock/streams/fs/file.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\streams\fs;
+namespace atoum\tests\units\mock\streams\fs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\mock\streams\fs\file as testedClass
+	atoum,
+	atoum\mock\stream,
+	atoum\mock\streams\fs\file as testedClass
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -14,7 +14,7 @@ class file extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\mock\stream');
+		$this->testedClass->extends('atoum\mock\stream');
 	}
 
 	public function testGet()
@@ -22,7 +22,7 @@ class file extends atoum\test
 		$this
 			->if($file = testedClass::get())
 			->then
-				->object($file)->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($file)->isInstanceOf('atoum\mock\stream\controller')
 				->castToString($file)->isNotEmpty()
 				->string(file_get_contents($file))->isEmpty()
 				->variable($fileResource = fopen($file, 'r'))->isNotEqualTo(false)
@@ -33,7 +33,7 @@ class file extends atoum\test
 				->boolean(unlink($file))->isTrue()
 			->if($file = testedClass::get($path = uniqid()))
 			->then
-				->object($file)->isInstanceOf('mageekguy\atoum\mock\stream\controller')
+				->object($file)->isInstanceOf('atoum\mock\stream\controller')
 				->castToString($file)->isEqualTo(testedClass::defaultProtocol . '://' . $path)
 				->string(file_get_contents($file))->isEmpty()
 				->variable($fileResource = fopen($file, 'r'))->isNotEqualTo(false)

--- a/tests/units/classes/mock/streams/fs/file/controller.php
+++ b/tests/units/classes/mock/streams/fs/file/controller.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\mock\streams\fs\file;
+namespace atoum\tests\units\mock\streams\fs\file;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\streams\fs\file\controller as testedClass
+	atoum,
+	atoum\mock\streams\fs\file\controller as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -13,7 +13,7 @@ class controller extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\mock\streams\fs\controller');
+		$this->testedClass->extends('atoum\mock\streams\fs\controller');
 	}
 
 	public function test__construct()
@@ -37,7 +37,7 @@ class controller extends atoum\test
 			->then
 				->boolean($controller->stream_open(uniqid(), 'r', uniqid()))->isFalse()
 				->exception(function() use ($controller) { $controller->mkdir = true; })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Unable to override streamWrapper::mkdir() for file')
 		;
 	}

--- a/tests/units/classes/php.php
+++ b/tests/units/classes/php.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php as testedClass
+	atoum,
+	atoum\php as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -170,7 +170,7 @@ class php extends atoum\test
 			->and($adapter->proc_open = false)
 			->then
 				->exception(function() use ($php, & $code) { $php->run($code = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\php\exception')
+					->isInstanceOf('atoum\php\exception')
 					->hasMessage('Unable to run \'' . $code . '\' with php binary \'' . $phpPath . '\'')
 				->adapter($adapter)
 					->call('proc_open')->withArguments((string) $php, array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => array('pipe', 'w')), array())->once()

--- a/tests/units/classes/php/call.php
+++ b/tests/units/classes/php/call.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php;
+namespace atoum\tests\units\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php
+	atoum,
+	atoum\php
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/php/call/arguments/decorator.php
+++ b/tests/units/classes/php/call/arguments/decorator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\call\arguments;
+namespace atoum\tests\units\php\call\arguments;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\php\call\arguments
+	atoum,
+	atoum\mock\stream,
+	atoum\php\call\arguments
 ;
 
 require_once __DIR__ . '/../../../../runner.php';

--- a/tests/units/classes/php/call/decorator.php
+++ b/tests/units/classes/php/call/decorator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\call;
+namespace atoum\tests\units\php\call;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\call
+	atoum,
+	atoum\php\call
 ;
 
 require_once __DIR__ . '/../../../runner.php';

--- a/tests/units/classes/php/exception.php
+++ b/tests/units/classes/php/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php;
+namespace atoum\tests\units\php;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -12,6 +12,6 @@ class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\exceptions\runtime');
+		$this->testedClass->extends('atoum\exceptions\runtime');
 	}
 }

--- a/tests/units/classes/php/mocker.php
+++ b/tests/units/classes/php/mocker.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php;
+namespace atoum\tests\units\php;
 
 require_once __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\mocker as testedClass
+	atoum,
+	atoum\php\mocker as testedClass
 ;
 
 function doSomething() {}
@@ -117,7 +117,7 @@ class mocker extends atoum\test
 				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
 				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
 				->exception(function() use ($php) { $php->generate(__NAMESPACE__ . '\doSomething'); })
-					->isInstanceof('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceof('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Function \'' . __NAMESPACE__ . '\doSomething\' already exists')
 			->if($php->{$functionName} = $returnValue = uniqid())
 			->then

--- a/tests/units/classes/php/tokenizer.php
+++ b/tests/units/classes/php/tokenizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php;
+namespace atoum\tests\units\php;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php
+	atoum,
+	atoum\php
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -23,7 +23,7 @@ class tokenizer extends atoum\test
 		$tokenizer = new php\tokenizer();
 
 		$this->assert
-			->object($iterator = $tokenizer->getIterator())->isInstanceOf('mageekguy\atoum\php\tokenizer\iterator')
+			->object($iterator = $tokenizer->getIterator())->isInstanceOf('atoum\php\tokenizer\iterator')
 			->sizeOf($iterator)->isZero()
 		;
 	}
@@ -65,7 +65,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 		;
@@ -73,7 +73,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php ?><?php ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 		;
@@ -81,7 +81,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php ?>foo<?php ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 		;
@@ -91,11 +91,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 		;
@@ -103,11 +103,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo ; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo ')
 		;
@@ -115,11 +115,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 		;
@@ -128,7 +128,7 @@ class tokenizer extends atoum\test
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo ?>'))->isIdenticalTo($tokenizer)
 			->castToString($tokenizer->getIterator())->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo ')
 		;
@@ -136,15 +136,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo; namespace bar; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar')
 		;
@@ -152,15 +152,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo?><?php namespace bar?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar')
 		;
@@ -168,15 +168,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo ?><?php namespace bar ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo ')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar ')
 		;
@@ -184,11 +184,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo {} ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo {}')
 		;
@@ -196,15 +196,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php namespace foo {} namespace bar {} ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getNamespace(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace foo {}')
 			->object($tokenizer->getIterator()->getNamespace(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpNamespace')
 				->toString
 					->isEqualTo('namespace bar {}')
 		;
@@ -214,11 +214,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\'; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 		;
@@ -226,11 +226,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\'?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 		;
@@ -238,11 +238,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\''))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 		;
@@ -250,11 +250,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\', bar = \'bar\'; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\', bar = \'bar\'')
 		;
@@ -262,15 +262,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php const foo = \'foo\'?><?php const bar = \'bar\'; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getConstant(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const foo = \'foo\'')
 			->object($tokenizer->getIterator()->getConstant(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpConstant')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpConstant')
 				->toString
 					->isEqualTo('const bar = \'bar\'')
 		;
@@ -280,11 +280,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar')
 		;
@@ -292,11 +292,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString->
 					isEqualTo('use foo\bar')
 		;
@@ -304,11 +304,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar')
 		;
@@ -316,15 +316,15 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar; use bar\foo; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar')
 			->object($tokenizer->getIterator()->getImportation(1))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use bar\foo')
 		;
@@ -332,11 +332,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar, bar\foo; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar, bar\foo')
 		;
@@ -346,11 +346,11 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php use foo\bar as bar; ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->object($tokenizer->getIterator()->getImportation(0))
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpImportation')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpImportation')
 				->toString
 					->isEqualTo('use foo\bar as bar')
 		;
@@ -360,7 +360,7 @@ class tokenizer extends atoum\test
 		$this->assert
 			->object($tokenizer->resetIterator()->tokenize($php = '<?php function foo() {} ?>'))->isIdenticalTo($tokenizer)
 			->object($tokenizer->getIterator())
-				->isInstanceOf('mageekguy\atoum\php\tokenizer\iterators\phpScript')
+				->isInstanceOf('atoum\php\tokenizer\iterators\phpScript')
 				->toString
 					->isEqualTo($php)
 			->castToString($tokenizer->getIterator()->getFunction(0))

--- a/tests/units/classes/php/tokenizer/iterator.php
+++ b/tests/units/classes/php/tokenizer/iterator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer;
+namespace atoum\tests\units\php\tokenizer;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer
+	atoum,
+	atoum\php\tokenizer
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -702,7 +702,7 @@ class iterator extends atoum\test
 					$iterator->append($innerIterator);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to append value because it has already a parent')
 		;
 

--- a/tests/units/classes/php/tokenizer/iterators/phpArgument.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpArgument.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpArgument extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpClass.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpClass extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpConstant.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpConstant.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpConstant extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpFunction.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpFunction.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpFunction extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpImportation.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpImportation.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpImportation extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpMethod.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpMethod.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpMethod extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterators\phpFunction')
+				->isSubClassOf('atoum\php\tokenizer\iterators\phpFunction')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpNamespace.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpNamespace.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpNamespace extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/iterators/phpProperty.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpProperty.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpProperty extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterator')
+				->isSubClassOf('atoum\php\tokenizer\iterator')
 		;
 	}
 }

--- a/tests/units/classes/php/tokenizer/iterators/phpScript.php
+++ b/tests/units/classes/php/tokenizer/iterators/phpScript.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer\iterators;
+namespace atoum\tests\units\php\tokenizer\iterators;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer,
-	mageekguy\atoum\php\tokenizer\iterators
+	atoum,
+	atoum\php\tokenizer,
+	atoum\php\tokenizer\iterators
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class phpScript extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->isSubClassOf('mageekguy\atoum\php\tokenizer\iterators\phpNamespace')
+				->isSubClassOf('atoum\php\tokenizer\iterators\phpNamespace')
 		;
 	}
 

--- a/tests/units/classes/php/tokenizer/token.php
+++ b/tests/units/classes/php/tokenizer/token.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\php\tokenizer;
+namespace atoum\tests\units\php\tokenizer;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\php\tokenizer
+	atoum,
+	atoum\php\tokenizer
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -14,7 +14,7 @@ class token extends atoum\test
 	public function testClass()
 	{
 		$this->assert
-			->testedClass->isSubclassOf('mageekguy\atoum\php\tokenizer\iterator\value')
+			->testedClass->isSubclassOf('atoum\php\tokenizer\iterator\value')
 		;
 	}
 
@@ -145,7 +145,7 @@ class token extends atoum\test
 						$token->setParent(new tokenizer\iterator());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Parent is already set')
 			;
 		;
@@ -160,7 +160,7 @@ class token extends atoum\test
 						$token->append(new tokenizer\token(uniqid(), uniqid(), rand(1, PHP_INT_MAX)));
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage($this->getTestedClassName() . '::append() is unavailable')
 		;
 	}

--- a/tests/units/classes/reader.php
+++ b/tests/units/classes/reader.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mock\mageekguy\atoum\reader as testedClass
+	atoum,
+	mock\atoum\reader as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -30,7 +30,7 @@ class reader extends atoum\test
 
 	public function testSetAdapter()
 	{
-		$writer = new \mock\mageekguy\atoum\writer();
+		$writer = new \mock\atoum\writer();
 
 		$this->assert
 			->object($writer->setAdapter($adapter = new atoum\adapter()))->isIdenticalTo($writer)

--- a/tests/units/classes/readers/std/in.php
+++ b/tests/units/classes/readers/std/in.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\readers\std;
+namespace atoum\tests\units\readers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\readers\std\in as testedClass
+	atoum,
+	atoum\readers\std\in as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -13,7 +13,7 @@ class in extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reader');
+		$this->testedClass->extends('atoum\reader');
 	}
 
 	public function testRead()
@@ -23,7 +23,7 @@ class in extends atoum\test
 			->if($adapter->fopen = false)
 			->then
 				->exception(function() use ($reader) { $reader->read(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to open php://stdin stream')
 				->adapter($adapter)
 					->call('fopen')->withArguments('php://stdin', 'r')->once()

--- a/tests/units/classes/report.php
+++ b/tests/units/classes/report.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report as testedClass
+	atoum,
+	atoum\report as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -14,7 +14,7 @@ class report extends atoum\test
 	public function testClass()
 	{
 		$this->testedClass
-			->implements('mageekguy\atoum\observer')
+			->implements('atoum\observer')
 		;
 	}
 
@@ -24,8 +24,8 @@ class report extends atoum\test
 			->if($report = new testedClass())
 			->then
 				->variable($report->getTitle())->isNull()
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEmpty()
 				->array($report->getWriters())->isEmpty()
 		;
@@ -76,10 +76,10 @@ class report extends atoum\test
 		$this
 			->if($report = new testedClass())
 			->then
-				->object($report->addField($field = new \mock\mageekguy\atoum\report\field()))->isIdenticalTo($report)
+				->object($report->addField($field = new \mock\atoum\report\field()))->isIdenticalTo($report)
 				->array($report->getFields())->isIdenticalTo(array($field))
 				->object($field->getLocale())->isIdenticalTo($report->getLocale())
-				->object($report->addField($otherField = new \mock\mageekguy\atoum\report\field()))->isIdenticalTo($report)
+				->object($report->addField($otherField = new \mock\atoum\report\field()))->isIdenticalTo($report)
 				->array($report->getFields())->isIdenticalTo(array($field, $otherField))
 				->object($field->getLocale())->isIdenticalTo($report->getLocale())
 				->object($otherField->getLocale())->isIdenticalTo($report->getLocale())
@@ -93,8 +93,8 @@ class report extends atoum\test
 			->then
 				->object($report->resetFields())->isIdenticalTo($report)
 				->array($report->getFields())->isEmpty()
-			->if($report->addField(new \mock\mageekguy\atoum\report\field()))
-			->and($report->addField(new \mock\mageekguy\atoum\report\field()))
+			->if($report->addField(new \mock\atoum\report\field()))
+			->and($report->addField(new \mock\atoum\report\field()))
 			->then
 				->object($report->resetFields())->isIdenticalTo($report)
 				->array($report->getFields())->isEmpty()

--- a/tests/units/classes/report/field.php
+++ b/tests/units/classes/report/field.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report;
+namespace atoum\tests\units\report;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report
+	atoum,
+	atoum\report
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -19,7 +19,7 @@ class field extends atoum\test
 	public function test__construct()
 	{
 		$this
-			->if($field = new \mock\mageekguy\atoum\report\field())
+			->if($field = new \mock\atoum\report\field())
 			->then
 				->variable($field->getEvents())->isNull()
 				->object($field->getLocale())->isEqualTo(new atoum\locale())

--- a/tests/units/classes/report/fields/runner/atoum/cli.php
+++ b/tests/units/classes/report/fields/runner/atoum/cli.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\atoum;
+namespace atoum\tests\units\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\runner\score,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\atoum\cli as testedClass
+	atoum\locale,
+	atoum\runner,
+	atoum\runner\score,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\atoum\cli as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
 
-class cli extends \mageekguy\atoum\test
+class cli extends \atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\field');
+		$this->testedClass->extends('atoum\report\field');
 	}
 
 	public function test__construct()
@@ -80,7 +80,7 @@ class cli extends \mageekguy\atoum\test
 				->variable($field->getPath())->isNull()
 				->variable($field->getVersion())->isNull()
 				->boolean($field->handleEvent(runner::runStart, $runner))->isTrue()
-				->string($field->getAuthor())->isEqualTo(\mageekguy\atoum\author)
+				->string($field->getAuthor())->isEqualTo(\atoum\author)
 				->string($field->getPath())->isEqualTo($atoumPath)
 				->string($field->getVersion())->isEqualTo($atoumVersion)
 		;
@@ -102,7 +102,7 @@ class cli extends \mageekguy\atoum\test
 				->castToString($field)->isEmpty()
 			->if($field->handleEvent(runner::runStart, $runner))
 			->then
-				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_('atoum version %s by %s (%s)'), $atoumVersion, \mageekguy\atoum\author, $atoumPath)) . PHP_EOL)
+				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_('atoum version %s by %s (%s)'), $atoumVersion, \atoum\author, $atoumPath)) . PHP_EOL)
 		;
 	}
 }

--- a/tests/units/classes/report/fields/runner/atoum/logo.php
+++ b/tests/units/classes/report/fields/runner/atoum/logo.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\atoum;
+namespace atoum\tests\units\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\runner\score,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\atoum\logo as testedClass
+	atoum\locale,
+	atoum\runner,
+	atoum\runner\score,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\atoum\logo as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
 
-class logo extends \mageekguy\atoum\test
+class logo extends \atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\atoum\cli');
+		$this->testedClass->extends('atoum\report\fields\runner\atoum\cli');
 	}
 
 	public function testHandleEvent()
@@ -37,7 +37,7 @@ class logo extends \mageekguy\atoum\test
 				->variable($field->getPath())->isNull()
 				->variable($field->getVersion())->isNull()
 				->boolean($field->handleEvent(runner::runStart, $runner))->isTrue()
-				->string($field->getAuthor())->isEqualTo(\mageekguy\atoum\author)
+				->string($field->getAuthor())->isEqualTo(\atoum\author)
 				->string($field->getPath())->isEqualTo($atoumPath)
 				->string($field->getVersion())->isEqualTo($atoumVersion)
 		;

--- a/tests/units/classes/report/fields/runner/atoum/phing.php
+++ b/tests/units/classes/report/fields/runner/atoum/phing.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\atoum;
+namespace atoum\tests\units\report\fields\runner\atoum;
 
 use
-	mageekguy\atoum\locale,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\runner\score,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\atoum
+	atoum\locale,
+	atoum\runner,
+	atoum\runner\score,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\atoum
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
 
-class phing extends \mageekguy\atoum\test
+class phing extends \atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\field');
+		$this->testedClass->extends('atoum\report\field');
 	}
 
 	public function test__construct()
@@ -80,7 +80,7 @@ class phing extends \mageekguy\atoum\test
 				->variable($field->getPath())->isNull()
 				->variable($field->getVersion())->isNull()
 				->boolean($field->handleEvent(runner::runStart, $runner))->isTrue()
-				->string($field->getAuthor())->isEqualTo(\mageekguy\atoum\author)
+				->string($field->getAuthor())->isEqualTo(\atoum\author)
 				->string($field->getPath())->isEqualTo($atoumPath)
 				->string($field->getVersion())->isEqualTo($atoumVersion)
 		;
@@ -102,7 +102,7 @@ class phing extends \mageekguy\atoum\test
 				->castToString($field)->isEmpty()
 			->if($field->handleEvent(runner::runStart, $runner))
 			->then
-				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_("Atoum version: %s \nAtoum path: %s \nAtoum author: %s"), $atoumVersion, $atoumPath, \mageekguy\atoum\author)))
+				->castToString($field)->isEqualTo($field->getPrompt() . $field->getColorizer()->colorize(sprintf($field->getLocale()->_("Atoum version: %s \nAtoum path: %s \nAtoum author: %s"), $atoumVersion, $atoumPath, \atoum\author)))
 		;
 	}
 }

--- a/tests/units/classes/report/fields/runner/coverage.php
+++ b/tests/units/classes/report/fields/runner/coverage.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner;
+namespace atoum\tests\units\report\fields\runner;
 
 use
-	mageekguy\atoum,
-	mock\mageekguy\atoum\report\fields\runner\coverage as testedClass
+	atoum,
+	mock\atoum\report\fields\runner\coverage as testedClass
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -13,7 +13,7 @@ class coverage extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\field');
+		$this->testedClass->extends('atoum\report\field');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/report/fields/runner/coverage/html.php
+++ b/tests/units/classes/report/fields/runner/coverage/html.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\coverage;
+namespace atoum\tests\units\report\fields\runner\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\template,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\coverage\html as testedClass
+	atoum,
+	atoum\test,
+	atoum\locale,
+	atoum\template,
+	atoum\mock,
+	atoum\mock\stream,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\coverage\html as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -20,7 +20,7 @@ class html extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\coverage\cli');
+		$this->testedClass->extends('atoum\report\fields\runner\coverage\cli');
 	}
 
 	public function test__construct()
@@ -39,7 +39,7 @@ class html extends atoum\test
 				->object($field->getPhp())->isEqualTo(new atoum\php())
 				->object($field->getAdapter())->isEqualTo(new atoum\adapter())
 				->object($field->getLocale())->isEqualTo(new locale())
-				->object($field->getTemplateParser())->isInstanceOf('mageekguy\atoum\template\parser')
+				->object($field->getTemplateParser())->isInstanceOf('atoum\template\parser')
 				->variable($field->getCoverage())->isNull()
 				->array($field->getSrcDirectories())->isEmpty()
 				->array($field->getEvents())->isEqualTo(array(atoum\runner::runStop))
@@ -52,7 +52,7 @@ class html extends atoum\test
 			->if($field = new testedClass(uniqid(), uniqid()))
 			->then
 				->castToString($field)->isEqualTo('Code coverage: unknown.' . PHP_EOL)
-			->if($coverage = new \mock\mageekguy\atoum\score\coverage())
+			->if($coverage = new \mock\atoum\score\coverage())
 			->and($coverageController = $coverage->getMockController())
 			->and($coverageController->count = rand(1, PHP_INT_MAX))
 			->and($coverageController->getClasses = array(
@@ -85,31 +85,31 @@ class html extends atoum\test
 			->and($coverageController->getValue = $coverageValue = rand(1, 10) / 10)
 			->and($coverageController->getValueForClass = $classCoverageValue = rand(1, 10) / 10)
 			->and($coverageController->getValueForMethod = $methodCoverageValue = rand(1, 10) / 10)
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getCoverage = $coverage)
-			->if($classCoverageTemplate = new \mock\mageekguy\atoum\template\tag('classCoverage'))
-			->and($classCoverageTemplate->addChild($classCoverageAvailableTemplate = new \mock\mageekguy\atoum\template\tag('classCoverageAvailable')))
-			->and($indexTemplate = new \mock\mageekguy\atoum\template())
+			->if($classCoverageTemplate = new \mock\atoum\template\tag('classCoverage'))
+			->and($classCoverageTemplate->addChild($classCoverageAvailableTemplate = new \mock\atoum\template\tag('classCoverageAvailable')))
+			->and($indexTemplate = new \mock\atoum\template())
 			->and($indexTemplate
-					->addChild($coverageAvailableTemplate = new \mock\mageekguy\atoum\template\tag('coverageAvailable'))
+					->addChild($coverageAvailableTemplate = new \mock\atoum\template\tag('coverageAvailable'))
 					->addChild($classCoverageTemplate)
 				)
 			->and($indexTemplateController = $indexTemplate->getMockController())
 			->and($indexTemplateController->__set = function() {})
 			->and($indexTemplateController->build = $buildOfIndexTemplate = uniqid())
-			->and($methodTemplate = new \mock\mageekguy\atoum\template())
+			->and($methodTemplate = new \mock\atoum\template())
 			->and($methodTemplateController = $methodTemplate->getMockController())
 			->and($methodTemplateController->__set = function() {})
-			->and($lineTemplate = new \mock\mageekguy\atoum\template\tag('line'))
+			->and($lineTemplate = new \mock\atoum\template\tag('line'))
 			->and($lineTemplateController = $lineTemplate->getMockController())
 			->and($lineTemplateController->__set = function() {})
-			->and($coveredLineTemplate = new \mock\mageekguy\atoum\template\tag('coveredLine'))
+			->and($coveredLineTemplate = new \mock\atoum\template\tag('coveredLine'))
 			->and($coveredLineTemplateController = $coveredLineTemplate->getMockController())
 			->and($coveredLineTemplateController->__set = function() {})
-			->and($notCoveredLineTemplate = new \mock\mageekguy\atoum\template\tag('notCoveredLine'))
+			->and($notCoveredLineTemplate = new \mock\atoum\template\tag('notCoveredLine'))
 			->and($notCoveredLineTemplateController = $notCoveredLineTemplate->getMockController())
 			->and($notCoveredLineTemplateController->__set = function() {})
-			->and($sourceFileTemplate = new \mock\mageekguy\atoum\template\tag('sourceFile'))
+			->and($sourceFileTemplate = new \mock\atoum\template\tag('sourceFile'))
 			->and($sourceFileTemplateController = $sourceFileTemplate->getMockController())
 			->and($sourceFileTemplateController->__set = function() {})
 			->and($sourceFileTemplate
@@ -117,12 +117,12 @@ class html extends atoum\test
 					->addChild($coveredLineTemplate)
 					->addChild($notCoveredLineTemplate)
 				)
-			->and($methodCoverageAvailableTemplate = new \mock\mageekguy\atoum\template\tag('methodCoverageAvailable'))
-			->and($methodTemplate = new \mock\mageekguy\atoum\template\tag('method'))
+			->and($methodCoverageAvailableTemplate = new \mock\atoum\template\tag('methodCoverageAvailable'))
+			->and($methodTemplate = new \mock\atoum\template\tag('method'))
 			->and($methodTemplate->addChild($methodCoverageAvailableTemplate))
-			->and($methodsTemplate = new \mock\mageekguy\atoum\template\tag('methods'))
+			->and($methodsTemplate = new \mock\atoum\template\tag('methods'))
 			->and($methodsTemplate->addChild($methodTemplate))
-			->and($classTemplate = new \mock\mageekguy\atoum\template())
+			->and($classTemplate = new \mock\atoum\template())
 			->and($classTemplateController = $classTemplate->getMockController())
 			->and($classTemplateController->__set = function() {})
 			->and($classTemplate
@@ -166,8 +166,8 @@ class html extends atoum\test
 			->and($reflectedMethod4Controller->getStartLine = 11)
 			->and($reflectedMethod4 = new \mock\reflectionMethod(uniqid(), uniqid(), $reflectedMethod4Controller))
 			->and($reflectedClassController->getMethods = array($reflectedMethod1, $reflectedMethod2, $reflectedMethod3, $reflectedMethod4))
-			->and($templateParser = new \mock\mageekguy\atoum\template\parser())
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\coverage\html($projectName = uniqid(), $destinationDirectory = uniqid()))
+			->and($templateParser = new \mock\atoum\template\parser())
+			->and($field = new \mock\atoum\report\fields\runner\coverage\html($projectName = uniqid(), $destinationDirectory = uniqid()))
 			->and($field
 					->setTemplateParser($templateParser)
 					->setTemplatesDirectory($templatesDirectory = uniqid())
@@ -176,7 +176,7 @@ class html extends atoum\test
 			->and($fieldController = $field->getMockController())
 			->and($fieldController->cleanDestinationDirectory = function() {})
 			->and($fieldController->getReflectionClass = $reflectedClass)
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->getMockController()->getScore = $score)
 			->and($field->setRootUrl($rootUrl = uniqid()))
 			->and($templateParserController = $templateParser->getMockController())
@@ -438,7 +438,7 @@ class html extends atoum\test
 			->and($destinationDirectory->readdir[4] = $file = stream::getSubStream($destinationDirectory))
 			->and($file->unlink = true)
 			->and($destinationDirectory->readdir[5] = false)
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\coverage\html(uniqid(), (string) $destinationDirectory))
+			->and($field = new \mock\atoum\report\fields\runner\coverage\html(uniqid(), (string) $destinationDirectory))
 			->and($field->setAdapter($adapter = new test\adapter()))
 			->and($adapter->rmdir = function() {})
 			->and($adapter->unlink = function() {})
@@ -500,7 +500,7 @@ class html extends atoum\test
 							$field->setReflectionClassInjector(function() {});
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Reflection class injector must take one argument')
 		;
 	}
@@ -518,7 +518,7 @@ class html extends atoum\test
 							$field->getReflectionClass(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 					->hasMessage('Reflection class injector must return a \reflectionClass instance')
 		;
 	}

--- a/tests/units/classes/report/fields/runner/coverage/treemap.php
+++ b/tests/units/classes/report/fields/runner/coverage/treemap.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\coverage;
+namespace atoum\tests\units\report\fields\runner\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\coverage\treemap as testedClass
+	atoum,
+	atoum\report\fields\runner\coverage\treemap as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -13,7 +13,7 @@ class treemap extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\coverage\cli');
+		$this->testedClass->extends('atoum\report\fields\runner\coverage\cli');
 	}
 
 	public function test__construct()
@@ -53,7 +53,7 @@ class treemap extends atoum\test
 				->object($treemap->getReflectionClass(uniqid()))->isIdenticalTo($reflectionClassInstance)
 				->object($treemap->getReflectionClass(uniqid()))->isIdenticalTo($reflectionClassInstance)
 				->exception(function() use($treemap) { $treemap->setReflectionClassFactory(function() {}); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Reflection class factory must take one argument')
 		;
 	}

--- a/tests/units/classes/report/fields/runner/duration/cli.php
+++ b/tests/units/classes/report/fields/runner/duration/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\duration;
+namespace atoum\tests\units\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration\cli as testedClass
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration\cli as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\duration');
+		$this->testedClass->extends('atoum\report\fields\runner\duration');
 	}
 
 	public function test__construct()
@@ -84,7 +84,7 @@ class cli extends atoum\test
 			->then
 				->boolean($field->handleEvent(runner::runStart, new atoum\runner()))->isFalse()
 				->variable($field->getValue())->isNull()
-			->if($runner = new \mock\mageekguy\atoum\runner())
+			->if($runner = new \mock\atoum\runner())
 			->and($runner->getMockController()->getRunningDuration = $runningDuration = rand(0, PHP_INT_MAX))
 			->then
 				->boolean($field->handleEvent(runner::runStop, $runner))->isTrue()
@@ -95,15 +95,15 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\runner())
+			->if($runner = new \mock\atoum\runner())
 			->and($runner->getMockController()->getRunningDuration = 1)
-			->and($prompt = new \mock\mageekguy\atoum\cli\prompt())
+			->and($prompt = new \mock\atoum\cli\prompt())
 			->and($prompt->getMockController()->__toString = $promptString = uniqid())
-			->and($titleColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+			->and($titleColorizer = new \mock\atoum\cli\colorizer())
 			->and($titleColorizer->getMockController()->colorize = $colorizedTitle = uniqid())
-			->and($durationColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+			->and($durationColorizer = new \mock\atoum\cli\colorizer())
 			->and($durationColorizer->getMockController()->colorize = $colorizedDuration = uniqid())
-			->and($locale = new \mock\mageekguy\atoum\locale())
+			->and($locale = new \mock\atoum\locale())
 			->and($locale->getMockController()->_ = function($string) { return $string; })
 			->and($field = new testedClass())
 			->and($field->setPrompt($prompt))

--- a/tests/units/classes/report/fields/runner/duration/phing.php
+++ b/tests/units/classes/report/fields/runner/duration/phing.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\duration;
+namespace atoum\tests\units\report\fields\runner\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\duration\phing as testedClass
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\duration\phing as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\duration\cli') ;
+		$this->testedClass->extends('atoum\report\fields\runner\duration\cli') ;
 	}
 
 	public function test__construct()
@@ -83,7 +83,7 @@ class phing extends atoum\test
 			->then
 				->boolean($field->handleEvent(runner::runStart, new atoum\runner()))->isFalse()
 				->variable($field->getValue())->isNull()
-			->if($runner = new \mock\mageekguy\atoum\runner())
+			->if($runner = new \mock\atoum\runner())
 			->and($runner->getMockController()->getRunningDuration = $runningDuration = rand(0, PHP_INT_MAX))
 			->then
 				->boolean($field->handleEvent(runner::runStop, $runner))->isTrue()
@@ -94,15 +94,15 @@ class phing extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\runner())
+			->if($runner = new \mock\atoum\runner())
 			->and($runner->getMockController()->getRunningDuration = 1)
-			->and($prompt = new \mock\mageekguy\atoum\cli\prompt())
+			->and($prompt = new \mock\atoum\cli\prompt())
 			->and($prompt->getMockController()->__toString = $promptString = uniqid())
-			->and($titleColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+			->and($titleColorizer = new \mock\atoum\cli\colorizer())
 			->and($titleColorizer->getMockController()->colorize = $colorizedTitle = uniqid())
-			->and($durationColorizer = new \mock\mageekguy\atoum\cli\colorizer())
+			->and($durationColorizer = new \mock\atoum\cli\colorizer())
 			->and($durationColorizer->getMockController()->colorize = $colorizedDuration = uniqid())
-			->and($locale = new \mock\mageekguy\atoum\locale())
+			->and($locale = new \mock\atoum\locale())
 			->and($locale->getMockController()->_ = function($string) { return $string; })
 			->and($field = new testedClass())
 			->and($field->setPrompt($prompt))

--- a/tests/units/classes/report/fields/runner/errors/cli.php
+++ b/tests/units/classes/report/fields/runner/errors/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\errors;
+namespace atoum\tests\units\report\fields\runner\errors;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner,
-	mock\mageekguy\atoum as mock
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\errors');
+		$this->testedClass->extends('atoum\report\fields\runner\errors');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/report/fields/runner/event/cli.php
+++ b/tests/units/classes/report/fields/runner/event/cli.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\event;
+namespace atoum\tests\units\report\fields\runner\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\mock,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -14,7 +14,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\event');
+		$this->testedClass->extends('atoum\report\fields\runner\event');
 	}
 
 	public function test__construct()
@@ -33,7 +33,7 @@ class cli extends atoum\test
 		$this
 			->if($testController = new atoum\mock\controller())
 			->and($testController->__construct = function() {})
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($runner = new atoum\runner())
 			->and($field = new runner\event\cli())
 			->then
@@ -89,7 +89,7 @@ class cli extends atoum\test
 			->and($runnerController = new atoum\mock\controller())
 			->and($runnerController->__construct = function() {})
 			->and($runnerController->getTestMethodNumber = function() use ($testMethodNumber) { return $testMethodNumber; })
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($field = new runner\event\cli())
 			->and($progressBar = new atoum\cli\progressBar($runner->getTestMethodNumber()))
 			->then

--- a/tests/units/classes/report/fields/runner/exceptions/cli.php
+++ b/tests/units/classes/report/fields/runner/exceptions/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\exceptions;
+namespace atoum\tests\units\report\fields\runner\exceptions;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\exceptions');
+		$this->testedClass->extends('atoum\report\fields\runner\exceptions');
 	}
 
 	public function test__construct()
@@ -138,7 +138,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getExceptions = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/cli.php
+++ b/tests/units/classes/report/fields/runner/failures/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures;
+namespace atoum\tests\units\report\fields\runner\failures;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\failures');
+		$this->testedClass->extends('atoum\report\fields\runner\failures');
 	}
 
 	public function test__construct()
@@ -106,7 +106,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/execute.php
+++ b/tests/units/classes/report/fields/runner/failures/execute.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures;
+namespace atoum\tests\units\report\fields\runner\failures;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures\execute as testedClass
+	atoum,
+	atoum\report\fields\runner\failures\execute as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -13,7 +13,7 @@ class execute extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\failures');
+		$this->testedClass->extends('atoum\report\fields\runner\failures');
 	}
 
 	public function test__construct()
@@ -22,8 +22,8 @@ class execute extends atoum\test
 			->if($field = new testedClass($command = uniqid()))
 			->then
 				->string($field->getCommand())->isEqualTo($command)
-				->object($field->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($field->getLocale())->isInstanceOf('mageekguy\atoum\locale')
+				->object($field->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($field->getLocale())->isInstanceOf('atoum\locale')
 		;
 	}
 
@@ -36,7 +36,7 @@ class execute extends atoum\test
 			->then
 				->castToString($field)->isEmpty()
 				->adapter($adapter)->call('system')->never()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/execute/macos/macvim.php
+++ b/tests/units/classes/report/fields/runner/failures/execute/macos/macvim.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures\execute\macos;
+namespace atoum\tests\units\report\fields\runner\failures\execute\macos;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures\execute\macos\macvim as testedClass
+	atoum,
+	atoum\report\fields\runner\failures\execute\macos\macvim as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../../runner.php';
@@ -13,7 +13,7 @@ class macvim extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\failures\execute');
+		$this->testedClass->extends('atoum\report\fields\runner\failures\execute');
 	}
 
 	public function test__construct()
@@ -22,8 +22,8 @@ class macvim extends atoum\test
 			->if($field = new testedClass())
 			->then
 				->string($field->getCommand())->isEqualTo('mvim --remote-silent +%2$s %1$s')
-				->object($field->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($field->getLocale())->isInstanceOf('mageekguy\atoum\locale')
+				->object($field->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($field->getLocale())->isInstanceOf('atoum\locale')
 		;
 	}
 
@@ -36,7 +36,7 @@ class macvim extends atoum\test
 			->then
 				->castToString($field)->isEmpty()
 				->adapter($adapter)->call('system')->never()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/execute/macos/phpstorm.php
+++ b/tests/units/classes/report/fields/runner/failures/execute/macos/phpstorm.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures\execute\macos;
+namespace atoum\tests\units\report\fields\runner\failures\execute\macos;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures\execute\macos\phpstorm as testedClass
+	atoum,
+	atoum\report\fields\runner\failures\execute\macos\phpstorm as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../../runner.php';
@@ -14,7 +14,7 @@ class phpstorm extends atoum\test
 	public function testClass()
 	{
 		$this
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\failures\execute')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\failures\execute')
 		;
 	}
 
@@ -40,7 +40,7 @@ class phpstorm extends atoum\test
 			->then
 				->castToString($field)->isEmpty()
 				->adapter($adapter)->call('system')->never()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/execute/unix/gedit.php
+++ b/tests/units/classes/report/fields/runner/failures/execute/unix/gedit.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures\execute\unix;
+namespace atoum\tests\units\report\fields\runner\failures\execute\unix;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures\execute\unix\gedit as testedClass
+	atoum,
+	atoum\report\fields\runner\failures\execute\unix\gedit as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../../runner.php';
@@ -14,7 +14,7 @@ class gedit extends atoum\test
 	public function testClass()
 	{
 		$this
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\failures\execute')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\failures\execute')
 		;
 	}
 
@@ -36,7 +36,7 @@ class gedit extends atoum\test
 			->then
 				->castToString($field)->isEmpty()
 				->adapter($adapter)->call('system')->never()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/execute/unix/gvim.php
+++ b/tests/units/classes/report/fields/runner/failures/execute/unix/gvim.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures\execute\unix;
+namespace atoum\tests\units\report\fields\runner\failures\execute\unix;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures\execute\unix\gvim as testedClass
+	atoum,
+	atoum\report\fields\runner\failures\execute\unix\gvim as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../../runner.php';
@@ -14,7 +14,7 @@ class gvim extends atoum\test
 	public function testClass()
 	{
 		$this
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\failures\execute')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\failures\execute')
 		;
 	}
 
@@ -36,7 +36,7 @@ class gvim extends atoum\test
 			->then
 				->castToString($field)->isEmpty()
 				->adapter($adapter)->call('system')->never()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/failures/execute/unix/phpstorm.php
+++ b/tests/units/classes/report/fields/runner/failures/execute/unix/phpstorm.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\failures\execute\unix;
+namespace atoum\tests\units\report\fields\runner\failures\execute\unix;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields\runner\failures\execute\unix\phpstorm as testedClass
+	atoum,
+	atoum\report\fields\runner\failures\execute\unix\phpstorm as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../../runner.php';
@@ -14,7 +14,7 @@ class phpstorm extends atoum\test
 	public function testClass()
 	{
 		$this
-			->testedClass->isSubclassOf('mageekguy\atoum\report\fields\runner\failures\execute')
+			->testedClass->isSubclassOf('atoum\report\fields\runner\failures\execute')
 		;
 	}
 
@@ -45,7 +45,7 @@ class phpstorm extends atoum\test
 			->then
 				->castToString($field)->isEmpty()
 				->adapter($adapter)->call('system')->never()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getErrors = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/outputs/cli.php
+++ b/tests/units/classes/report/fields/runner/outputs/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\outputs;
+namespace atoum\tests\units\report\fields\runner\outputs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\outputs
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\outputs
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\outputs');
+		$this->testedClass->extends('atoum\report\fields\runner\outputs');
 	}
 
 	public function test__construct()
@@ -137,7 +137,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getOutputs = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/php/path/cli.php
+++ b/tests/units/classes/report/fields/runner/php/path/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\php\path;
+namespace atoum\tests\units\report\fields\runner\php\path;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\php\path');
+		$this->testedClass->extends('atoum\report\fields\runner\php\path');
 	}
 
 	public function test__construct()
@@ -78,7 +78,7 @@ class cli extends atoum\test
 	{
 		$this
 			->if($field = new runner\php\path\cli())
-			->and($score = new \mock\mageekguy\atoum\runner\score())
+			->and($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getPhpPath = $phpPath = uniqid())
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStop, $runner = new atoum\runner()))->isFalse()
@@ -92,7 +92,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getPhpPath = $phpPath = uniqid())
 			->and($defaultField = new runner\php\path\cli())
 			->then

--- a/tests/units/classes/report/fields/runner/php/version/cli.php
+++ b/tests/units/classes/report/fields/runner/php/version/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\php\version;
+namespace atoum\tests\units\report\fields\runner\php\version;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner,
-	mageekguy\atoum\mock\mageekguy\atoum as mock
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner,
+	atoum\mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\php\version');
+		$this->testedClass->extends('atoum\report\fields\runner\php\version');
 	}
 
 	public function test__construct()
@@ -96,7 +96,7 @@ class cli extends atoum\test
 	{
 		$this
 			->if($field = new runner\php\version\cli())
-			->and($score = new \mock\mageekguy\atoum\runner\score())
+			->and($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getPhpVersion = $phpVersion = uniqid())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))
@@ -111,7 +111,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getPhpVersion = $phpVersion = uniqid())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/result/cli.php
+++ b/tests/units/classes/report/fields/runner/result/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result;
+namespace atoum\tests\units\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\result\cli as testedClass
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\result\cli as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -16,7 +16,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\field');
+		$this->testedClass->extends('atoum\report\field');
 	}
 
 	public function test__construct()
@@ -82,12 +82,12 @@ class cli extends atoum\test
 	public function testHandleEvent()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getAssertionNumber = $assertionNumber = rand(1, PHP_INT_MAX))
 			->and($score->getMockController()->getFailNumber = $failNumber = rand(1, PHP_INT_MAX))
 			->and($score->getMockController()->getErrorNumber = $errorNumber = rand(1, PHP_INT_MAX))
 			->and($score->getMockController()->getExceptionNumber = $exceptionNumber = rand(1, PHP_INT_MAX))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($runner->getMockController()->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
@@ -112,20 +112,20 @@ class cli extends atoum\test
 
 	public function test__toString()
 	{
-		$score = new \mock\mageekguy\atoum\score();
+		$score = new \mock\atoum\score();
 		$scoreController = $score->getMockController();
 		$scoreController->getAssertionNumber = 1;
 		$scoreController->getFailNumber = 0;
 		$scoreController->getErrorNumber = 0;
 		$scoreController->getExceptionNumber = 0;
 
-		$runner = new \mock\mageekguy\atoum\runner();
+		$runner = new \mock\atoum\runner();
 		$runnerController = $runner->getMockController();
 		$runnerController->getScore = $score;
 		$runnerController->getTestNumber = 1;
 		$runnerController->getTestMethodNumber = 1;
 
-		$locale = new \mock\mageekguy\atoum\locale();
+		$locale = new \mock\atoum\locale();
 		$localeController = $locale->getMockController();
 		$localeController->_ = function ($string) use (& $noTestRunningString, & $successString, & $failureString) {
 			switch ($string)
@@ -166,15 +166,15 @@ class cli extends atoum\test
 			}
 		};
 
-		$prompt = new \mock\mageekguy\atoum\cli\prompt();
+		$prompt = new \mock\atoum\cli\prompt();
 		$promptController = $prompt->getMockController();
 		$promptController->__toString = $promptString = uniqid();
 
-		$successColorizer = new \mock\mageekguy\atoum\cli\colorizer();
+		$successColorizer = new \mock\atoum\cli\colorizer();
 		$successColorizerController = $successColorizer->getMockController();
 		$successColorizerController->colorize = $colorizedSuccessString = uniqid();
 
-		$failureColorizer = new \mock\mageekguy\atoum\cli\colorizer();
+		$failureColorizer = new \mock\atoum\cli\colorizer();
 		$failureColorizerController = $failureColorizer->getMockController();
 		$failureColorizerController->colorize = $colorizedFailureString = uniqid();
 

--- a/tests/units/classes/report/fields/runner/result/logo.php
+++ b/tests/units/classes/report/fields/runner/result/logo.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result;
+namespace atoum\tests\units\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\result\logo as testedClass
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\result\logo as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -16,19 +16,19 @@ class logo extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\result\cli');
+		$this->testedClass->extends('atoum\report\fields\runner\result\cli');
 	}
 
 	public function test__toString()
 	{
-		$score = new \mock\mageekguy\atoum\score();
+		$score = new \mock\atoum\score();
 		$scoreController = $score->getMockController();
 		$scoreController->getAssertionNumber = 1;
 		$scoreController->getFailNumber = 0;
 		$scoreController->getErrorNumber = 0;
 		$scoreController->getExceptionNumber = 0;
 
-		$runner = new \mock\mageekguy\atoum\runner();
+		$runner = new \mock\atoum\runner();
 		$runnerController = $runner->getMockController();
 		$runnerController->getScore = $score;
 		$runnerController->getTestNumber = 1;

--- a/tests/units/classes/report/fields/runner/result/notifier.php
+++ b/tests/units/classes/report/fields/runner/result/notifier.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result;
+namespace atoum\tests\units\report\fields\runner\result;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\adapter,
-	mageekguy\atoum\test
+	atoum,
+	atoum\locale,
+	atoum\adapter,
+	atoum\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -15,13 +15,13 @@ class notifier extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\result');
+		$this->testedClass->extends('atoum\report\fields\runner\result');
 	}
 
 	public function test__construct()
 	{
 		$this
-			->if($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier())
+			->if($field = new \mock\atoum\report\fields\runner\result\notifier())
 			->then
 				->object($field->getLocale())->isEqualTo(new locale())
 				->object($field->getAdapter())->isEqualTo(new adapter())
@@ -32,7 +32,7 @@ class notifier extends atoum\test
 				->variable($field->getExceptionNumber())->isNull()
 				->array($field->getEvents())->isEqualTo(array(atoum\runner::runStop))
 			->if($adapter = new adapter())
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier($adapter))
 			->then
 				->object($field->getAdapter())->isIdenticalTo($adapter)
 		;
@@ -41,16 +41,16 @@ class notifier extends atoum\test
 	public function testHandleEvent()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($this->calling($score)->getAssertionNumber = $assertionNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getFailNumber = $failNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getErrorNumber = $errorNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getExceptionNumber = $exceptionNumber = rand(1, PHP_INT_MAX))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($this->calling($runner)->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($runner)->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier())
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier())
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStart, $runner))->isFalse()
 				->variable($field->getTestNumber())->isNull()
@@ -72,10 +72,10 @@ class notifier extends atoum\test
 	public function testNotify()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\score())
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->if($score = new \mock\atoum\score())
+			->and($runner = new \mock\atoum\runner())
 			->and($this->calling($runner)->getScore = $score)
-			->and($locale = new \mock\mageekguy\atoum\locale())
+			->and($locale = new \mock\atoum\locale())
 			->and($this->calling($locale)->_ = function ($string) use (& $noTestRunningString, & $successString, & $failureString) {
 					switch ($string)
 					{
@@ -128,7 +128,7 @@ class notifier extends atoum\test
 			->and($this->calling($score)->getExceptionNumber = 0)
 			->and($adapter = new test\adapter())
 			->and($adapter->system = function() use (& $output) { return $output = uniqid(); })
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier($adapter))
 			->and($field->setLocale($locale))
 			->and($field->handleEvent(atoum\runner::runStop, $runner))
 			->then
@@ -143,7 +143,7 @@ class notifier extends atoum\test
 			->if($this->calling($runner)->getTestNumber = $testNumber = rand(2, PHP_INT_MAX))
 			->and($this->calling($runner)->getTestMethodNumber = $testMethodNumber = rand(2, PHP_INT_MAX))
 			->and($this->calling($score)->getAssertionNumber = $assertionNumber = rand(2, PHP_INT_MAX))
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier($adapter))
 			->and($field->setLocale($locale))
 			->and($field->handleEvent(atoum\runner::runStop, $runner))
 			->then
@@ -160,7 +160,7 @@ class notifier extends atoum\test
 			->and($this->calling($score)->getErrorNumber = 1)
 			->and($this->calling($score)->getExceptionNumber = 1)
 			->and($this->calling($score)->getUncompletedMethodNumber = 1)
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier($adapter))
 			->and($field->setLocale($locale))
 			->and($field->handleEvent(atoum\runner::runStop, $runner))
 			->then
@@ -179,7 +179,7 @@ class notifier extends atoum\test
 			->and($this->calling($score)->getErrorNumber = $errorNumber = rand(2, PHP_INT_MAX))
 			->and($this->calling($score)->getExceptionNumber = $exceptionNumber = rand(2, PHP_INT_MAX))
 			->and($this->calling($score)->getUncompletedMethodNumber = $uncompletedTestNumber = rand(2, PHP_INT_MAX))
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier($adapter))
 			->and($field->setLocale($locale))
 			->and($field->handleEvent(atoum\runner::runStop, $runner))
 			->then
@@ -197,7 +197,7 @@ class notifier extends atoum\test
 	public function testSetAdapter()
 	{
 		$this
-			->if($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier())
+			->if($field = new \mock\atoum\report\fields\runner\result\notifier())
 			->then
 				->object($field->setAdapter($adapter = new atoum\adapter()))->isIdenticalTo($field)
 				->object($field->getAdapter())->isIdenticalTo($adapter)
@@ -213,7 +213,7 @@ class notifier extends atoum\test
 		$this
 			->if($adapter = new test\adapter())
 			->and($adapter->system = function() use (& $output) { return $output = uniqid(); })
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier($adapter))
 			->then
 				->string($field->send(uniqid(), uniqid(), true))->isEqualTo($output)
 		;

--- a/tests/units/classes/report/fields/runner/result/notifier/image.php
+++ b/tests/units/classes/report/fields/runner/result/notifier/image.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result\notifier;
+namespace atoum\tests\units\report\fields\runner\result\notifier;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields\runner\result\notifier\image as testedClass
+	atoum,
+	atoum\test\adapter,
+	atoum\exceptions,
+	atoum\report\fields\runner\result\notifier\image as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class image extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\report\fields\runner\result\notifier')
+				->extends('atoum\report\fields\runner\result\notifier')
 		;
 	}
 
@@ -26,7 +26,7 @@ class image extends atoum\test
 		$this
 			->if($adapter = new adapter())
 			->if($adapter->file_exists = true)
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier\image($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier\image($adapter))
 			->then
 			->variable($field->getSuccessImage())->isNull()
 			->object($field->setSuccessImage($path = uniqid()))->isIdenticalTo($field)
@@ -43,7 +43,7 @@ class image extends atoum\test
 		$this
 			->if($adapter = new adapter())
 			->and($adapter->file_exists = true)
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier\image($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier\image($adapter))
 			->then
 				->variable($field->getFailureImage())->isNull()
 				->object($field->setFailureImage($path = uniqid()))->isIdenticalTo($field)
@@ -60,7 +60,7 @@ class image extends atoum\test
 		$this
 			->if($adapter = new adapter())
 			->and($adapter->file_exists = true)
-			->and($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier\image($adapter))
+			->and($field = new \mock\atoum\report\fields\runner\result\notifier\image($adapter))
 			->and($field->setSuccessImage($successImage = uniqid()))
 			->then
 				->string($field->getImage(true))->isEqualTo($successImage)
@@ -70,7 +70,7 @@ class image extends atoum\test
 							$field->getImage(true);
 						}
 					)
-						->isInstanceOf('\\mageekguy\\atoum\\exceptions\\runtime')
+						->isInstanceOf('\\atoum\\exceptions\\runtime')
 						->hasMessage(sprintf('File %s does not exist', $successImage))
 			->if($field->setFailureImage($failureImage = uniqid()))
 			->and($adapter->file_exists = true)
@@ -82,7 +82,7 @@ class image extends atoum\test
 							$field->getImage(false);
 						}
 					)
-						->isInstanceOf('\\mageekguy\\atoum\\exceptions\\runtime')
+						->isInstanceOf('\\atoum\\exceptions\\runtime')
 						->hasMessage(sprintf('File %s does not exist', $failureImage))
 		;
 	}
@@ -90,14 +90,14 @@ class image extends atoum\test
 	public function testAsString()
 	{
 		$this
-			->if($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier\image())
+			->if($field = new \mock\atoum\report\fields\runner\result\notifier\image())
 			->and($this->calling($field)->notify = null)
 			->then
 				->castToString($field)->isEmpty()
 			->if($this->calling($field)->notify = $output = uniqid())
 			->then
 				->castToString($field)->isEqualTo($output . PHP_EOL)
-			->if($field = new \mock\mageekguy\atoum\report\fields\runner\result\notifier\image())
+			->if($field = new \mock\atoum\report\fields\runner\result\notifier\image())
 			->and($this->calling($field)->notify->throw = new exceptions\runtime($message = uniqid()))
 			->then
 				->castToString($field)->isEqualTo($message . PHP_EOL)

--- a/tests/units/classes/report/fields/runner/result/notifier/image/growl.php
+++ b/tests/units/classes/report/fields/runner/result/notifier/image/growl.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result\notifier\image;
+namespace atoum\tests\units\report\fields\runner\result\notifier\image;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\runner\result\notifier\image\growl as testedClass
+	atoum,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\report\fields\runner\result\notifier\image\growl as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -17,7 +17,7 @@ class growl extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\report\fields\runner\result\notifier\image')
+				->extends('atoum\report\fields\runner\result\notifier\image')
 		;
 	}
 
@@ -39,12 +39,12 @@ class growl extends atoum\test
 	public function testHandleEvent()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($this->calling($score)->getAssertionNumber = $assertionNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getFailNumber = $failNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getErrorNumber = $errorNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getExceptionNumber = $exceptionNumber = rand(1, PHP_INT_MAX))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($this->calling($runner)->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($runner)->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
@@ -75,10 +75,10 @@ class growl extends atoum\test
 			->if($adapter = new adapter())
 			->and($adapter->system = function() {})
 			->and($adapter->file_exists = true)
-			->and($score = new \mock\mageekguy\atoum\score())
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($score = new \mock\atoum\score())
+			->and($runner = new \mock\atoum\runner())
 			->and($this->calling($runner)->getScore = $score)
-			->and($locale = new \mock\mageekguy\atoum\locale())
+			->and($locale = new \mock\atoum\locale())
 			->and($this->calling($locale)->_ = function ($string) use (& $noTestRunningString, & $successString, & $failureString) {
 					switch ($string)
 					{

--- a/tests/units/classes/report/fields/runner/result/notifier/image/libnotify.php
+++ b/tests/units/classes/report/fields/runner/result/notifier/image/libnotify.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result\notifier\image;
+namespace atoum\tests\units\report\fields\runner\result\notifier\image;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\runner\result\notifier\image\libnotify as testedClass
+	atoum,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\report\fields\runner\result\notifier\image\libnotify as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -17,7 +17,7 @@ class libnotify extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\report\fields\runner\result\notifier\image')
+				->extends('atoum\report\fields\runner\result\notifier\image')
 		;
 	}
 
@@ -39,12 +39,12 @@ class libnotify extends atoum\test
 	public function testHandleEvent()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($this->calling($score)->getAssertionNumber = $assertionNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getFailNumber = $failNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getErrorNumber = $errorNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getExceptionNumber = $exceptionNumber = rand(1, PHP_INT_MAX))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($this->calling($runner)->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($runner)->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
@@ -75,10 +75,10 @@ class libnotify extends atoum\test
 			->if($adapter = new adapter())
 			->and($adapter->system = function() {})
 			->and($adapter->file_exists = true)
-			->and($score = new \mock\mageekguy\atoum\score())
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($score = new \mock\atoum\score())
+			->and($runner = new \mock\atoum\runner())
 			->and($this->calling($runner)->getScore = $score)
-			->and($locale = new \mock\mageekguy\atoum\locale())
+			->and($locale = new \mock\atoum\locale())
 			->and($this->calling($locale)->_ = function ($string) use (& $noTestRunningString, & $successString, & $failureString) {
 					switch ($string)
 					{

--- a/tests/units/classes/report/fields/runner/result/notifier/terminal.php
+++ b/tests/units/classes/report/fields/runner/result/notifier/terminal.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\result\notifier;
+namespace atoum\tests\units\report\fields\runner\result\notifier;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\runner\result\notifier\terminal as testedClass
+	atoum,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\report\fields\runner\result\notifier\terminal as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class terminal extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\report\fields\runner\result\notifier')
+				->extends('atoum\report\fields\runner\result\notifier')
 		;
 	}
 
@@ -39,12 +39,12 @@ class terminal extends atoum\test
 	public function testHandleEvent()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($this->calling($score)->getAssertionNumber = $assertionNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getFailNumber = $failNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getErrorNumber = $errorNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($score)->getExceptionNumber = $exceptionNumber = rand(1, PHP_INT_MAX))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($this->calling($runner)->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($this->calling($runner)->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
@@ -72,10 +72,10 @@ class terminal extends atoum\test
 		$this
 			->if($adapter = new adapter())
 			->and($adapter->system = function() {})
-			->and($score = new \mock\mageekguy\atoum\score())
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($score = new \mock\atoum\score())
+			->and($runner = new \mock\atoum\runner())
 			->and($this->calling($runner)->getScore = $score)
-			->and($locale = new \mock\mageekguy\atoum\locale())
+			->and($locale = new \mock\atoum\locale())
 			->and($this->calling($locale)->_ = function ($string) use (& $noTestRunningString, & $successString, & $failureString) {
 					switch ($string)
 					{

--- a/tests/units/classes/report/fields/runner/tap/plan.php
+++ b/tests/units/classes/report/fields/runner/tap/plan.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tap;
+namespace atoum\tests\units\report\fields\runner\tap;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report\fields\runner\tap\plan as testedClass
+	atoum,
+	atoum\runner,
+	atoum\report\fields\runner\tap\plan as testedClass
 ;
 
 require __DIR__ . '/../../../../../runner.php';
@@ -14,7 +14,7 @@ class plan extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\field');
+		$this->testedClass->extends('atoum\report\field');
 	}
 
 	public function test__construct()
@@ -29,7 +29,7 @@ class plan extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\runner())
+			->if($runner = new \mock\atoum\runner())
 			->and($this->calling($runner)->getTestMethodNumber = $testMethodNumber = rand(1, PHP_INT_MAX))
 			->and($field = new testedClass())
 			->if($field->handleEvent(runner::runStop, $runner))

--- a/tests/units/classes/report/fields/runner/tests/coverage/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/coverage/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\coverage;
+namespace atoum\tests\units\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\score,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\mock,
+	atoum\score,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\coverage');
+		$this->testedClass->extends('atoum\report\fields\runner\tests\coverage');
 	}
 
 	public function test__construct()
@@ -123,7 +123,7 @@ class cli extends atoum\test
 	{
 		$this
 			->if($scoreCoverage = new score\coverage())
-			->and($score = new \mock\mageekguy\atoum\runner\score())
+			->and($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getCoverage = function() use ($scoreCoverage) { return $scoreCoverage; })
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/tests/coverage/phing.php
+++ b/tests/units/classes/report/fields/runner/tests/coverage/phing.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\coverage;
+namespace atoum\tests\units\report\fields\runner\tests\coverage;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\score,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\coverage\phing as testedClass
+	atoum,
+	atoum\mock,
+	atoum\score,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\coverage\phing as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\coverage\cli');
+		$this->testedClass->extends('atoum\report\fields\runner\tests\coverage\cli');
 	}
 
 	public function test__construct()
@@ -152,7 +152,7 @@ class phing extends atoum\test
 	{
 		$this
 			->if($scoreCoverage = new score\coverage())
-			->and($score = new \mock\mageekguy\atoum\runner\score())
+			->and($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getCoverage = function() use ($scoreCoverage) { return $scoreCoverage; })
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/tests/duration/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/duration/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\duration;
+namespace atoum\tests\units\report\fields\runner\tests\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\duration');
+		$this->testedClass->extends('atoum\report\fields\runner\tests\duration');
 	}
 
 	public function test__construct()
@@ -99,9 +99,9 @@ class cli extends atoum\test
 				->boolean($field->handleEvent(atoum\runner::runStart, new atoum\runner()))->isFalse()
 				->variable($field->getValue())->isNull()
 				->variable($field->getTestNumber())->isNull()
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getTotalDuration = $totalDuration = (float) rand(1, PHP_INT_MAX))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = $testsNumber = rand(1, PHP_INT_MAX))
 			->then
@@ -114,9 +114,9 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getTotalDuration = $totalDuration = (rand(1, 100) / 1000))
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = $testNumber = 1)
 			->and($defaultField = new tests\duration\cli())

--- a/tests/units/classes/report/fields/runner/tests/memory/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/memory/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\memory;
+namespace atoum\tests\units\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\memory
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\tests\units,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\memory
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\memory');
+		$this->testedClass->extends('atoum\report\fields\runner\tests\memory');
 	}
 
 	public function test__construct()
@@ -96,9 +96,9 @@ class cli extends atoum\test
 	{
 		$this
 			->if($field = new memory\cli())
-			->and($score = new \mock\mageekguy\atoum\runner\score())
+			->and($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = function () use (& $testNumber) { return $testNumber = rand(0, PHP_INT_MAX); })
 			->then
@@ -114,9 +114,9 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($defaultField = new memory\cli())

--- a/tests/units/classes/report/fields/runner/tests/memory/phing.php
+++ b/tests/units/classes/report/fields/runner/tests/memory/phing.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\memory;
+namespace atoum\tests\units\report\fields\runner\tests\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\tests\units,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\memory
+	atoum,
+	atoum\runner,
+	atoum\locale,
+	atoum\tests\units,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\memory
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-	  $this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\memory\cli');
+	  $this->testedClass->extends('atoum\report\fields\runner\tests\memory\cli');
 	}
 
 	public function test__construct()
@@ -97,9 +97,9 @@ class phing extends atoum\test
 
 		$this
 			->if($field = new memory\phing())
-			->and($score = new \mock\mageekguy\atoum\runner\score())
+			->and($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = function () use (& $testNumber) { return $testNumber = rand(0, PHP_INT_MAX); })
 			->then
@@ -115,9 +115,9 @@ class phing extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($score->getMockController()->getTotalMemoryUsage = function() use (& $totalMemoryUsage) { return $totalMemoryUsage = rand(1, PHP_INT_MAX); })
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($runner->setScore($score))
 			->and($runner->getMockController()->getTestNumber = $testNumber = rand(1, PHP_INT_MAX))
 			->and($defaultField = new memory\phing())

--- a/tests/units/classes/report/fields/runner/tests/skipped.php
+++ b/tests/units/classes/report/fields/runner/tests/skipped.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests;
+namespace atoum\tests\units\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mock\mageekguy\atoum\report\fields\runner\tests\skipped as testedClass
+	atoum,
+	atoum\runner,
+	mock\atoum\report\fields\runner\tests\skipped as testedClass
 ;
 
 require __DIR__ . '/../../../../../runner.php';
@@ -15,7 +15,7 @@ class skipped extends atoum\test
 	public function testClass()
 	{
 		$this->testedClass
-			->extends('mageekguy\atoum\report\field')
+			->extends('atoum\report\field')
 			->isAbstract()
 		;
 	}

--- a/tests/units/classes/report/fields/runner/tests/skipped/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/skipped/cli.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\skipped;
+namespace atoum\tests\units\report\fields\runner\tests\skipped;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\runner\tests\skipped\cli as testedClass
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\runner\tests\skipped\cli as testedClass
 ;
 
 require __DIR__ . '/../../../../../../runner.php';
@@ -15,7 +15,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\skipped');
+		$this->testedClass->extends('atoum\report\fields\runner\tests\skipped');
 	}
 
 	public function testSetTitlePrompt()
@@ -91,7 +91,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($this->calling($score)->getSkippedMethods = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/tests/uncompleted/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/uncompleted/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests\uncompleted;
+namespace atoum\tests\units\report\fields\runner\tests\uncompleted;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\tests\units,
-	mock\mageekguy\atoum as mock,
-	mageekguy\atoum\report\fields\runner\tests
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\tests\units,
+	mock\atoum as mock,
+	atoum\report\fields\runner\tests
 ;
 
 require_once __DIR__ . '/../../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\runner\tests\uncompleted');
+		$this->testedClass->extends('atoum\report\fields\runner\tests\uncompleted');
 	}
 
 	public function test__construct()
@@ -151,7 +151,7 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\runner\score())
+			->if($score = new \mock\atoum\runner\score())
 			->and($this->calling($score)->getUncompletedMethods = array())
 			->and($runner = new atoum\runner())
 			->and($runner->setScore($score))

--- a/tests/units/classes/report/fields/runner/tests/void.php
+++ b/tests/units/classes/report/fields/runner/tests/void.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\runner\tests;
+namespace atoum\tests\units\report\fields\runner\tests;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mock\mageekguy\atoum\report\fields\runner\tests\void as testedClass
+	atoum,
+	atoum\runner,
+	mock\atoum\report\fields\runner\tests\void as testedClass
 ;
 
 require __DIR__ . '/../../../../../runner.php';
@@ -15,7 +15,7 @@ class void extends atoum\test
 	public function testClass()
 	{
 		$this->testedClass
-			->extends('mageekguy\atoum\report\field')
+			->extends('atoum\report\field')
 			->isAbstract()
 		;
 	}

--- a/tests/units/classes/report/fields/test/duration/cli.php
+++ b/tests/units/classes/report/fields/test/duration/cli.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\duration;
+namespace atoum\tests\units\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\test\adapter,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -19,7 +19,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\test\duration');
+		$this->testedClass->extends('atoum\report\fields\test\duration');
 	}
 
 	public function test__construct()
@@ -96,14 +96,14 @@ class cli extends atoum\test
 	{
 		$this
 			->if($field = new test\duration\cli())
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalDuration = function() use (& $runningDuration) { return $runningDuration = rand(0, PHP_INT_MAX); })
 			->and($adapter = new adapter())
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
 			->and($testController->getScore = $score)
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStop, $test))->isFalse()
 				->variable($field->getValue())->isNull()
@@ -117,12 +117,12 @@ class cli extends atoum\test
 		$this
 			->if($adapter = new adapter())
 			->and($adapter->class_exists = true)
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalDuration = $runningDuration = rand(1, 1000) / 1000)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
 			->and($testController->getScore = $score)
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($defaultField = new test\duration\cli())
 			->and($customField = new test\duration\cli())
 			->and($customField->setPrompt($prompt = new prompt()))

--- a/tests/units/classes/report/fields/test/duration/phing.php
+++ b/tests/units/classes/report/fields/test/duration/phing.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\duration;
+namespace atoum\tests\units\report\fields\test\duration;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\test\adapter,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -19,7 +19,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-	  $this->testedClass->extends('mageekguy\atoum\report\fields\test\duration\cli');
+	  $this->testedClass->extends('atoum\report\fields\test\duration\cli');
 	}
 
 	public function test__construct()
@@ -96,14 +96,14 @@ class phing extends atoum\test
 	{
 		$this
 			->if($field = new test\duration\phing())
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalDuration = function() use (& $runningDuration) { return $runningDuration = rand(0, PHP_INT_MAX); })
 			->and($adapter = new adapter())
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
 			->and($testController->getScore = $score)
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStop, $test))->isFalse()
 				->variable($field->getValue())->isNull()
@@ -117,12 +117,12 @@ class phing extends atoum\test
 		$this
 			->if($adapter = new adapter())
 			->and($adapter->class_exists = true)
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalDuration = $runningDuration = rand(1, 1000) / 1000)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
 			->and($testController->getScore = $score)
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($defaultField = new test\duration\phing())
 			->and($customField = new test\duration\phing())
 			->and($customField->setPrompt($prompt = new prompt()))

--- a/tests/units/classes/report/fields/test/event/cli.php
+++ b/tests/units/classes/report/fields/test/event/cli.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\event;
+namespace atoum\tests\units\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -14,7 +14,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\test\event');
+		$this->testedClass->extends('atoum\report\fields\test\event');
 	}
 
 	public function test__construct()
@@ -49,7 +49,7 @@ class cli extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($field = new test\event\cli())
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStart, $test))->isFalse()
@@ -104,7 +104,7 @@ class cli extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new atoum\mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($field = new test\event\cli())
 			->and($count = rand(1, PHP_INT_MAX))
 			->and($test->getMockController()->count = function() use ($count) { return $count; })

--- a/tests/units/classes/report/fields/test/event/phing.php
+++ b/tests/units/classes/report/fields/test/event/phing.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\event;
+namespace atoum\tests\units\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -14,7 +14,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-	  $this->testedClass->extends('mageekguy\atoum\report\fields\test\event\cli');
+	  $this->testedClass->extends('atoum\report\fields\test\event\cli');
 	}
 
 	public function test__construct()
@@ -35,7 +35,7 @@ class phing extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($field = new test\event\phing())
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStart, $test))->isFalse()
@@ -90,7 +90,7 @@ class phing extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new atoum\mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($field = new test\event\phing())
 			->and($count = rand(1, PHP_INT_MAX))
 			->and($test->getMockController()->count = function() use ($count) { return $count; })

--- a/tests/units/classes/report/fields/test/event/tap.php
+++ b/tests/units/classes/report/fields/test/event/tap.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\event;
+namespace atoum\tests\units\report\fields\test\event;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\report\fields\test\event\tap as testedClass
+	atoum,
+	atoum\mock,
+	atoum\exceptions,
+	atoum\report\fields\test\event\tap as testedClass
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -15,7 +15,7 @@ class tap extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\event');
+		$this->testedClass->extends('atoum\report\fields\event');
 	}
 
 	public function test__construct()
@@ -33,10 +33,10 @@ class tap extends atoum\test
 		$this
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
-			->and($runner = new \mock\mageekguy\atoum\runner())
+			->and($runner = new \mock\atoum\runner())
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($field = new testedClass())
 			->then
 				->boolean($field->handleEvent(atoum\runner::runStart, $runner))->isTrue()
@@ -87,7 +87,7 @@ class tap extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($test = new \mock\mageekguy\atoum\test())
+			->if($test = new \mock\atoum\test())
 			->and($this->calling($test)->getClass = $class = uniqid())
 			->and($this->calling($test)->getCurrentMethod = $method = uniqid())
 			->and($field = new testedClass())
@@ -157,7 +157,7 @@ class tap extends atoum\test
 					'fail' => $fail4 = uniqid()
 				)
 			)
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
 			->and($field = new testedClass())
 			->then
@@ -216,7 +216,7 @@ class tap extends atoum\test
 					'file' => $file2 = uniqid()
 				)
 			)
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
 			->and($field = new testedClass())
 			->then
@@ -264,7 +264,7 @@ class tap extends atoum\test
 					'message' => ($message2 = uniqid()) . PHP_EOL . ($otherMessage2 = uniqid()) . PHP_EOL . ($anotherMessage2 = uniqid())
 				)
 			)
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
 			->and($field = new testedClass())
 			->then
@@ -312,7 +312,7 @@ class tap extends atoum\test
 		$this
 			->mockGenerator->shunt('__construct')
 			->if($score = new \mock\atoum\test\score())
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
 			->and($this->calling($test)->getClass = $class = uniqid())
 			->and($this->calling($test)->getCurrentMethod[1] = $method = uniqid())
@@ -362,7 +362,7 @@ class tap extends atoum\test
 		$this
 			->mockGenerator->shunt('__construct')
 			->if($score = new \mock\atoum\test\score())
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
 			->and($this->calling($test)->getClass = $class = uniqid())
 			->and($this->calling($test)->getCurrentMethod[1] = $method = uniqid())
@@ -409,7 +409,7 @@ class tap extends atoum\test
 		$this
 			->mockGenerator->shunt('__construct')
 			->if($score = new \mock\atoum\test\score())
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
             ->and($this->calling($test)->getPath = $file = uniqid())
             ->and($this->calling($test)->getClass = $class = uniqid())
@@ -473,7 +473,7 @@ class tap extends atoum\test
 		$this
 			->mockGenerator->shunt('__construct')
 			->if($score = new \mock\atoum\test\score())
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($this->calling($test)->getScore = $score)
 			->and($this->calling($test)->getClass = $class = uniqid())
 			->and($this->calling($test)->getCurrentMethod = $method = uniqid())

--- a/tests/units/classes/report/fields/test/memory/cli.php
+++ b/tests/units/classes/report/fields/test/memory/cli.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\memory;
+namespace atoum\tests\units\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\test\memory');
+		$this->testedClass->extends('atoum\report\fields\test\memory');
 	}
 
 	public function test__construct()
@@ -80,13 +80,13 @@ class cli extends atoum\test
 	{
 		$this
 			->if($field = new test\memory\cli())
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 			->and($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
 			->and($testController = new atoum\mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($test->getMockController()->getScore = $score)
 			->then
 				->boolean($field->handleEvent(atoum\test::runStart, $test))->isFalse()
@@ -99,13 +99,13 @@ class cli extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\score())
+			->if($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 			->and($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
 			->and($testController = new atoum\mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($test->getMockController()->getScore = $score)
 			->and($defaultField = new test\memory\cli())
 			->and($customField = new test\memory\cli())

--- a/tests/units/classes/report/fields/test/memory/phing.php
+++ b/tests/units/classes/report/fields/test/memory/phing.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\memory;
+namespace atoum\tests\units\report\fields\test\memory;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\tests\units
+	atoum,
+	atoum\locale,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test,
+	atoum\tests\units
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -17,7 +17,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\test\memory\cli');
+		$this->testedClass->extends('atoum\report\fields\test\memory\cli');
 	}
 
 	public function test__construct()
@@ -80,13 +80,13 @@ class phing extends atoum\test
 	{
 		$this
 			->if($field = new test\memory\phing())
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 			->and($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
 			->and($testController = new atoum\mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($test->getMockController()->getScore = $score)
 			->then
 				->boolean($field->handleEvent(atoum\test::runStart, $test))->isFalse()
@@ -99,13 +99,13 @@ class phing extends atoum\test
 	public function test__toString()
 	{
 		$this
-			->if($score = new \mock\mageekguy\atoum\score())
+			->if($score = new \mock\atoum\score())
 			->and($score->getMockController()->getTotalMemoryUsage = $totalMemoryUsage = rand(0, PHP_INT_MAX))
 			->and($adapter = new atoum\test\adapter())
 			->and($adapter->class_exists = true)
 			->and($testController = new atoum\mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($test->getMockController()->getScore = $score)
 			->and($defaultField = new test\memory\phing())
 			->and($customField = new test\memory\phing())

--- a/tests/units/classes/report/fields/test/run/cli.php
+++ b/tests/units/classes/report/fields/test/run/cli.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\run;
+namespace atoum\tests\units\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\test\run');
+		$this->testedClass->extends('atoum\report\fields\test\run');
 	}
 
 	public function test__construct()
@@ -69,7 +69,7 @@ class cli extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->then
 				->boolean($field->handleEvent(atoum\test::runStop, $test))->isFalse()
 				->variable($field->getTestClass())->isNull()
@@ -105,7 +105,7 @@ class cli extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($defaultField = new test\run\cli())
 			->then
 				->castToString($defaultField)->isEqualTo('There is currently no test running.' . PHP_EOL)

--- a/tests/units/classes/report/fields/test/run/phing.php
+++ b/tests/units/classes/report/fields/test/run/phing.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\report\fields\test\run;
+namespace atoum\tests\units\report\fields\test\run;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\locale,
-	mageekguy\atoum\test\adapter,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test
+	atoum,
+	atoum\mock,
+	atoum\locale,
+	atoum\test\adapter,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test
 ;
 
 require_once __DIR__ . '/../../../../../runner.php';
@@ -18,7 +18,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report\fields\test\run\cli');
+		$this->testedClass->extends('atoum\report\fields\test\run\cli');
 	}
 
 	public function test__construct()
@@ -69,7 +69,7 @@ class phing extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->then
 				->boolean($field->handleEvent(atoum\test::runStop, $test))->isFalse()
 				->variable($field->getTestClass())->isNull()
@@ -105,7 +105,7 @@ class phing extends atoum\test
 			->and($adapter->class_exists = true)
 			->and($testController = new mock\controller())
 			->and($testController->getTestedClassName = uniqid())
-			->and($test = new \mock\mageekguy\atoum\test($adapter))
+			->and($test = new \mock\atoum\test($adapter))
 			->and($defaultField = new test\run\phing())
 			->then
 				->castToString($defaultField)->isEqualTo('There is currently no test running.')

--- a/tests/units/classes/reports/asynchronous.php
+++ b/tests/units/classes/reports/asynchronous.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports;
+namespace atoum\tests\units\reports;
 
 require __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class asynchronous extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\report');
+		$this->testedClass->extends('atoum\report');
 	}
 
 	public function testHandleEvent()
 	{
 		$this
-			->if($report = new \mock\mageekguy\atoum\reports\asynchronous())
+			->if($report = new \mock\atoum\reports\asynchronous())
 			->and($report->setAdapter($adapter = new atoum\test\adapter()))
 			->then
 				->object($report->handleEvent(atoum\runner::runStop, new atoum\runner()))->isIdenticalTo($report)

--- a/tests/units/classes/reports/asynchronous/builder.php
+++ b/tests/units/classes/reports/asynchronous/builder.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields\test,
-	mageekguy\atoum\report\fields\runner,
-	mageekguy\atoum\reports\asynchronous\builder as testedClass
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields\test,
+	atoum\report\fields\runner,
+	atoum\reports\asynchronous\builder as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -17,7 +17,7 @@ class builder extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->extends('atoum\reports\asynchronous');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/reports/asynchronous/clover.php
+++ b/tests/units/classes/reports/asynchronous/clover.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\score,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\reports\asynchronous\clover as testedClass
+	atoum,
+	atoum\score,
+	atoum\mock,
+	atoum\reports\asynchronous\clover as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -20,7 +20,7 @@ class clover extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->extends('atoum\reports\asynchronous');
 	}
 
 	public function testClassConstants()
@@ -40,8 +40,8 @@ class clover extends atoum\test
 			->if($report = new testedClass($adapter = new atoum\test\adapter()))
 			->then
 				->array($report->getFields(atoum\runner::runStart))->isEmpty()
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEmpty()
 				->adapter($adapter)->call('extension_loaded')->withArguments('libxml')->once()
 			->if($adapter->extension_loaded = false)
@@ -50,7 +50,7 @@ class clover extends atoum\test
 								new testedClass($adapter);
 							}
 						)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('libxml PHP extension is mandatory for clover report')
 		;
 	}
@@ -61,18 +61,18 @@ class clover extends atoum\test
 			->if($adapter = new atoum\test\adapter())
 			->if($adapter->extension_loaded = true)
 			->and($report = new testedClass($adapter))
-			->and($score = new \mock\mageekguy\atoum\score())
-			->and($coverage = new \mock\mageekguy\atoum\score\coverage())
-			->and($writer = new \mock\mageekguy\atoum\writers\file())
+			->and($score = new \mock\atoum\score())
+			->and($coverage = new \mock\atoum\score\coverage())
+			->and($writer = new \mock\atoum\writers\file())
 			->and($writer->getMockController()->write = $writer)
 			->then
 				->when(function() use ($report, $writer) {
-						$report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \mageekguy\atoum\runner());
+						$report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \atoum\runner());
 					})
 					->mock($writer)->call('writeAsynchronousReport')->withArguments($report)->once()
 			->and($adapter->time = 762476400)
 			->and($adapter->uniqid = 'foo')
-			->and($observable = new \mock\mageekguy\atoum\runner())
+			->and($observable = new \mock\atoum\runner())
 			->and($observable->getMockController()->getScore = $score)
 			->and($score->getMockController()->getCoverage = $coverage)
 			->and($coverage->getMockController()->getClasses = array())

--- a/tests/units/classes/reports/asynchronous/coveralls.php
+++ b/tests/units/classes/reports/asynchronous/coveralls.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\score,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\reports\asynchronous\coveralls as testedClass
+	atoum,
+	atoum\score,
+	atoum\mock,
+	atoum\reports\asynchronous\coveralls as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -20,7 +20,7 @@ class coveralls extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->extends('atoum\reports\asynchronous');
 	}
 
 	public function testClassConstants()
@@ -40,10 +40,10 @@ class coveralls extends atoum\test
 			->if($report = new testedClass($sourceDir = uniqid(), $token = uniqid()))
 			->then
 				->array($report->getFields(atoum\runner::runStart))->isEmpty()
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 				->array($report->getFields())->isEmpty()
-				->object($report->getSourceDir())->isInstanceOf('\\mageekguy\\atoum\\fs\\path')
+				->object($report->getSourceDir())->isInstanceOf('\\atoum\\fs\\path')
 				->castToString($report->getSourceDir())->isEqualTo($sourceDir)
 				->object($report->getBranchFinder())->isInstanceOf('\\Closure')
 				->string($report->getServiceName())->isEqualTo('atoum')
@@ -57,7 +57,7 @@ class coveralls extends atoum\test
 								new testedClass(uniqid(), uniqid(), $adapter);
 							}
 						)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('JSON PHP extension is mandatory for coveralls report')
 		;
 	}
@@ -119,18 +119,18 @@ class coveralls extends atoum\test
 				}
 			})
 			->and($report = new testedClass($sourceDir = uniqid(), $token = '51bb597d202b4', $adapter))
-			->and($score = new \mock\mageekguy\atoum\score())
-			->and($coverage = new \mock\mageekguy\atoum\score\coverage())
-			->and($writer = new \mock\mageekguy\atoum\writers\http())
+			->and($score = new \mock\atoum\score())
+			->and($coverage = new \mock\atoum\score\coverage())
+			->and($writer = new \mock\atoum\writers\http())
 			->and($writer->getMockController()->writeAsynchronousReport = function() use ($writer) { return $writer; })
 			->then
 				->when(function() use ($report, $writer) {
-						$report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \mageekguy\atoum\runner());
+						$report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \atoum\runner());
 					})
 					->mock($writer)->call('writeAsynchronousReport')->withArguments($report)->once()
 			->if($adapter->date = '2013-05-13 10:00:00 +0000')
 			->and($adapter->file_get_contents = '<?php')
-			->and($observable = new \mock\mageekguy\atoum\runner())
+			->and($observable = new \mock\atoum\runner())
 			->and($observable->getMockController()->getScore = $score)
 			->and($score->getMockController()->getCoverage = $coverage)
 			->and($coverage->getMockController()->getClasses = array())
@@ -237,7 +237,7 @@ class coveralls extends atoum\test
 			->and($adapter->file_get_contents = '')
 			->and($adapter->stream_context_create = $context = uniqid())
 			->and($report = new testedClass(uniqid(), uniqid(), $adapter))
-			->and($writer = new \mock\mageekguy\atoum\writers\http())
+			->and($writer = new \mock\atoum\writers\http())
 			->then
 				->object($report->addDefaultWriter($writer))->isIdenticalTo($report)
 				->mock($writer)

--- a/tests/units/classes/reports/asynchronous/vim.php
+++ b/tests/units/classes/reports/asynchronous/vim.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\reports\asynchronous
+	atoum,
+	atoum\reports\asynchronous
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -13,7 +13,7 @@ class vim extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->extends('atoum\reports\asynchronous');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/reports/asynchronous/xunit.php
+++ b/tests/units/classes/reports/asynchronous/xunit.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\asynchronous;
+namespace atoum\tests\units\reports\asynchronous;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner,
-	mageekguy\atoum\report,
-	mageekguy\atoum\reports\asynchronous as reports
+	atoum,
+	atoum\runner,
+	atoum\report,
+	atoum\reports\asynchronous as reports
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,7 +15,7 @@ class xunit extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\asynchronous');
+		$this->testedClass->extends('atoum\reports\asynchronous');
 	}
 
 	public function testClassConstants()
@@ -31,12 +31,12 @@ class xunit extends atoum\test
 			->and($report = new reports\xunit($adapter))
 			->then
 				->array($report->getFields(atoum\runner::runStart))->isEmpty()
-				->object($report->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($report->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($report->getLocale())->isInstanceOf('atoum\locale')
+				->object($report->getAdapter())->isInstanceOf('atoum\adapter')
 			->if($adapter->extension_loaded = false)
 			->then
 				->exception(function() use ($adapter) { new reports\xunit($adapter); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('libxml PHP extension is mandatory for xunit report')
 		;
 	}
@@ -56,10 +56,10 @@ class xunit extends atoum\test
 			->then
 				->string($report->setTitle($title = uniqid())->handleEvent(atoum\runner::runStop, new atoum\runner())->getTitle())->isEqualTo($title)
 			->if($report = new reports\xunit($adapter))
-			->and($writer = new \mock\mageekguy\atoum\writers\file())
+			->and($writer = new \mock\atoum\writers\file())
 			->and($writer->getMockController()->write = $writer)
 			->then
-				->when(function() use ($report, $writer) { $report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \mageekguy\atoum\runner()); })
+				->when(function() use ($report, $writer) { $report->addWriter($writer)->handleEvent(atoum\runner::runStop, new \atoum\runner()); })
 					->mock($writer)->call('writeAsynchronousReport')->withArguments($report)->once()
 		;
 	}
@@ -76,7 +76,7 @@ class xunit extends atoum\test
 			->and($runner->setScore($score))
 			->and($testScore = new atoum\test\score())
 			->and($testScore->addPass())
-			->and($test = new \mock\mageekguy\atoum\test())
+			->and($test = new \mock\atoum\test())
 			->and($test->getMockController()->getCurrentMethod[1] = $method = 'method')
 			->and($test->getMockController()->getCurrentMethod[2] = $otherMethod = 'otherMethod')
 			->and($test->getMockController()->getCurrentMethod[3] = $thirdMethod = 'thirdMethod')

--- a/tests/units/classes/reports/realtime/cli.php
+++ b/tests/units/classes/reports/realtime/cli.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime;
+namespace atoum\tests\units\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields,
-	mageekguy\atoum\reports\realtime\cli as testedClass
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields,
+	atoum\reports\realtime\cli as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -16,7 +16,7 @@ class cli extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\realtime');
+		$this->testedClass->extends('atoum\reports\realtime');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/reports/realtime/cli/light.php
+++ b/tests/units/classes/reports/realtime/cli/light.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime\cli;
+namespace atoum\tests\units\reports\realtime\cli;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields,
-	mageekguy\atoum\reports\realtime\cli\light as testedClass
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields,
+	atoum\reports\realtime\cli\light as testedClass
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -16,7 +16,7 @@ class light extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\realtime');
+		$this->testedClass->extends('atoum\reports\realtime');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/reports/realtime/phing.php
+++ b/tests/units/classes/reports/realtime/phing.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime;
+namespace atoum\tests\units\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli\prompt,
-	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields,
-	mageekguy\atoum\reports\realtime\phing as testedClass
+	atoum,
+	atoum\cli\prompt,
+	atoum\cli\colorizer,
+	atoum\report\fields,
+	atoum\reports\realtime\phing as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -16,7 +16,7 @@ class phing extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\reports\realtime');
+		$this->testedClass->extends('atoum\reports\realtime');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/reports/realtime/tap.php
+++ b/tests/units/classes/reports/realtime/tap.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\reports\realtime;
+namespace atoum\tests\units\reports\realtime;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\report\fields,
-	mageekguy\atoum\reports\realtime\tap as testedClass
+	atoum,
+	atoum\report\fields,
+	atoum\reports\realtime\tap as testedClass
 ;
 
 require __DIR__ . '/../../../runner.php';
@@ -15,7 +15,7 @@ class tap extends atoum\test
 	public function testClass()
 	{
 		$this->testedClass
-			->extends('mageekguy\atoum\reports\realtime')
+			->extends('atoum\reports\realtime')
 		;
 	}
 

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\runner as testedClass
+	atoum,
+	atoum\test,
+	atoum\mock,
+	atoum\runner as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -17,9 +17,9 @@ class runner extends atoum\test
 	{
 		$this->assert
 			->testedClass
-				->hasInterface('mageekguy\atoum\observable')
-			->string(atoum\runner::atoumVersionConstant)->isEqualTo('mageekguy\atoum\version')
-			->string(atoum\runner::atoumDirectoryConstant)->isEqualTo('mageekguy\atoum\directory')
+				->hasInterface('atoum\observable')
+			->string(atoum\runner::atoumVersionConstant)->isEqualTo('atoum\version')
+			->string(atoum\runner::atoumDirectoryConstant)->isEqualTo('atoum\directory')
 			->string(atoum\runner::runStart)->isEqualTo('runnerStart')
 			->string(atoum\runner::runStop)->isEqualTo('runnerStop')
 		;
@@ -30,12 +30,12 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->object($runner->getScore())->isInstanceOf('mageekguy\atoum\score')
-				->object($runner->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($runner->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($runner->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
+				->object($runner->getScore())->isInstanceOf('atoum\score')
+				->object($runner->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($runner->getLocale())->isInstanceOf('atoum\locale')
+				->object($runner->getIncluder())->isInstanceOf('atoum\includer')
 				->variable($runner->getTestGenerator())->isNull()
-				->object($runner->getTestDirectoryIterator())->isInstanceOf('mageekguy\atoum\iterators\recursives\directory\factory')
+				->object($runner->getTestDirectoryIterator())->isInstanceOf('atoum\iterators\recursives\directory\factory')
 				->object($defaultGlobIteratorFactory = $runner->getGlobIteratorFactory())->isInstanceOf('closure')
 				->object($defaultGlobIteratorFactory($pattern = uniqid()))->isEqualTo(new \globIterator($pattern))
 				->object($defaultReflectionClassFactory = $runner->getReflectionClassFactory())->isInstanceOf('closure')
@@ -142,7 +142,7 @@ class runner extends atoum\test
 				->object($runner->getTestGenerator())->isIdenticalTo($generator)
 				->object($runner->setTestGenerator())->isIdenticalTo($runner)
 				->object($runner->getTestGenerator())
-					->isInstanceOf('mageekguy\atoum\test\generator')
+					->isInstanceOf('atoum\test\generator')
 					->isNotIdenticalTo($generator)
 		;
 	}
@@ -191,7 +191,7 @@ class runner extends atoum\test
 			->if($runner = new testedClass())
 			->then
 				->array($runner->getObservers())->isEmpty()
-				->object($runner->addObserver($observer = new \mock\mageekguy\atoum\observers\runner()))->isIdenticalTo($runner)
+				->object($runner->addObserver($observer = new \mock\atoum\observers\runner()))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEqualTo(array($observer))
 		;
 	}
@@ -202,13 +202,13 @@ class runner extends atoum\test
 			->if($runner = new testedClass())
 			->then
 				->array($runner->getObservers())->isEmpty()
-				->object($runner->removeObserver(new \mock\mageekguy\atoum\observers\runner()))->isIdenticalTo($runner)
+				->object($runner->removeObserver(new \mock\atoum\observers\runner()))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEmpty()
-			->if($runner->addObserver($observer1 = new \mock\mageekguy\atoum\observers\runner()))
-			->and($runner->addObserver($observer2 = new \mock\mageekguy\atoum\observers\runner()))
+			->if($runner->addObserver($observer1 = new \mock\atoum\observers\runner()))
+			->and($runner->addObserver($observer2 = new \mock\atoum\observers\runner()))
 			->then
 				->array($runner->getObservers())->isEqualTo(array($observer1, $observer2))
-				->object($runner->removeObserver(new \mock\mageekguy\atoum\observers\runner()))->isIdenticalTo($runner)
+				->object($runner->removeObserver(new \mock\atoum\observers\runner()))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEqualTo(array($observer1, $observer2))
 				->object($runner->removeObserver($observer1))->isIdenticalTo($runner)
 				->array($runner->getObservers())->isEqualTo(array($observer2))
@@ -223,7 +223,7 @@ class runner extends atoum\test
 			->if($runner = new testedClass())
 			->then
 				->object($runner->callObservers(atoum\runner::runStart))->isIdenticalTo($runner)
-			->if($runner->addObserver($observer = new \mock\mageekguy\atoum\observers\runner()))
+			->if($runner->addObserver($observer = new \mock\atoum\observers\runner()))
 			->then
 				->object($runner->callObservers(atoum\runner::runStart))->isIdenticalTo($runner)
 				->mock($observer)->call('handleEvent')->withArguments(atoum\runner::runStart, $runner)->once()
@@ -243,8 +243,8 @@ class runner extends atoum\test
 			->if($runner->run())
 			->then
 				->variable($runner->getRunningDuration())->isNull()
-			->if(eval('namespace ' . __NAMESPACE__ . ' { class forTestGetRunningDuration extends \mageekguy\atoum\test { public function testSomething() {} } }'))
-			->and($adapter->get_declared_classes = array('mageekguy\atoum\tests\units\forTestGetRunningDuration'))
+			->if(eval('namespace ' . __NAMESPACE__ . ' { class forTestGetRunningDuration extends \atoum\test { public function testSomething() {} } }'))
+			->and($adapter->get_declared_classes = array('atoum\tests\units\forTestGetRunningDuration'))
 			->and($runner->run())
 			->then
 				->integer($runner->getRunningDuration())->isEqualTo(100)
@@ -285,7 +285,7 @@ class runner extends atoum\test
 	{
 		$this
 			->if($runner = new testedClass())
-			->and($includer = new \mock\mageekguy\atoum\includer())
+			->and($includer = new \mock\atoum\includer())
 			->and($includer->getMockController()->includePath = function() {})
 			->and($runner->setIncluder($includer))
 			->then
@@ -353,8 +353,8 @@ class runner extends atoum\test
 				->object($runner->removeReport(new atoum\reports\realtime\cli()))->isIdenticalTo($runner)
 				->array($runner->getReports())->isEmpty()
 				->array($runner->getObservers())->isEmpty()
-			->if($report1 = new \mock\mageekguy\atoum\report())
-			->and($report2 = new \mock\mageekguy\atoum\report())
+			->if($report1 = new \mock\atoum\report())
+			->and($report2 = new \mock\atoum\report())
 			->and($runner->addReport($report1)->addReport($report2))
 			->then
 				->array($runner->getReports())->isEqualTo(array($report1, $report2))
@@ -392,8 +392,8 @@ class runner extends atoum\test
 				->object($runner->removeReports())->isIdenticalTo($runner)
 				->array($runner->getReports())->isEmpty()
 				->array($runner->getObservers())->isEmpty()
-			->if($report1 = new \mock\mageekguy\atoum\report())
-			->and($report2 = new \mock\mageekguy\atoum\report())
+			->if($report1 = new \mock\atoum\report())
+			->and($report2 = new \mock\atoum\report())
 			->and($runner->addReport($report1)->addReport($report2))
 			->then
 				->array($runner->getReports())->isEqualTo(array($report1, $report2))
@@ -442,7 +442,7 @@ class runner extends atoum\test
 	public function testSetPathAndVersionInScore()
 	{
 		$this
-			->if($php = new \mock\mageekguy\atoum\php())
+			->if($php = new \mock\atoum\php())
 			->and($this->calling($php)->getBinaryPath = $phpPath = uniqid())
 			->and($this->calling($php)->run = $php)
 			->and($this->calling($php)->isRunning = false)
@@ -464,7 +464,7 @@ class runner extends atoum\test
 			->and($runner = new testedClass())
 			->and($runner->setPhp($php))
 			->and($runner->setAdapter($adapter))
-			->and($runner->setScore($score = new \mock\mageekguy\atoum\runner\score()))
+			->and($runner->setScore($score = new \mock\atoum\runner\score()))
 			->then
 				->object($runner->setPathAndVersionInScore())->isIdenticalTo($runner)
 				->mock($score)
@@ -473,7 +473,7 @@ class runner extends atoum\test
 					->call('setPhpPath')->withArguments($phpPath)->once()
 					->call('setPhpVersion')->withArguments($phpVersion)->once()
 			->if($adapter->defined = false)
-			->and($runner->setScore($score = new \mock\mageekguy\atoum\runner\score()))
+			->and($runner->setScore($score = new \mock\atoum\runner\score()))
 			->then
 				->object($runner->setPathAndVersionInScore())->isIdenticalTo($runner)
 				->mock($score)
@@ -482,13 +482,13 @@ class runner extends atoum\test
 					->call('setPhpPath')->withArguments($phpPath)->once()
 					->call('setPhpVersion')->withArguments($phpVersion)->once()
 			->if($this->calling($php)->getExitCode = rand(1, PHP_INT_MAX))
-			->and($runner->setScore($score = new \mock\mageekguy\atoum\runner\score()))
+			->and($runner->setScore($score = new \mock\atoum\runner\score()))
 			->then
 				->exception(function() use ($runner) {
 						$runner->setPathAndVersionInScore();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to get PHP version from \'' . $php . '\'')
 		;
 	}

--- a/tests/units/classes/runner/score.php
+++ b/tests/units/classes/runner/score.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\runner;
+namespace atoum\tests\units\runner;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\runner\score as testedClass
+	atoum,
+	atoum\runner\score as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -13,7 +13,7 @@ class score extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubClassOf('mageekguy\atoum\score');
+		$this->testedClass->isSubClassOf('atoum\score');
 	}
 
 	public function test__construct()
@@ -62,7 +62,7 @@ class score extends atoum\test
 							$score->setAtoumPath(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path of atoum is already set')
 				->object($score->reset()->setAtoumPath($path = rand(1, PHP_INT_MAX)))->isIdenticalTo($score)
 				->string($score->getAtoumPath())->isEqualTo((string) $path)
@@ -80,7 +80,7 @@ class score extends atoum\test
 							$score->setAtoumVersion(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Version of atoum is already set')
 				->object($score->reset()->setAtoumVersion($version = rand(1, PHP_INT_MAX)))->isIdenticalTo($score)
 				->string($score->getAtoumVersion())->isEqualTo((string) $version)
@@ -98,7 +98,7 @@ class score extends atoum\test
 							$score->setPhpPath(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('PHP path is already set')
 				->object($score->reset()->setPhpPath($path = rand(1, PHP_INT_MAX)))->isIdenticalTo($score)
 				->string($score->getPhpPath())->isEqualTo((string) $path)
@@ -116,7 +116,7 @@ class score extends atoum\test
 						$score->setPhpVersion(uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('PHP version is already set')
 		;
 	}

--- a/tests/units/classes/score.php
+++ b/tests/units/classes/score.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\exceptions
+	atoum,
+	atoum\exceptions
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -25,7 +25,7 @@ class score extends atoum\test
 				->array($score->getMemoryUsages())->isEmpty()
 				->array($score->getUncompletedMethods())->isEmpty()
 				->array($score->getSkippedMethods())->isEmpty()
-				->object($score->getCoverage())->isInstanceOf('mageekguy\atoum\score\coverage')
+				->object($score->getCoverage())->isInstanceOf('atoum\score\coverage')
 			->and($score = new atoum\score($coverage = new atoum\score\coverage()))
 			->then
 				->integer($score->getPassNumber())->isZero()
@@ -907,7 +907,7 @@ class score extends atoum\test
 		$this
 			->if($score = new atoum\score())
 			->then
-				->object($coverage = $score->getCoverage())->isInstanceOf('mageekguy\atoum\score\coverage')
+				->object($coverage = $score->getCoverage())->isInstanceOf('atoum\score\coverage')
 		;
 	}
 
@@ -1177,7 +1177,7 @@ class score extends atoum\test
 		$this
 			->if($score = new atoum\score())
 			->exception(function() use ($score, & $key) { $score->deleteError($key = rand(- PHP_INT_MAX, PHP_INT_MAX)); })
-				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 				->hasMessage('Error key \'' . $key . '\' does not exist')
 			->if($score->addError(uniqid(), uniqid(), uniqid(), rand(1, PHP_INT_MAX), $type = rand(1, PHP_INT_MAX), $message = uniqid(), uniqid(), rand(1, PHP_INT_MAX)))
 			->then

--- a/tests/units/classes/score/coverage.php
+++ b/tests/units/classes/score/coverage.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\score;
+namespace atoum\tests\units\score;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\score,
-	mageekguy\atoum\score\coverage as testedClass
+	atoum,
+	atoum\mock,
+	atoum\score,
+	atoum\score\coverage as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -49,7 +49,7 @@ class coverage extends atoum\test
 				->object($coverage->getAdapter())->isIdenticalTo($adapter)
 				->object($coverage->setAdapter())->isIdenticalTo($coverage)
 				->object($coverage->getAdapter())
-					->isInstanceOf('mageekguy\atoum\adapter')
+					->isInstanceOf('atoum\adapter')
 					->isNotIdenticalTo($adapter)
 		;
 	}

--- a/tests/units/classes/script.php
+++ b/tests/units/classes/script.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers,
-	mageekguy\atoum\script\prompt,
-	mock\mageekguy\atoum as mock
+	atoum,
+	atoum\writers,
+	atoum\script\prompt,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -32,12 +32,12 @@ class script extends atoum\test
 			->if($script = new mock\script($name = uniqid()))
 			->then
 				->string($script->getName())->isEqualTo($name)
-				->object($script->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($script->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($script->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
-				->object($script->getOutputWriter())->isInstanceOf('mageekguy\atoum\writers\std\out')
+				->object($script->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($script->getLocale())->isInstanceOf('atoum\locale')
+				->object($script->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
+				->object($script->getOutputWriter())->isInstanceOf('atoum\writers\std\out')
 				->object($script->getInfoWriter())->isIdenticalTo($script->getOutputWriter())
-				->object($script->getErrorWriter())->isInstanceOf('mageekguy\atoum\writers\std\err')
+				->object($script->getErrorWriter())->isInstanceOf('atoum\writers\std\err')
 				->object($script->getWarningWriter())->isIdenticalTo($script->getErrorWriter())
 				->object($script->getHelpWriter())->isEqualTo($defaultHelpWriter)
 				->array($script->getHelp())->isEmpty()
@@ -47,11 +47,11 @@ class script extends atoum\test
 			->then
 				->string($script->getName())->isEqualTo($name)
 				->object($script->getAdapter())->isIdenticalTo($adapter)
-				->object($script->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($script->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
-				->object($script->getOutputWriter())->isInstanceOf('mageekguy\atoum\writers\std\out')
+				->object($script->getLocale())->isInstanceOf('atoum\locale')
+				->object($script->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
+				->object($script->getOutputWriter())->isInstanceOf('atoum\writers\std\out')
 				->object($script->getInfoWriter())->isIdenticalTo($script->getOutputWriter())
-				->object($script->getErrorWriter())->isInstanceOf('mageekguy\atoum\writers\std\err')
+				->object($script->getErrorWriter())->isInstanceOf('atoum\writers\std\err')
 				->object($script->getWarningWriter())->isIdenticalTo($script->getErrorWriter())
 				->object($script->getHelpWriter())->isEqualTo($defaultHelpWriter)
 				->array($script->getHelp())->isEmpty()
@@ -64,7 +64,7 @@ class script extends atoum\test
 						new mock\script($name = uniqid(), $adapter);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('\'' . $name . '\' must be used in CLI only')
 		;
 	}

--- a/tests/units/classes/script/arguments/parser.php
+++ b/tests/units/classes/script/arguments/parser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\script\arguments;
+namespace atoum\tests\units\script\arguments;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\script
+	atoum,
+	atoum\script
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -46,27 +46,27 @@ class parser extends atoum\test
 			->if($parser = new script\arguments\parser())
 			->then
 				->castToString($parser)->isEmpty()
-			->if($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array()))
+			->if($parser->parse(new \mock\atoum\script(uniqid()), array()))
 			->then
 				->castToString($parser)->isEmpty()
 			->if($parser->addHandler(function($script, $argument, $values) {}, array('-a')))
-			->and($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array()))
+			->and($parser->parse(new \mock\atoum\script(uniqid()), array()))
 			->then
 				->castToString($parser)->isEmpty()
-			->if($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array('-a')))
+			->if($parser->parse(new \mock\atoum\script(uniqid()), array('-a')))
 			->then
 				->castToString($parser)->isEqualTo('-a')
-			->if($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array('-a', 'A')))
+			->if($parser->parse(new \mock\atoum\script(uniqid()), array('-a', 'A')))
 			->then
 				->castToString($parser)->isEqualTo('-a A')
-			->if($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array('-a', 'A', 'B', 'C')))
+			->if($parser->parse(new \mock\atoum\script(uniqid()), array('-a', 'A', 'B', 'C')))
 			->then
 				->castToString($parser)->isEqualTo('-a A B C')
 			->if($parser->addHandler(function($script, $argument, $values) {}, array('--b')))
-			->and($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array('-a', 'A', 'B', 'C')))
+			->and($parser->parse(new \mock\atoum\script(uniqid()), array('-a', 'A', 'B', 'C')))
 			->then
 				->castToString($parser)->isEqualTo('-a A B C')
-			->and($parser->parse(new \mock\mageekguy\atoum\script(uniqid()), array('-a', 'A', 'B', 'C', '--b')))
+			->and($parser->parse(new \mock\atoum\script(uniqid()), array('-a', 'A', 'B', 'C', '--b')))
 			->then
 				->castToString($parser)->isEqualTo('-a A B C --b')
 		;
@@ -85,7 +85,7 @@ class parser extends atoum\test
 	public function testGetValues()
 	{
 		$this
-			->if($script = new \mock\mageekguy\atoum\script(uniqid()))
+			->if($script = new \mock\atoum\script(uniqid()))
 			->and($parser = new script\arguments\parser())
 			->then
 				->array($parser->getValues())->isEmpty()
@@ -117,7 +117,7 @@ class parser extends atoum\test
 	public function testGetIterator()
 	{
 		$this
-			->if($script = new \mock\mageekguy\atoum\script(uniqid()))
+			->if($script = new \mock\atoum\script(uniqid()))
 			->and($parser = new script\arguments\parser())
 			->and($parser->parse($script, array()))
 			->then
@@ -140,7 +140,7 @@ class parser extends atoum\test
 	{
 		$this
 			->assert('when using $_SERVER')
-				->if($script = new \mock\mageekguy\atoum\script(uniqid()))
+				->if($script = new \mock\atoum\script(uniqid()))
 				->and($superglobals = new atoum\superglobals())
 				->and($superglobals->_SERVER['argv'] = array())
 				->and($parser = new script\arguments\parser($superglobals))
@@ -215,12 +215,12 @@ class parser extends atoum\test
 				->if($superglobals->_SERVER['argv'] = array('scriptName', '-ac'))
 				->then
 					->exception(function() use ($parser, $script) { $parser->parse($script); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+						->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 						->hasMessage('Argument \'-ac\' is unknown, did you mean \'--c\'?')
 				->if($superglobals->_SERVER['argv'] = array('scriptName', '-unknownArgument'))
 				->then
 					->exception(function() use ($parser, $script) { $parser->parse($script); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+						->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 						->hasMessage('Argument \'-unknownArgument\' is unknown')
 				->if($parser->setDefaultHandler(function($script, $argument) use (& $defaultHandlerScript, & $defaultHandlerArgument)
 						{
@@ -297,7 +297,7 @@ class parser extends atoum\test
 							$parser->parse($script, array('b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+						->isInstanceOf('atoum\exceptions\runtime\unexpectedValue')
 						->hasMessage('Argument \'b\' is unknown')
 				->if($superglobals->_SERVER['argv'] = array('scriptName', '-a', 'a1', 'a2', '-b', 'b1', 'b2', 'b3', '-d', 'd1', 'd2', '--c'))
 				->and($parser->addHandler(function($script, $argument, $value) {}, array('-d'), PHP_INT_MAX))
@@ -357,25 +357,25 @@ class parser extends atoum\test
 							$parser->addHandler(function() {}, $argument = array('-b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take three arguments')
 				->exception(function() use ($parser) {
 							$parser->addHandler(function($script) {}, array('-b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take three arguments')
 				->exception(function() use ($parser) {
 							$parser->addHandler(function($script, $argument) {}, array('-b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take three arguments')
 				->exception(function() use ($parser, & $badArgument) {
 							$parser->addHandler(function($script, $argument, $values) {}, array($badArgument = 'b'));
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Argument \'' . $badArgument . '\' is invalid')
 				->object($parser->addHandler($otherHandler = function($script, $argument, $values) {}, array($otherArgument = '-b'), $priority = rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($parser)
 				->array($parser->getHandlers())->isEqualTo(array($argument => array($handler, $handler), $otherArgument => array($otherHandler)))
@@ -394,13 +394,13 @@ class parser extends atoum\test
 							$parser->setDefaultHandler(function() {});
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take two arguments')
 				->exception(function() use ($parser) {
 							$parser->setDefaultHandler(function($script) {});
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Handler must take two arguments')
 		;
 	}

--- a/tests/units/classes/script/configurable.php
+++ b/tests/units/classes/script/configurable.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\script;
+namespace atoum\tests\units\script;
 
 use
-	mageekguy\atoum,
-	mock\mageekguy\atoum\script\configurable as testedClass
+	atoum,
+	mock\atoum\script\configurable as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class configurable extends atoum\test
 	{
 		$this->testedClass
 			->isAbstract()
-			->extends('mageekguy\atoum\script')
+			->extends('atoum\script')
 		;
 	}
 
@@ -31,7 +31,7 @@ class configurable extends atoum\test
 			->then
 				->string($configurable->getName())->isEqualTo($name)
 				->object($configurable->getAdapter())->isEqualTo(new atoum\adapter())
-				->object($configurable->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
+				->object($configurable->getIncluder())->isInstanceOf('atoum\includer')
 				->array($configurable->getConfigFiles())->isEmpty()
 				->array($configurable->getHelp())->isEqualTo(array(
 						array(
@@ -50,7 +50,7 @@ class configurable extends atoum\test
 			->then
 				->string($configurable->getName())->isEqualTo($name)
 				->object($configurable->getAdapter())->isIdenticalTo($adapter)
-				->object($configurable->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
+				->object($configurable->getIncluder())->isInstanceOf('atoum\includer')
 				->array($configurable->getConfigFiles())->isEmpty()
 				->array($configurable->getHelp())->isEqualTo(array(
 						array(
@@ -88,9 +88,9 @@ class configurable extends atoum\test
 			->if($configurable = new testedClass(uniqid()))
 			->then
 				->exception(function() use ($configurable, & $file) { $configurable->useConfigFile($file = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\includer\exception')
+					->isInstanceOf('atoum\includer\exception')
 					->hasMessage('Unable to find configuration file \'' . $file . '\'')
-			->if($includer = new \mock\mageekguy\atoum\includer())
+			->if($includer = new \mock\atoum\includer())
 			->and($this->calling($includer)->includePath = function() {})
 			->and($configurable->setIncluder($includer))
 			->then

--- a/tests/units/classes/script/prompt.php
+++ b/tests/units/classes/script/prompt.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\script;
+namespace atoum\tests\units\script;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\script\prompt as testedClass
+	atoum,
+	atoum\script\prompt as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/scripts/builder.php
+++ b/tests/units/classes/scripts/builder.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\scripts,
-	mageekguy\atoum\scripts\builder\vcs,
-	mageekguy\atoum\scripts\builder as testedClass
+	atoum,
+	atoum\mock,
+	atoum\scripts,
+	atoum\scripts\builder\vcs,
+	atoum\scripts\builder as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -27,7 +27,7 @@ class builder extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\script\configurable');
+		$this->testedClass->extends('atoum\script\configurable');
 	}
 
 	public function testClassConstants()
@@ -44,11 +44,11 @@ class builder extends atoum\test
 			->if($builder = new testedClass($name = uniqid()))
 			->then
 				->string($builder->getName())->isEqualTo($name)
-				->object($builder->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($builder->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($builder->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
-				->object($builder->getOutputWriter())->isInstanceOf('mageekguy\atoum\writers\std\out')
-				->object($builder->getErrorWriter())->isInstanceOf('mageekguy\atoum\writers\std\err')
+				->object($builder->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($builder->getLocale())->isInstanceOf('atoum\locale')
+				->object($builder->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
+				->object($builder->getOutputWriter())->isInstanceOf('atoum\writers\std\out')
+				->object($builder->getErrorWriter())->isInstanceOf('atoum\writers\std\err')
 				->array($builder->getRunnerConfigurationFiles())->isEmpty()
 				->variable($builder->getVersion())->isNull()
 				->variable($builder->getWorkingDirectory())->isNull()
@@ -59,16 +59,16 @@ class builder extends atoum\test
 				->string($builder->getUnitTestRunnerScript())->isEqualTo(scripts\builder::defaultUnitTestRunnerScript)
 				->string($builder->getPharGeneratorScript())->isEqualTo(scripts\builder::defaultPharGeneratorScript)
 				->variable($builder->getReportTitle())->isNull()
-				->object($builder->getVcs())->isInstanceOf('mageekguy\atoum\scripts\builder\vcs\svn')
+				->object($builder->getVcs())->isInstanceOf('atoum\scripts\builder\vcs\svn')
 				->variable($builder->getTaggerEngine())->isNull()
 			->if($builder = new testedClass($name = uniqid(), $adapter = new atoum\adapter()))
 			->then
 				->string($builder->getName())->isEqualTo($name)
 				->object($builder->getAdapter())->isIdenticalTo($adapter)
-				->object($builder->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($builder->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
-				->object($builder->getOutputWriter())->isInstanceOf('mageekguy\atoum\writers\std\out')
-				->object($builder->getErrorWriter())->isInstanceOf('mageekguy\atoum\writers\std\err')
+				->object($builder->getLocale())->isInstanceOf('atoum\locale')
+				->object($builder->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
+				->object($builder->getOutputWriter())->isInstanceOf('atoum\writers\std\out')
+				->object($builder->getErrorWriter())->isInstanceOf('atoum\writers\std\err')
 				->array($builder->getRunnerConfigurationFiles())->isEmpty()
 				->variable($builder->getVersion())->isNull()
 				->variable($builder->getWorkingDirectory())->isNull()
@@ -79,7 +79,7 @@ class builder extends atoum\test
 				->string($builder->getUnitTestRunnerScript())->isEqualTo(scripts\builder::defaultUnitTestRunnerScript)
 				->string($builder->getPharGeneratorScript())->isEqualTo(scripts\builder::defaultPharGeneratorScript)
 				->variable($builder->getReportTitle())->isNull()
-				->object($builder->getVcs())->isInstanceOf('mageekguy\atoum\scripts\builder\vcs\svn')
+				->object($builder->getVcs())->isInstanceOf('atoum\scripts\builder\vcs\svn')
 				->variable($builder->getTaggerEngine())->isNull()
 		;
 	}
@@ -147,7 +147,7 @@ class builder extends atoum\test
 			->if($builder = new testedClass(uniqid()))
 			->and->mockGenerator->shunt('__construct')
 			->then
-				->object($builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs()))->isIdenticalTo($builder)
+				->object($builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs()))->isIdenticalTo($builder)
 				->object($builder->getVcs())->isIdenticalTo($vcs)
 		;
 	}
@@ -298,7 +298,7 @@ class builder extends atoum\test
 	public function testCheckUnitTests()
 	{
 		$this
-			->if($builder = new \mock\mageekguy\atoum\scripts\builder(uniqid(), $adapter = new atoum\test\adapter()))
+			->if($builder = new \mock\atoum\scripts\builder(uniqid(), $adapter = new atoum\test\adapter()))
 			->and($builder->disableUnitTestChecking())
 			->then
 				->boolean($builder->unitTestCheckingIsEnabled())->isFalse()
@@ -309,20 +309,20 @@ class builder extends atoum\test
 						$builder->checkUnitTests();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Unable to check unit tests, working directory is undefined')
 			->if->mockGenerator->shunt('__construct')
-			->and($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs())
+			->and($vcs = new \mock\atoum\scripts\builder\vcs())
 			->and($this->calling($vcs)->exportRepository = function() {})
 			->and($builder->setVcs($vcs))
-			->and($php = new \mock\mageekguy\atoum\php())
+			->and($php = new \mock\atoum\php())
 			->and($this->calling($php)->run = $php)
 			->and($builder->setPhp($php))
 			->and($builder->setWorkingDirectory($workingDirectory = uniqid()))
 			->and($builder->setUnitTestRunnerScript($unitTestRunnerScript = uniqid()))
 			->and($builder->setReportTitle($reportTitle = uniqid()))
 			->and($builder->addRunnerConfigurationFile($runnerConfigurationFile = uniqid()))
-			->and($score = new \mock\mageekguy\atoum\score())
+			->and($score = new \mock\atoum\score())
 			->and($this->calling($score)->getFailNumber = 0)
 			->and($this->calling($score)->getExceptionNumber = 0)
 			->and($this->calling($score)->getErrorNumber = 0)
@@ -406,7 +406,7 @@ class builder extends atoum\test
 						$builder->checkUnitTests();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to delete score file \'' . $scoreFile . '\'')
 			->if($adapter->unlink = true)
 			->and($this->calling($score)->getFailNumber = rand(1, PHP_INT_MAX))
@@ -449,15 +449,15 @@ class builder extends atoum\test
 	public function testCreatePhar()
 	{
 		$this
-			->if($builder = new \mock\mageekguy\atoum\scripts\builder(uniqid(), $adapter = new atoum\test\adapter()))
-			->and($builder->setTaggerEngine($taggerEngine = new \mock\mageekguy\atoum\scripts\tagger\engine()))
+			->if($builder = new \mock\atoum\scripts\builder(uniqid(), $adapter = new atoum\test\adapter()))
+			->and($builder->setTaggerEngine($taggerEngine = new \mock\atoum\scripts\tagger\engine()))
 			->and($this->calling($taggerEngine)->tagVersion = function() {})
 			->and($builder->disablePharCreation())
 			->then
 				->boolean($builder->createPhar())->isTrue()
 			->if($builder->enablePharCreation())
 			->and->mockGenerator->shunt('__construct')
-			->and($builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs()))
+			->and($builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs()))
 			->and($this->calling($vcs)->getNextRevisions = array())
 			->and($this->calling($vcs)->exportRepository = function() {})
 			->then
@@ -465,7 +465,7 @@ class builder extends atoum\test
 							$builder->createPhar();
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Unable to create phar, destination directory is undefined')
 			->if($builder->setDestinationDirectory($destinationDirectory = uniqid()))
 			->then
@@ -473,10 +473,10 @@ class builder extends atoum\test
 							$builder->createPhar();
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Unable to create phar, working directory is undefined')
 			->if($builder->setWorkingDirectory($workingDirectory = uniqid()))
-			->and($builder->setPhp($php = new \mock\mageekguy\atoum\php()))
+			->and($builder->setPhp($php = new \mock\atoum\php()))
 			->and($this->calling($php)->run = $php)
 			->and($builder->setPharGeneratorScript($pharGeneratorScript = uniqid()))
 			->and($this->calling($builder)->writeErrorInErrorsDirectory = function() {})
@@ -544,7 +544,7 @@ class builder extends atoum\test
 							$builder->createPhar();
 						}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to save last revision in file \'' . $revisionFile . '\'')
 			->if($this->resetMock($vcs))
 			->and($this->calling($vcs)->getNextRevisions[1] = array(1, 2, 3))
@@ -592,7 +592,7 @@ class builder extends atoum\test
 			->and($adapter->fwrite = function() {})
 			->and($adapter->fclose = function() {})
 			->and($adapter->unlink = function() {})
-			->and($builder = new \mock\mageekguy\atoum\scripts\builder(uniqid(), $adapter))
+			->and($builder = new \mock\atoum\scripts\builder(uniqid(), $adapter))
 			->and($builder->setRunFile($runFile = uniqid()))
 			->and($this->calling($builder)->createPhar = function() {})
 			->then
@@ -625,11 +625,11 @@ class builder extends atoum\test
 							$builder->writeErrorInErrorsDirectory(uniqid());
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic')
+						->isInstanceOf('atoum\exceptions\logic')
 						->hasMessage('Revision is undefined')
 				->adapter($adapter)->call('file_put_contents')->never()
 			->if->mockGenerator->shunt('__construct')
-			->and($builder->setVcs($vcs = new \mock\mageekguy\atoum\scripts\builder\vcs()))
+			->and($builder->setVcs($vcs = new \mock\atoum\scripts\builder\vcs()))
 			->and($vcs->setRevision($revision = rand(1, PHP_INT_MAX)))
 			->then
 				->string($builder->getErrorsDirectory())->isEqualTo($errorDirectory)
@@ -643,7 +643,7 @@ class builder extends atoum\test
 							$builder->writeErrorInErrorsDirectory($message = uniqid());
 						}
 					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Unable to save error in file \'' . $errorDirectory . \DIRECTORY_SEPARATOR . $revision . '\'')
 				->adapter($adapter)->call('file_put_contents')->withArguments($errorDirectory . \DIRECTORY_SEPARATOR . $revision, $message, \LOCK_EX | \FILE_APPEND)->once()
 		;

--- a/tests/units/classes/scripts/builder/vcs/svn.php
+++ b/tests/units/classes/scripts/builder/vcs/svn.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\builder\vcs;
+namespace atoum\tests\units\scripts\builder\vcs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\scripts\builder\vcs
+	atoum,
+	atoum\mock,
+	atoum\mock\stream,
+	atoum\scripts\builder\vcs
 ;
 
 require_once __DIR__ . '/../../../../runner.php';
@@ -26,7 +26,7 @@ class svn extends atoum\test
 
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\scripts\builder\vcs');
+		$this->testedClass->isSubclassOf('atoum\scripts\builder\vcs');
 	}
 
 	public function test__construct()
@@ -34,7 +34,7 @@ class svn extends atoum\test
 		$this
 			->if($svn = new vcs\svn())
 			->then
-				->object($svn->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($svn->getAdapter())->isInstanceOf('atoum\adapter')
 				->variable($svn->getRepositoryUrl())->isNull()
 			->if($svn = new vcs\svn($adapter = new atoum\adapter()))
 			->then
@@ -142,7 +142,7 @@ class svn extends atoum\test
 						$svn->getNextRevisions();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to get logs, repository url is undefined')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->never()
@@ -201,7 +201,7 @@ class svn extends atoum\test
 		$adapter = new atoum\test\adapter();
 		$adapter->extension_loaded = true;
 
-		$svn = new \mock\mageekguy\atoum\scripts\builder\vcs\svn($adapter);
+		$svn = new \mock\atoum\scripts\builder\vcs\svn($adapter);
 
 		$this->assert
 			->object($svn->setWorkingDirectory($workingDirectory = uniqid()))->isIdenticalTo($svn)
@@ -216,7 +216,7 @@ class svn extends atoum\test
 		$adapter = new atoum\test\adapter();
 		$adapter->extension_loaded = true;
 
-		$svn = new \mock\mageekguy\atoum\scripts\builder\vcs\svn($adapter);
+		$svn = new \mock\atoum\scripts\builder\vcs\svn($adapter);
 
 		$svn->getMockController()->cleanWorkingDirectory = $svn;
 
@@ -225,7 +225,7 @@ class svn extends atoum\test
 						$svn->exportRepository(uniqid());
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to export repository, repository url is undefined')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->never()
@@ -248,7 +248,7 @@ class svn extends atoum\test
 						$svn->exportRepository();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to checkout repository \'' . $repositoryUrl . '\' in directory \'' . $workingDirectory . '\'')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->once()
@@ -271,7 +271,7 @@ class svn extends atoum\test
 						$svn->exportRepository();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to checkout repository \'' . $repositoryUrl . '\' in directory \'' . $workingDirectory . '\'')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->once()
@@ -294,7 +294,7 @@ class svn extends atoum\test
 						$svn->exportRepository();
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to checkout repository \'' . $repositoryUrl . '\' in directory \'' . $workingDirectory . '\'')
 			->adapter($adapter)
 				->call('svn_auth_set_parameter')->withArguments(PHP_SVN_AUTH_PARAM_IGNORE_SSL_VERIFY_ERRORS, true)->once()
@@ -351,7 +351,7 @@ class svn extends atoum\test
 			->and($workingDirectory->readdir[4] = $aFile = stream::getSubStream($workingDirectory))
 			->and($aFile->unlink = true)
 			->and($workingDirectory->readdir[5] = false)
-			->and($svn = new \mock\mageekguy\atoum\scripts\builder\vcs\svn($adapter, $svnController = new mock\controller()))
+			->and($svn = new \mock\atoum\scripts\builder\vcs\svn($adapter, $svnController = new mock\controller()))
 			->and($svn->setWorkingDirectory('atoum://workingDirectory'))
 			->then
 				->object($svn->cleanWorkingDirectory())->isIdenticalTo($svn)

--- a/tests/units/classes/scripts/phar/generator.php
+++ b/tests/units/classes/scripts/phar/generator.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\phar;
+namespace atoum\tests\units\scripts\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\mock\stream,
-	mageekguy\atoum\iterators,
-	mageekguy\atoum\scripts\phar
+	atoum,
+	atoum\mock,
+	atoum\mock\stream,
+	atoum\iterators,
+	atoum\scripts\phar
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -16,7 +16,7 @@ class generator extends atoum\test
 {
 	public function testClassConstants()
 	{
-		$this->string(phar\generator::phar)->isEqualTo('mageekguy.atoum.phar');
+		$this->string(phar\generator::phar)->isEqualTo('atoum.phar');
 	}
 
 	public function test__construct()
@@ -29,19 +29,19 @@ class generator extends atoum\test
 						$generator = new phar\generator($name = uniqid(), $adapter);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('\'' . $name . '\' must be used in CLI only')
 			->if($adapter->php_sapi_name = function() { return 'cli'; })
 			->and($generator = new phar\generator($name = uniqid(), $adapter))
 			->then
 				->object($generator->getAdapter())->isIdenticalTo($adapter)
-				->object($generator->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($generator->getOutputWriter())->isInstanceOf('mageekguy\atoum\writer')
-				->object($generator->getErrorWriter())->isInstanceOf('mageekguy\atoum\writer')
+				->object($generator->getLocale())->isInstanceOf('atoum\locale')
+				->object($generator->getOutputWriter())->isInstanceOf('atoum\writer')
+				->object($generator->getErrorWriter())->isInstanceOf('atoum\writer')
 				->string($generator->getName())->isEqualTo($name)
 				->variable($generator->getOriginDirectory())->isNull()
 				->variable($generator->getDestinationDirectory())->isNull()
-				->object($generator->getArgumentsParser())->isInstanceOf('mageekguy\atoum\script\arguments\parser')
+				->object($generator->getArgumentsParser())->isInstanceOf('atoum\script\arguments\parser')
 		;
 	}
 
@@ -57,7 +57,7 @@ class generator extends atoum\test
 						$generator->setOriginDirectory('');
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Empty origin directory is invalid')
 			->if($adapter->is_dir = function() { return false; })
 			->then
@@ -65,7 +65,7 @@ class generator extends atoum\test
 						$generator->setOriginDirectory($directory = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path \'' . $directory . '\' of origin directory is invalid')
 			->if($adapter->is_dir = function() { return true; })
 			->then
@@ -79,7 +79,7 @@ class generator extends atoum\test
 						$generator->setOriginDirectory($generator->getDestinationDirectory());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Origin directory must be different from destination directory')
 			->if($realDirectory = $generator->getDestinationDirectory() . DIRECTORY_SEPARATOR . uniqid())
 			->and($adapter->realpath = function($path) use ($realDirectory) { return $realDirectory; })
@@ -101,7 +101,7 @@ class generator extends atoum\test
 						$generator->setDestinationDirectory('');
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Empty destination directory is invalid')
 			->if ($adapter->is_dir = function() { return false; })
 			->then
@@ -109,7 +109,7 @@ class generator extends atoum\test
 						$generator->setDestinationDirectory($directory = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Path \'' . $directory . '\' of destination directory is invalid')
 			->if($adapter->is_dir = function() { return true; })
 			->then
@@ -125,7 +125,7 @@ class generator extends atoum\test
 						$generator->setDestinationDirectory($generator->getOriginDirectory());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Destination directory must be different from origin directory')
 		;
 	}
@@ -142,7 +142,7 @@ class generator extends atoum\test
 						$generator->setStubFile('');
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Stub file is invalid')
 			->if($adapter->is_file = function() { return false; })
 			->then
@@ -150,7 +150,7 @@ class generator extends atoum\test
 						$generator->setStubFile(uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Stub file is not a valid file')
 			->if($adapter->is_file = function() { return true; })
 			->then
@@ -184,7 +184,7 @@ class generator extends atoum\test
 	{
 		$this
 			->if($generator = new phar\generator(uniqid()))
-			->and($stdout = new \mock\mageekguy\atoum\writers\std\out())
+			->and($stdout = new \mock\atoum\writers\std\out())
 			->and($stdout->getMockController()->write = function() {})
 			->and($generator->setOutputWriter($stdout))
 			->then
@@ -197,7 +197,7 @@ class generator extends atoum\test
 	{
 		$this
 			->if($generator = new phar\generator(uniqid()))
-			->and($stderr = new \mock\mageekguy\atoum\writers\std\err())
+			->and($stderr = new \mock\atoum\writers\std\err())
 			->and($this->calling($stderr)->clear = $stderr)
 			->and($this->calling($stderr)->write = function() {})
 			->and($generator->setErrorWriter($stderr))
@@ -227,7 +227,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Origin directory must be defined')
 			->if($generator->setOriginDirectory((string) $originDirectory))
 			->then
@@ -235,7 +235,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Destination directory must be defined')
 			->if($generator->setDestinationDirectory(uniqid()))
 			->then
@@ -243,7 +243,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Stub file must be defined')
 			->if($generator->setStubFile($stubFile = uniqid()))
 			->and($adapter->is_readable = function() { return false; })
@@ -252,7 +252,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Origin directory \'' . $generator->getOriginDirectory() . '\' is not readable')
 			->if($adapter->is_readable = function($path) use ($originDirectory) { return ($path === (string) $originDirectory); })
 			->and($adapter->is_writable = function() { return false; })
@@ -261,7 +261,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Destination directory \'' . $generator->getDestinationDirectory() . '\' is not writable')
 			->if($adapter->is_writable = function() { return true; })
 			->then
@@ -269,7 +269,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Stub file \'' . $generator->getStubFile() . '\' is not readable')
 			->if($adapter->is_readable = function($path) use ($originDirectory, $stubFile) { return ($path === (string) $originDirectory || $path === $stubFile); })
 			->and($generator->setPharFactory(function($name) use (& $phar) {
@@ -292,7 +292,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('ABOUT file is missing in \'' . $generator->getOriginDirectory() . '\'')
 			->if($adapter->file_get_contents = function($file) use ($generator, & $description) {
 					switch ($file)
@@ -310,7 +310,7 @@ class generator extends atoum\test
 						$generator->run();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('COPYING file is missing in \'' . $generator->getOriginDirectory() . '\'')
 			->if($adapter->file_get_contents = function($file) use ($generator, & $description, & $licence, & $stub) {
 					switch ($file)
@@ -354,9 +354,9 @@ class generator extends atoum\test
 			->if($superglobals = new atoum\superglobals())
 			->and($superglobals->_SERVER = array('argv' => array(uniqid(), '--help')))
 			->and($generator->setArgumentsParser(new atoum\script\arguments\parser($superglobals)))
-			->and($stdout = new \mock\mageekguy\atoum\writers\std\out())
+			->and($stdout = new \mock\atoum\writers\std\out())
 			->and($stdout->getMockController()->write = function() {})
-			->and($stderr = new \mock\mageekguy\atoum\writers\std\err())
+			->and($stderr = new \mock\atoum\writers\std\err())
 			->and($stderr->getMockController()->write = function() {})
 			->and($generator->setOutputWriter($stdout))
 			->and($generator->setHelpWriter($stdout))

--- a/tests/units/classes/scripts/phar/stub.php
+++ b/tests/units/classes/scripts/phar/stub.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\phar;
+namespace atoum\tests\units\scripts\phar;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\phar,
-	mock\mageekguy\atoum as mock
+	atoum,
+	atoum\scripts\phar,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -14,7 +14,7 @@ class stub extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\scripts\runner');
+		$this->testedClass->extends('atoum\scripts\runner');
 	}
 
 	public function testClassConstants()
@@ -36,12 +36,12 @@ class stub extends atoum\test
 			->and($stdOut->getMockController()->write = function() {})
 			->then
 				->exception(function() use ($stub) { $stub->update(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to update the PHAR, phar.readonly is set, use \'-d phar.readonly=0\'')
 			->if($adapter->ini_get = function($name) { return $name === 'phar.readonly' ? 0 : $name = 'allow_url_fopen' ? 0 : ini_get($name); })
 			->then
 				->exception(function() use ($stub) { $stub->update(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to update the PHAR, allow_url_fopen is not set, use \'-d allow_url_fopen=1\'')
 			->if($adapter->ini_get = function($name) { return $name === 'phar.readonly' ? 0 : $name = 'allow_url_fopen' ? 1 : ini_get($name); })
 			->and($stub->setPharFactory(function($path) use (& $phar) {

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\cli,
-	mageekguy\atoum\mock\stream,
-	mock\mageekguy\atoum as mock,
-	mageekguy\atoum\scripts\runner as testedClass
+	atoum,
+	atoum\cli,
+	atoum\mock\stream,
+	mock\atoum as mock,
+	atoum\scripts\runner as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -16,7 +16,7 @@ class runner extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\script\configurable');
+		$this->testedClass->extends('atoum\script\configurable');
 	}
 
 	public function testClassConstants()
@@ -35,10 +35,10 @@ class runner extends atoum\test
 				->boolean($runner->hasDefaultArguments())->isFalse()
 				->array($runner->getDefaultArguments())->isEmpty()
 				->string($runner->getName())->isEqualTo($name)
-				->object($runner->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
-				->object($runner->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($runner->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
-				->object($runner->getRunner())->isInstanceOf('mageekguy\atoum\runner')
+				->object($runner->getAdapter())->isInstanceOf('atoum\adapter')
+				->object($runner->getLocale())->isInstanceOf('atoum\locale')
+				->object($runner->getIncluder())->isInstanceOf('atoum\includer')
+				->object($runner->getRunner())->isInstanceOf('atoum\runner')
 				->variable($runner->getScoreFile())->isNull()
 				->array($runner->getReports())->isEmpty()
 				->array($runner->getArguments())->isEmpty()
@@ -194,9 +194,9 @@ class runner extends atoum\test
 			->then
 				->string($runner->getName())->isEqualTo($name)
 				->object($runner->getAdapter())->isIdenticalTo($adapter)
-				->object($runner->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($runner->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
-				->object($runner->getRunner())->isInstanceOf('mageekguy\atoum\runner')
+				->object($runner->getLocale())->isInstanceOf('atoum\locale')
+				->object($runner->getIncluder())->isInstanceOf('atoum\includer')
+				->object($runner->getRunner())->isInstanceOf('atoum\runner')
 				->variable($runner->getScoreFile())->isNull()
 				->array($runner->getArguments())->isEmpty()
 				->array($runner->getHelp())->isEqualTo(array(
@@ -366,13 +366,13 @@ class runner extends atoum\test
 	{
 		$this
 			->if($runner = new testedClass(uniqid()))
-			->and($runner->setLocale($locale = new \mock\mageekguy\atoum\locale()))
+			->and($runner->setLocale($locale = new \mock\atoum\locale()))
 			->then
 				->exception(function() use ($runner, & $file) {
 						$runner->useConfigFile($file = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\includer\exception')
+					->isInstanceOf('atoum\includer\exception')
 					->hasMessage('Unable to find configuration file \'' . $file . '\'')
 				->mock($locale)->call('_')->withArguments('Unable to find configuration file \'%s\'')->once()
 			->if($configFile = stream::get())
@@ -387,23 +387,23 @@ class runner extends atoum\test
 	public function testAddTestAllDirectory()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
-			->and($stderr = new \mock\mageekguy\atoum\writers\std\err())
+			->if($runner = new \mock\atoum\scripts\runner(uniqid()))
+			->and($stderr = new \mock\atoum\writers\std\err())
 			->and($this->calling($stderr)->clear = $stderr)
 			->and($this->calling($stderr)->write = function() {})
 			->and($runner->setErrorWriter($stderr))
 			->then
 				->object($runner->addTestAllDirectory(uniqid()))->isIdenticalTo($runner)
-				->mock($stderr)->call('write')->withArguments('Error: --test-all argument is deprecated, please replace call to mageekguy\atoum\scripts\runner::addTestAllDirectory(\'path/to/default/tests/directory\') by $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in your configuration files and use atoum without any argument instead' . PHP_EOL)->once()
+				->mock($stderr)->call('write')->withArguments('Error: --test-all argument is deprecated, please replace call to atoum\scripts\runner::addTestAllDirectory(\'path/to/default/tests/directory\') by $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in your configuration files and use atoum without any argument instead' . PHP_EOL)->once()
 		;
 	}
 
 	public function testAddDefaultReport()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->if($runner = new \mock\atoum\scripts\runner(uniqid()))
 			->then
-				->object($report = $runner->addDefaultReport())->isInstanceOf('mageekguy\atoum\reports\realtime\cli')
+				->object($report = $runner->addDefaultReport())->isInstanceOf('atoum\reports\realtime\cli')
 				->array($report->getWriters())->isEqualTo(array(new atoum\writers\std\out()))
 		;
 	}
@@ -411,11 +411,11 @@ class runner extends atoum\test
 	public function testAddReport()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->if($runner = new \mock\atoum\scripts\runner(uniqid()))
 			->then
-				->object($runner->addReport($report = new \mock\mageekguy\atoum\report()))->isIdenticalTo($runner)
+				->object($runner->addReport($report = new \mock\atoum\report()))->isIdenticalTo($runner)
 				->array($runner->getReports())->isEqualTo(array($report))
-				->object($runner->addReport($otherReport = new \mock\mageekguy\atoum\report()))->isIdenticalTo($runner)
+				->object($runner->addReport($otherReport = new \mock\atoum\report()))->isIdenticalTo($runner)
 				->array($runner->getReports())->isEqualTo(array($report, $otherReport))
 		;
 	}
@@ -423,11 +423,11 @@ class runner extends atoum\test
 	public function testSetReport()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->if($runner = new \mock\atoum\scripts\runner(uniqid()))
 			->then
-				->object($runner->setReport($report = new \mock\mageekguy\atoum\report()))->isIdenticalTo($runner)
+				->object($runner->setReport($report = new \mock\atoum\report()))->isIdenticalTo($runner)
 				->array($runner->getReports())->isEqualTo(array($report))
-				->object($runner->setReport($otherReport = new \mock\mageekguy\atoum\report()))->isIdenticalTo($runner)
+				->object($runner->setReport($otherReport = new \mock\atoum\report()))->isIdenticalTo($runner)
 				->array($runner->getReports())->isEqualTo(array($otherReport))
 			->if($runner->addReport($report))
 			->then
@@ -438,7 +438,7 @@ class runner extends atoum\test
 	public function testSetNamespaces()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->if($runner = new \mock\atoum\scripts\runner(uniqid()))
 			->then
 				->object($runner->testNamespaces(array()))->isIdenticalTo($runner)
 				->array($runner->getTestedNamespaces())->isEmpty()
@@ -450,7 +450,7 @@ class runner extends atoum\test
 	public function testAddDefaultArguments()
 	{
 		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->if($runner = new \mock\atoum\scripts\runner(uniqid()))
 			->then
 				->object($runner->addDefaultArguments($arg1 = uniqid()))->isInstanceOf($runner)
 				->boolean($runner->hasDefaultArguments())->isTrue()
@@ -466,8 +466,8 @@ class runner extends atoum\test
 		$this
 			->given($runner = new testedClass(uniqid()))
 			->and($runner->setAdapter($adapter = new atoum\test\adapter()))
-			->and($runner->setOutputWriter($outputWriter = new \mock\mageekguy\atoum\writers\std\out()))
-			->and($runner->setPrompt($prompt = new \mock\mageekguy\atoum\script\prompt()))
+			->and($runner->setOutputWriter($outputWriter = new \mock\atoum\writers\std\out()))
+			->and($runner->setPrompt($prompt = new \mock\atoum\script\prompt()))
 			->and($adapter->copy = true)
 			->and($adapter->getcwd = $currentDirectory = uniqid())
 			->and($adapter->file_exists = false)
@@ -545,7 +545,7 @@ class runner extends atoum\test
 			->and($adapter->copy = false)
 			->then
 				->exception(function() use ($runner) { $runner->init(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to write \'' . atoum\directory . '/resources/configurations/runner/atoum.php.dist\' to \'' . $currentDirectory . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile . '\'')
 		;
 	}

--- a/tests/units/classes/scripts/tagger.php
+++ b/tests/units/classes/scripts/tagger.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts,
-	mock\mageekguy\atoum as mock
+	atoum,
+	atoum\scripts,
+	mock\atoum as mock
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class tagger extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubclassOf('mageekguy\atoum\script');
+		$this->testedClass->isSubclassOf('atoum\script');
 	}
 
 	public function test__construct()
@@ -22,7 +22,7 @@ class tagger extends atoum\test
 		$this
 			->if($tagger = new scripts\tagger(uniqid()))
 			->then
-				->object($tagger->getEngine())->isInstanceOf('mageekguy\atoum\scripts\tagger\engine')
+				->object($tagger->getEngine())->isInstanceOf('atoum\scripts\tagger\engine')
 		;
 	}
 
@@ -41,8 +41,8 @@ class tagger extends atoum\test
 		$this
 			->if($helpWriter = new mock\writers\std\out())
 			->and($this->calling($helpWriter)->write = function() {})
-			->and($tagger = new \mock\mageekguy\atoum\scripts\tagger(uniqid()))
-			->and($tagger->setEngine($engine = new \mock\mageekguy\atoum\scripts\tagger\engine()))
+			->and($tagger = new \mock\atoum\scripts\tagger(uniqid()))
+			->and($tagger->setEngine($engine = new \mock\atoum\scripts\tagger\engine()))
 			->and($tagger->setHelpWriter($helpWriter))
 			->and($this->calling($engine)->tagVersion = function() {})
 			->then

--- a/tests/units/classes/scripts/tagger/engine.php
+++ b/tests/units/classes/scripts/tagger/engine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\tagger;
+namespace atoum\tests\units\scripts\tagger;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\scripts\tagger
+	atoum,
+	atoum\mock,
+	atoum\scripts\tagger
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -14,7 +14,7 @@ class engine extends atoum\test
 {
 	public function testClassConstants()
 	{
-		$this->string(\mageekguy\atoum\scripts\tagger\engine::defaultVersionPattern)->isEqualTo('/\$Rev: [^ ]+ \$/');
+		$this->string(\atoum\scripts\tagger\engine::defaultVersionPattern)->isEqualTo('/\$Rev: [^ ]+ \$/');
 	}
 
 	public function test__construct()
@@ -25,8 +25,8 @@ class engine extends atoum\test
 			->variable($tagger->getSrcDirectory())->isNull()
 			->variable($tagger->getDestinationDirectory())->isNull()
 			->variable($tagger->getVersion())->isNull()
-			->string($tagger->getVersionPattern())->isEqualTo(\mageekguy\atoum\scripts\tagger\engine::defaultVersionPattern)
-			->object($tagger->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->string($tagger->getVersionPattern())->isEqualTo(\atoum\scripts\tagger\engine::defaultVersionPattern)
+			->object($tagger->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$tagger = new tagger\engine($adapter = new atoum\adapter());
@@ -35,7 +35,7 @@ class engine extends atoum\test
 			->variable($tagger->getSrcDirectory())->isNull()
 			->variable($tagger->getDestinationDirectory())->isNull()
 			->variable($tagger->getVersion())->isNull()
-			->string($tagger->getVersionPattern())->isEqualTo(\mageekguy\atoum\scripts\tagger\engine::defaultVersionPattern)
+			->string($tagger->getVersionPattern())->isEqualTo(\atoum\scripts\tagger\engine::defaultVersionPattern)
 			->object($tagger->getAdapter())->isIdenticalTo($adapter)
 		;
 	}
@@ -116,7 +116,7 @@ class engine extends atoum\test
 					$tagger->setSrcIteratorInjector(function() {});
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Src iterator injector must take one argument')
 			->object($tagger->setSrcIteratorInjector(function($directory) { return new \recursiveDirectoryIterator($directory); }))->isIdenticalTo($tagger)
 			->object($tagger->getSrcIterator())->isInstanceOf('recursiveDirectoryIterator')
@@ -133,7 +133,7 @@ class engine extends atoum\test
 					$tagger->getSrcIterator();
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to get files iterator, source directory is undefined')
 		;
 
@@ -141,7 +141,7 @@ class engine extends atoum\test
 
 		$this->assert
 			->object($tagger->getSrcIterator())->isInstanceOf('recursiveIteratorIterator')
-			->object($tagger->getSrcIterator()->getInnerIterator())->isInstanceOf('mageekguy\atoum\iterators\filters\recursives\dot')
+			->object($tagger->getSrcIterator()->getInnerIterator())->isInstanceOf('atoum\iterators\filters\recursives\dot')
 		;
 	}
 
@@ -157,7 +157,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to tag, src directory is undefined')
 		;
 
@@ -168,7 +168,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to tag, version is undefined')
 		;
 
@@ -182,7 +182,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Unable to tag, src iterator injector does not return an iterator')
 		;
 
@@ -218,7 +218,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to tag, path \'' . $file2 . '\' is unreadable')
 		;
 
@@ -231,7 +231,7 @@ class engine extends atoum\test
 					$tagger->tagVersion(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to tag, path \'' . $file2 . '\' is unwritable')
 		;
 

--- a/tests/units/classes/scripts/treemap.php
+++ b/tests/units/classes/scripts/treemap.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts;
+namespace atoum\tests\units\scripts;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\treemap as testedClass,
-	mock\mageekguy\atoum\scripts\treemap\analyzer as analyzer,
-	mock\mageekguy\atoum\scripts\treemap\categorizer as categorizer
+	atoum,
+	atoum\scripts\treemap as testedClass,
+	mock\atoum\scripts\treemap\analyzer as analyzer,
+	mock\atoum\scripts\treemap\categorizer as categorizer
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,7 +15,7 @@ class treemap extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\script\configurable');
+		$this->testedClass->extends('atoum\script\configurable');
 	}
 
 	public function testClassConstants()
@@ -163,7 +163,7 @@ class treemap extends atoum\test
 			->if($this->calling($includer)->includePath->throw = new atoum\includer\exception())
 			->then
 				->exception(function() use ($treemap, & $file) { $treemap->useConfigFile($file = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\includer\exception')
+					->isInstanceOf('atoum\includer\exception')
 					->hasMessage('Unable to find configuration file \'' . $file . '\'')
 		;
 	}

--- a/tests/units/classes/scripts/treemap/analyzer/generic.php
+++ b/tests/units/classes/scripts/treemap/analyzer/generic.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\treemap\analyzer;
+namespace atoum\tests\units\scripts\treemap\analyzer;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\treemap\analyzer\generic as testedClass
+	atoum,
+	atoum\scripts\treemap\analyzer\generic as testedClass
 ;
 
 require_once __DIR__ . '/../../../../runner.php';

--- a/tests/units/classes/scripts/treemap/categorizer.php
+++ b/tests/units/classes/scripts/treemap/categorizer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\scripts\treemap;
+namespace atoum\tests\units\scripts\treemap;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\scripts\treemap\categorizer as testedClass
+	atoum,
+	atoum\scripts\treemap\categorizer as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -42,13 +42,13 @@ class categorizer extends atoum\test
 				->object($categorizer->setMinDepthColor($color = 'FFFFFF'))->isIdenticalTo($categorizer)
 				->string($categorizer->getMinDepthColor())->isEqualTo('#' . $color)
 				->exception(function() use ($categorizer, & $color) { $categorizer->setMinDepthColor('#00000g'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Color must be in hexadecimal format')
 				->exception(function() use ($categorizer, & $color) { $categorizer->setMinDepthColor('#00000'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Color must be in hexadecimal format')
 				->exception(function() use ($categorizer, & $color) { $categorizer->setMinDepthColor('@000000'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Color must be in hexadecimal format')
 		;
 	}
@@ -71,13 +71,13 @@ class categorizer extends atoum\test
 				->object($categorizer->setMaxDepthColor($color = 'FFFFFF'))->isIdenticalTo($categorizer)
 				->string($categorizer->getMaxDepthColor())->isEqualTo('#' . $color)
 				->exception(function() use ($categorizer, & $color) { $categorizer->setMaxDepthColor('#00000g'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Color must be in hexadecimal format')
 				->exception(function() use ($categorizer, & $color) { $categorizer->setMaxDepthColor('#00000'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Color must be in hexadecimal format')
 				->exception(function() use ($categorizer, & $color) { $categorizer->setMaxDepthColor('@000000'); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Color must be in hexadecimal format')
 		;
 	}

--- a/tests/units/classes/superglobals.php
+++ b/tests/units/classes/superglobals.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\superglobals as testedClass
+	atoum,
+	atoum\superglobals as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -42,7 +42,7 @@ class superglobals extends atoum\test
 							$superglobals->{$name = uniqid()} = uniqid();
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('PHP superglobal \'$' . $name . '\' does not exist')
 			->if($superglobals->GLOBALS = ($variable = uniqid()))
 			->then

--- a/tests/units/classes/template.php
+++ b/tests/units/classes/template.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -51,14 +51,14 @@ class template extends atoum\test
 		$template = new atoum\template();
 
 		$this->assert
-			->object($iterator = $template->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
 		;
 
 		$template->addChild($childTag = new atoum\template\tag(uniqid()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($childTag)
 		;
@@ -66,7 +66,7 @@ class template extends atoum\test
 		$template->addChild($otherChildTag = new atoum\template\tag($childTag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(2)
 			->object($iterator->current())->isIdenticalTo($childTag)
 			->object($iterator->next()->current())->isIdenticalTo($otherChildTag)
@@ -75,11 +75,11 @@ class template extends atoum\test
 		$template->addChild($anotherChildTag = new atoum\template\tag(uniqid()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(2)
 			->object($iterator->current())->isIdenticalTo($childTag)
 			->object($iterator->next()->current())->isIdenticalTo($otherChildTag)
-			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($anotherChildTag)
 		;
@@ -87,12 +87,12 @@ class template extends atoum\test
 		$childTag->addChild($littleChildTag  = new atoum\template\tag($childTag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(3)
 			->object($iterator->current())->isIdenticalTo($childTag)
 			->object($iterator->next()->current())->isIdenticalTo($littleChildTag)
 			->object($iterator->next()->current())->isIdenticalTo($otherChildTag)
-			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->{$anotherChildTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($anotherChildTag)
 		;
@@ -612,7 +612,7 @@ class template extends atoum\test
 						$template->addChild($templateWithSameId);
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Id \'' . $id . '\' is already defined')
 		;
 	}
@@ -657,16 +657,16 @@ class template extends atoum\test
 		$template = new atoum\template();
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
 		;
 
 		$template->addChild($tag = new atoum\template\tag(uniqid()));
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
-			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(1)
 			->object($iterator->current())->isIdenticalTo($tag)
 		;
@@ -674,9 +674,9 @@ class template extends atoum\test
 		$template->addChild($otherTag = new atoum\template\tag($tag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
-			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(2)
 			->object($iterator->current())->isIdenticalTo($tag)
 			->object($iterator->next()->current())->isIdenticalTo($otherTag)
@@ -685,9 +685,9 @@ class template extends atoum\test
 		$tag->addChild($childTag = new atoum\template\tag($tag->getTag()));
 
 		$this->assert
-			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag(uniqid()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isZero()
-			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($iterator = $template->getByTag($tag->getTag()))->isInstanceOf('atoum\template\iterator')
 			->sizeOf($iterator)->isEqualTo(3)
 			->object($iterator->current())->isIdenticalTo($tag)
 			->object($iterator->next()->current())->isIdenticalTo($childTag)

--- a/tests/units/classes/template/data.php
+++ b/tests/units/classes/template/data.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\template
+	atoum,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/template/iterator.php
+++ b/tests/units/classes/template/iterator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\template
+	atoum,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -25,7 +25,7 @@ class iterator extends atoum\test
 		$iterator = new template\iterator();
 
 		$this->assert
-			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isZero()
 		;
 
@@ -37,20 +37,20 @@ class iterator extends atoum\test
 		$tag->addChild($childTag = new template\tag($tag->getTag()));
 
 		$this->assert
-			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isZero()
-			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isEqualTo(1)
 		;
 
 		$childTag->addChild($littleChildTag = new template\tag(uniqid()));
 
 		$this->assert
-			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{uniqid()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isZero()
-			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{$childTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isEqualTo(1)
-			->object($innerIterator = $iterator->{$childTag->getTag()}->{$littleChildTag->getTag()})->isInstanceOf('mageekguy\atoum\template\iterator')
+			->object($innerIterator = $iterator->{$childTag->getTag()}->{$littleChildTag->getTag()})->isInstanceOf('atoum\template\iterator')
 			->sizeOf($innerIterator)->isEqualTo(1)
 		;
 	}
@@ -110,7 +110,7 @@ class iterator extends atoum\test
 		$iterator = new template\iterator();
 
 		$template = new atoum\template();
-		$template->addChild($tag = new \mock\mageekguy\atoum\template\tag(uniqid()));
+		$template->addChild($tag = new \mock\atoum\template\tag(uniqid()));
 		$tag->getMockController()->build = function() {};
 
 		$iterator->addTag($tag->getTag(), $template);

--- a/tests/units/classes/template/parser.php
+++ b/tests/units/classes/template/parser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\template
+	atoum,
+	atoum\test,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,21 +18,21 @@ class parser extends atoum\test
 
 		$this->assert
 			->string($parser->getNamespace())->isEqualTo(template\parser::defaultNamespace)
-			->object($parser->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($parser->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$parser = new template\parser($namespace = uniqid());
 
 		$this->assert
 			->string($namespace)->isEqualTo($parser->getNamespace())
-			->object($parser->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($parser->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$parser = new template\parser($namespace = rand(1, PHP_INT_MAX));
 
 		$this->assert
 			->string($parser->getNamespace())->isEqualTo((string) $namespace)
-			->object($parser->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+			->object($parser->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 
 		$parser = new template\parser($namespace = uniqid(), $adapter = new atoum\test\adapter());
@@ -70,7 +70,7 @@ class parser extends atoum\test
 
 	public function testCheckString()
 	{
-		$this->define->parserException = '\mageekguy\atoum\tests\units\asserters\template\parser\exception';
+		$this->define->parserException = '\atoum\tests\units\asserters\template\parser\exception';
 
 		$parser = new template\parser();
 
@@ -91,8 +91,8 @@ class parser extends atoum\test
 					$parser->checkString('<' . template\parser::defaultNamespace . ':' . $tag . ' id="" />');
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id must not be empty')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -109,8 +109,8 @@ class parser extends atoum\test
 					$parser->checkString($tagWithId . $tagWithId);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id \'' . $id . '\' is already defined in line 1 at offset 1')
 				->hasErrorLine(1)
 				->hasErrorOffset(41)
@@ -123,8 +123,8 @@ class parser extends atoum\test
 					$parser->checkString($tagWithInvalidAttribute);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Attribute \'foo\' is unknown')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -137,8 +137,8 @@ class parser extends atoum\test
 					$parser->checkString($firstTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -153,8 +153,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $firstTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -167,8 +167,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $spaces . $firstTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -182,8 +182,8 @@ class parser extends atoum\test
 					$parser->checkString($firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -191,8 +191,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -200,8 +200,8 @@ class parser extends atoum\test
 					$parser->checkString($eols . $spaces . $firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -210,7 +210,7 @@ class parser extends atoum\test
 
 	public function testCheckFile()
 	{
-		$this->define->parserException = '\mageekguy\atoum\tests\units\asserters\template\parser\exception';
+		$this->define->parserException = '\atoum\tests\units\asserters\template\parser\exception';
 
 		$parser = new template\parser(null, $adapter = new test\adapter());
 
@@ -221,7 +221,7 @@ class parser extends atoum\test
 					$parser->checkFile($path = uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to get contents from file \'' . $path . '\'')
 		;
 
@@ -268,8 +268,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id must not be empty')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -308,8 +308,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Id \'' . $id . '\' is already defined in line 1 at offset 1')
 				->hasErrorLine(1)
 				->hasErrorOffset(41)
@@ -322,8 +322,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Attribute \'foo\' is unknown')
 				->hasErrorLine(1)
 				->hasErrorOffset(1)
@@ -336,8 +336,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -350,8 +350,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -364,8 +364,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $tag . '\' must be closed')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -381,8 +381,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -395,8 +395,8 @@ class parser extends atoum\test
 					$parser->checkFile(uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + 1)
@@ -409,8 +409,8 @@ class parser extends atoum\test
 					$parser->checkFile($eols . $spaces . $firstTag . $secondTag);
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-				->isInstanceOf('mageekguy\atoum\template\parser\exception')
+				->isInstanceOf('atoum\exceptions\runtime')
+				->isInstanceOf('atoum\template\parser\exception')
 				->hasMessage('Tag \'' . $notOpenTag . '\' is not open')
 				->hasErrorLine(strlen($eols) + 1)
 				->hasErrorOffset(strlen($firstTag) + strlen($spaces) + 1)
@@ -422,28 +422,28 @@ class parser extends atoum\test
 		$parser = new template\parser();
 
 		$this->assert
-			->object($root = $parser->parseString(''))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString(''))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->isEmpty()
 		;
 
 		$this->assert
-			->object($root = $parser->parseString($string = uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString($string = uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$this->assert
-			->object($root = $parser->parseString($string = uniqid() . "\n" . uniqid() . "\n"))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString($string = uniqid() . "\n" . uniqid() . "\n"))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' />'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' />'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -452,9 +452,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -463,9 +463,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '" />'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '" />'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -474,9 +474,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '"/>'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '"/>'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -485,9 +485,9 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>'))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString('<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>'))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -496,39 +496,39 @@ class parser extends atoum\test
 		;
 
 		$this->assert
-			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
 		$this->assert
-			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '">' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseString(($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '">' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid())))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(1)->getId())->isEqualTo($id)
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
 		$this->assert
 			->object($root = $parser->parseString(($string = str_repeat("\n", 6)) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>'))
 			->array($root->getChildren())->hasSize(2)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(7)
@@ -547,41 +547,41 @@ class parser extends atoum\test
 					$parser->parseFile($path = uniqid());
 				}
 			)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Unable to get contents from file \'' . $path . '\'')
 		;
 
 		$adapter->file_get_contents = '';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->isEmpty()
 		;
 
 		$adapter->file_get_contents = $string = uniqid();
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$adapter->file_get_contents = $string = uniqid() . "\n" . uniqid() . "\n";
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
 		;
 
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' />';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -592,9 +592,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '/>';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -605,9 +605,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '" />';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -618,9 +618,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '"/>';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->string($root->getChild(0)->getId())->isEqualTo($id)
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -631,9 +631,9 @@ class parser extends atoum\test
 		$adapter->file_get_contents = '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>';
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(1)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(0)->getTag())->isEqualTo($tag)
 			->variable($root->getChild(0)->getId())->isNull()
 			->string($root->getChild(0)->getData())->isEmpty()
@@ -644,32 +644,32 @@ class parser extends atoum\test
 		$adapter->file_get_contents = ($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . '>' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid());
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
 		$adapter->file_get_contents = ($string1 = uniqid()) . '<' . template\parser::defaultNamespace . ':' . ($tag = uniqid()) . ' id="' . ($id = uniqid()) . '">' . ($data = uniqid()) . '</' . template\parser::defaultNamespace . ':' . $tag . '>' . ($string2 = uniqid());
 
 		$this->assert
-			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('mageekguy\atoum\template')
+			->object($root = $parser->parseFile(uniqid()))->isInstanceOf('atoum\template')
 			->array($root->getChildren())->hasSize(3)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string1)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->string($root->getChild(1)->getId())->isEqualTo($id)
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(1)
 			->integer($root->getChild(1)->getOffset())->isEqualTo(strlen($string1) + 1)
-			->object($root->getChild(2))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(2))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(2)->getData())->isEqualTo($string2)
 		;
 
@@ -678,9 +678,9 @@ class parser extends atoum\test
 		$this->assert
 			->object($root = $parser->parseFile(uniqid()))
 			->array($root->getChildren())->hasSize(2)
-			->object($root->getChild(0))->isInstanceOf('mageekguy\atoum\template\data')
+			->object($root->getChild(0))->isInstanceOf('atoum\template\data')
 			->string($root->getChild(0)->getData())->isEqualTo($string)
-			->object($root->getChild(1))->isInstanceOf('mageekguy\atoum\template\tag')
+			->object($root->getChild(1))->isInstanceOf('atoum\template\tag')
 			->variable($root->getChild(1)->getId())->isNull()
 			->string($root->getChild(1)->getData())->isEmpty()
 			->integer($root->getChild(1)->getLine())->isEqualTo(7)

--- a/tests/units/classes/template/tag.php
+++ b/tests/units/classes/template/tag.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\template;
+namespace atoum\tests\units\template;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\template
+	atoum,
+	atoum\template
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -14,7 +14,7 @@ class tag extends atoum\test
 	public function test__construct()
 	{
 		$this->assert
-			->testedClass->isSubClassOf('mageekguy\atoum\template')
+			->testedClass->isSubClassOf('atoum\template')
 		;
 
 		$this->assert
@@ -22,31 +22,31 @@ class tag extends atoum\test
 					$template = new template\tag('');
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Tag must not be an empty string')
 			->exception(function() {
 					$template = new template\tag(uniqid(), null, 0);
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Line must be greater than 0')
 			->exception(function() {
 						$template = new template\tag(uniqid(), null, - rand(1, PHP_INT_MAX));
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Line must be greater than 0')
 			->exception(function() {
 						$template = new template\tag(uniqid(), null, rand(1, PHP_INT_MAX), 0);
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Offset must be greater than 0')
 			->exception(function() {
 					$template = new template\tag(uniqid(), null, rand(1, PHP_INT_MAX), - rand(1, PHP_INT_MAX));
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Offset must be greater than 0')
 		;
 
@@ -78,7 +78,7 @@ class tag extends atoum\test
 						$template->setId('');
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Id must not be empty')
 		;
 
@@ -100,7 +100,7 @@ class tag extends atoum\test
 						$template->setId($id);
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Id \'' . $id . '\' is already defined in line unknown at offset unknown')
 		;
 	}
@@ -136,7 +136,7 @@ class tag extends atoum\test
 						$template->setAttribute($attribute = uniqid(), uniqid());
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Attribute \'' . $attribute . '\' is unknown')
 		;
 	}
@@ -155,7 +155,7 @@ class tag extends atoum\test
 						$template->unsetAttribute($attribute = uniqid());
 					}
 				)
-				->isInstanceOf('mageekguy\atoum\exceptions\logic')
+				->isInstanceOf('atoum\exceptions\logic')
 				->hasMessage('Attribute \'' . $attribute . '\' is unknown')
 		;
 	}

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace mageekguy\atoum
+namespace atoum
 {
 	class emptyTest {}
 	class notEmptyTest {}
 }
 
-namespace mageekguy\atoum\mock\mageekguy\atoum
+namespace atoum\mock\atoum
 {
 	class test {}
 }
 
-namespace mageekguy\atoum\tests\units
+namespace atoum\tests\units
 {
 	use
-		mageekguy\atoum,
-		mageekguy\atoum\mock
+		atoum,
+		atoum\mock
 	;
 
 	require_once __DIR__ . '/../runner.php';
@@ -53,7 +53,7 @@ namespace mageekguy\atoum\tests\units
 	{
 		public function __construct()
 		{
-			$this->setTestedClassName('mageekguy\atoum\test');
+			$this->setTestedClassName('atoum\test');
 
 			parent::__construct();
 		}
@@ -88,10 +88,10 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getScore())->isInstanceOf('mageekguy\atoum\score')
+					->object($test->getScore())->isInstanceOf('atoum\score')
 					->object($test->getLocale())->isEqualTo(new atoum\locale())
 					->object($test->getAdapter())->isEqualTo(new atoum\adapter())
-					->object($test->getPhpMocker())->isInstanceOf('mageekguy\atoum\php\mocker')
+					->object($test->getPhpMocker())->isInstanceOf('atoum\php\mocker')
 					->boolean($test->isIgnored())->isTrue()
 					->boolean($test->debugModeIsEnabled())->isFalse()
 					->array($test->getAllTags())->isEqualTo($tags = array('empty', 'fake', 'dummy'))
@@ -120,9 +120,9 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->assert)->isInstanceOf('mageekguy\atoum\test')
-					->object($test->define)->isInstanceOf('mageekguy\atoum\test\asserter\generator')
-					->object($test->mockGenerator)->isInstanceOf('mageekguy\atoum\mock\generator')
+					->object($test->assert)->isInstanceOf('atoum\test')
+					->object($test->define)->isInstanceOf('atoum\test\asserter\generator')
+					->object($test->mockGenerator)->isInstanceOf('atoum\mock\generator')
 				->if($test->setMockGenerator($mockGenerator = new atoum\test\mock\generator($this)))
 				->then
 					->object($test->mockGenerator)->isIdenticalTo($mockGenerator)
@@ -131,10 +131,10 @@ namespace mageekguy\atoum\tests\units
 					->object($test->assert)->isIdenticalTo($test)
 					->variable($test->exception)->isNull()
 					->exception(function() use ($test, & $property) { $test->{$property = uniqid()}; })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Asserter \'' . $property . '\' does not exist')
 					->exception($test->exception)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Asserter \'' . $property . '\' does not exist')
 			;
 		}
@@ -216,7 +216,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getMockGenerator())->isInstanceOf('mageekguy\atoum\mock\generator')
+					->object($test->getMockGenerator())->isInstanceOf('atoum\mock\generator')
 				->if($test->setMockGenerator($mockGenerator = new atoum\test\mock\generator($this)))
 				->then
 					->object($test->getMockGenerator())->isIdenticalTo($mockGenerator)
@@ -240,7 +240,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getAsserterGenerator())->isInstanceOf('mageekguy\atoum\test\asserter\generator')
+					->object($test->getAsserterGenerator())->isInstanceOf('atoum\test\asserter\generator')
 				->if($test->setAsserterGenerator($asserterGenerator = new atoum\test\asserter\generator($this)))
 				->then
 					->object($test->getAsserterGenerator())->isIdenticalTo($asserterGenerator)
@@ -270,7 +270,7 @@ namespace mageekguy\atoum\tests\units
 					->object($test->setPhpMocker())->isIdenticalTo($test)
 					->object($test->getPhpMocker())
 						->isNotIdenticalTo($phpMocker)
-						->isInstanceOf('mageekguy\atoum\php\mocker')
+						->isInstanceOf('atoum\php\mocker')
 			;
 		}
 
@@ -295,7 +295,7 @@ namespace mageekguy\atoum\tests\units
 				->and($test->getMockController()->getClass = $testClass = 'foo')
 				->then
 					->exception(function() use ($test) { $test->getTestedClassName(); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Test class \'' . $testClass . '\' is not in a namespace which match pattern \'' . $test->getTestNamespace() . '\'')
 				->if($test->getMockController()->getClass = 'tests\units\foo')
 				->then
@@ -332,7 +332,7 @@ namespace mageekguy\atoum\tests\units
 							}
 						)
 						->isInstanceOf('invalidArgumentException')
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test namespace must not be empty')
 			;
 		}
@@ -342,7 +342,7 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+					->object($test->getAdapter())->isInstanceOf('atoum\adapter')
 			;
 		}
 
@@ -392,10 +392,10 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->exception(function() use ($test) { $test->setMaxChildrenNumber(- rand(1, PHP_INT_MAX)); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Maximum number of children must be greater or equal to 1')
 					->exception(function() use ($test) { $test->setMaxChildrenNumber(0); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Maximum number of children must be greater or equal to 1')
 					->object($test->setMaxChildrenNumber($maxChildrenNumber = rand(1, PHP_INT_MAX)))->isIdenticalTo($test)
 					->integer($test->getMaxChildrenNumber())->isEqualTo($maxChildrenNumber)
@@ -549,7 +549,7 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->exception(function() use ($test, & $method) { $test->methodIsIgnored($method = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() does not exist')
 			;
 		}
@@ -572,7 +572,7 @@ namespace mageekguy\atoum\tests\units
 					->object($test->setMethodTags('testMethod1', $tags = array(uniqid(), uniqid())))->isIdenticalTo($test)
 					->array($test->getMethodTags('testMethod1'))->isEqualTo($tags)
 					->exception(function() use ($test, & $method) { $test->setMethodTags($method = uniqid(), array()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() does not exist')
 			;
 		}
@@ -584,7 +584,7 @@ namespace mageekguy\atoum\tests\units
 				->then
 					->array($test->getMethodTags('testMethod1'))->isEqualTo(array('test', 'method', 'one'))
 					->exception(function() use ($test, & $method) { $test->getMethodTags($method = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() does not exist')
 			;
 		}
@@ -617,7 +617,7 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new notEmptyTest())
 				->then
 					->exception(function() use ($test, & $method) { $test->addMandatoryMethodExtension($method = uniqid(), uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() does not exist')
 					->object($test->addMandatoryMethodExtension('testMethod1', $extension = uniqid()))->isIdenticalTo($test)
 					->array($test->getMandatoryMethodExtensions())->isEqualTo(array('testMethod1' => array($extension), 'testMethod2' => array('mbstring', 'socket')))
@@ -657,7 +657,7 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new notEmptyTest())
 				->then
 					->exception(function() use ($test, & $method) { $test->addMethodPhpVersion($method, '6.0'); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() does not exist')
 					->object($test->addMethodPhpVersion('testMethod1', '5.3'))->isIdenticalTo($test)
 					->array($test->getMethodPhpVersions())->isEqualTo(array('testMethod1' => array('5.3' => '>='), 'testMethod2' => array()))
@@ -688,12 +688,12 @@ namespace mageekguy\atoum\tests\units
 					->object($test->run())->isIdenticalTo($test)
 					->mock($test)
 						->call('callObservers')
-							->withArguments(\mageekguy\atoum\test::runStart)->never()
-							->withArguments(\mageekguy\atoum\test::runStop)->never()
-							->withArguments(\mageekguy\atoum\test::beforeSetUp)->never()
-							->withArguments(\mageekguy\atoum\test::afterSetUp)->never()
-							->withArguments(\mageekguy\atoum\test::beforeTestMethod)->never()
-							->withArguments(\mageekguy\atoum\test::afterTestMethod)->never()
+							->withArguments(\atoum\test::runStart)->never()
+							->withArguments(\atoum\test::runStop)->never()
+							->withArguments(\atoum\test::beforeSetUp)->never()
+							->withArguments(\atoum\test::afterSetUp)->never()
+							->withArguments(\atoum\test::beforeTestMethod)->never()
+							->withArguments(\atoum\test::afterTestMethod)->never()
 			;
 		}
 
@@ -702,16 +702,16 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new foo())
 				->then
-					->string($test->getTestedClassName())->isEqualTo('mageekguy\atoum\test')
+					->string($test->getTestedClassName())->isEqualTo('atoum\test')
 					->exception(function() use ($test) { $test->setTestedClassName(uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Tested class name is already defined')
 				->if($test = new self())
 				->then
 					->object($test->setTestedClassName($class = uniqid()))->isIdenticalTo($test)
 					->string($test->getTestedClassName())->isEqualTo($class)
 					->exception(function() use ($test) { $test->setTestedClassName(uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Tested class name is already defined')
 			;
 		}
@@ -786,12 +786,12 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->exception(function() use ($test, & $method) { $test->setDataProvider($method = uniqid(), uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method ' . get_class($test) . '::' . $method . '() does not exist')
 				->if($test = new notEmptyTest())
 				->then
 					->exception(function() use ($test, & $dataProvider) { $test->setDataProvider('testMethod1', $dataProvider = uniqid()); })
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Data provider ' . get_class($test) . '::' . $dataProvider . '() is unknown')
 					->object($test->setDataProvider('testMethod1', 'aDataProvider'))->isIdenticalTo($test)
 					->array($test->getDataProviders())->isEqualTo(array('testMethod1' => 'aDataProvider'))
@@ -890,7 +890,7 @@ namespace mageekguy\atoum\tests\units
 
 					return $reflection;
 				})
-				->and($score = new \mock\mageekguy\atoum\test\score())
+				->and($score = new \mock\atoum\test\score())
 				->and($test = new emptyTest(null, null, null, null, $factory))
 				->and($test->setAdapter($adapter))
 				->and($test->setScore($score))
@@ -907,7 +907,7 @@ namespace mageekguy\atoum\tests\units
 		public function testGetTestedClassNameFromTestClass()
 		{
 			$this
-				->string(atoum\test::getTestedClassNameFromTestClass(__CLASS__))->isEqualTo('mageekguy\atoum\test')
+				->string(atoum\test::getTestedClassNameFromTestClass(__CLASS__))->isEqualTo('atoum\test')
 				->string(atoum\test::getTestedClassNameFromTestClass('foo\bar\tests\units\testedClass'))->isEqualTo('foo\bar\testedClass')
 				->if(atoum\test::setNamespace('test\unit'))
 				->then
@@ -922,7 +922,7 @@ namespace mageekguy\atoum\tests\units
 				->then
 					->string(atoum\test::getTestedClassNameFromTestClass('foo\bar\test\unit\testedClass'))->isEqualTo('foo\bar\testedClass')
 					->exception(function() { atoum\test::getTestedClassNameFromTestClass('foo\bar\aaa\bbb\testedClass'); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Test class \'foo\bar\aaa\bbb\testedClass\' is not in a namespace which contains \'' . atoum\test::getNamespace() . '\'')
 				->if(atoum\test::setNamespace('#(?:^|\\\)xxxs?\\\yyys?\\\#i'))
 				->then
@@ -931,7 +931,7 @@ namespace mageekguy\atoum\tests\units
 					->string(atoum\test::getTestedClassNameFromTestClass('foo\bar\xxxs\yyys\testedClass'))->isEqualTo('foo\bar\testedClass')
 					->string(atoum\test::getTestedClassNameFromTestClass('foo\bar\xxx\yyys\testedClass'))->isEqualTo('foo\bar\testedClass')
 					->exception(function() { atoum\test::getTestedClassNameFromTestClass('foo\bar\aaa\bbb\testedClass'); })
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+						->isInstanceOf('atoum\exceptions\runtime')
 						->hasMessage('Test class \'foo\bar\aaa\bbb\testedClass\' is not in a namespace which match pattern \'' . atoum\test::getNamespace() . '\'')
 					->string(atoum\test::getTestedClassNameFromTestClass('foo\bar\aaa\bbb\testedClass', '#(?:^|\\\)aaas?\\\bbbs?\\\#i'))->isEqualTo('foo\bar\testedClass')
 			;

--- a/tests/units/classes/test/adapter.php
+++ b/tests/units/classes/test/adapter.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test;
+namespace atoum\tests\units\test;
 
 use
-	mageekguy\atoum\test,
-	mageekguy\atoum\test\adapter as testedClass
+	atoum\test,
+	atoum\test\adapter as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -13,7 +13,7 @@ class adapter extends test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\adapter');
+		$this->testedClass->extends('atoum\adapter');
 	}
 
 	public function test__construct()
@@ -35,14 +35,14 @@ class adapter extends test
 				->object($adapter->md5->getClosure())->isIdenticalTo($closure)
 			->if($adapter->md5 = $return = uniqid())
 			->then
-				->object($adapter->md5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
-				->object($adapter->MD5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($adapter->md5)->isInstanceOf('atoum\test\adapter\invoker')
+				->object($adapter->MD5)->isInstanceOf('atoum\test\adapter\invoker')
 				->string($adapter->invoke('md5'))->isEqualTo($return)
 				->string($adapter->invoke('MD5'))->isEqualTo($return)
 			->if($adapter->MD5 = $return = uniqid())
 			->then
-				->object($adapter->md5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
-				->object($adapter->MD5)->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->object($adapter->md5)->isInstanceOf('atoum\test\adapter\invoker')
+				->object($adapter->MD5)->isInstanceOf('atoum\test\adapter\invoker')
 				->string($adapter->invoke('md5'))->isEqualTo($return)
 				->string($adapter->invoke('MD5'))->isEqualTo($return)
 		;
@@ -148,13 +148,13 @@ class adapter extends test
 							$adapter->require(uniqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Function \'require()\' is not invokable by an adapter')
 				->exception(function() use ($adapter) {
 							$adapter->REQUIRE(uNiqid());
 						}
 					)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Function \'REQUIRE()\' is not invokable by an adapter')
 			->if($adapter->md5 = 0)
 			->and($adapter->md5[1] = 1)

--- a/tests/units/classes/test/adapter/invoker.php
+++ b/tests/units/classes/test/adapter/invoker.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\adapter;
+namespace atoum\tests\units\test\adapter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\adapter
+	atoum,
+	atoum\test\adapter
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -39,7 +39,7 @@ class invoker extends atoum\test
 						$invoker->{uniqid()} = uniqid();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 		;
 	}
 
@@ -102,7 +102,7 @@ class invoker extends atoum\test
 						$invoker->setClosure(function() {}, - rand(1, PHP_INT_MAX));
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->object($invoker->setClosure($value = function() {}))->isIdenticalTo($invoker)
 				->boolean($invoker->isEmpty())->isFalse()
@@ -125,7 +125,7 @@ class invoker extends atoum\test
 						$invoker->getClosure(- rand(1, PHP_INT_MAX));
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->variable($invoker->getClosure(rand(0, PHP_INT_MAX)))->isNull()
 			->if($invoker->setClosure($value = function() {}, 0))
@@ -156,7 +156,7 @@ class invoker extends atoum\test
 						$invoker->closureIsSetForCall(- rand(1, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->boolean($invoker->closureIsSetForCall(rand(0, PHP_INT_MAX)))->isFalse()
 			->if($invoker->setClosure(function() {}, 0))
@@ -184,13 +184,13 @@ class invoker extends atoum\test
 						$invoker->unsetClosure(- rand(1, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->exception(function() use ($invoker, & $call) {
 						$invoker->unsetClosure($call = rand(0, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('There is no closure defined for call ' . $call)
 			->if($invoker->setClosure(function() {}))
 			->then
@@ -209,7 +209,7 @@ class invoker extends atoum\test
 						$invoker->offsetSet(- rand(1, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->object($invoker->offsetSet(1, $value = function() {}))->isIdenticalTo($invoker)
 				->boolean($invoker->isEmpty())->isFalse()
@@ -228,7 +228,7 @@ class invoker extends atoum\test
 						$invoker->offsetGet(- rand(1, PHP_INT_MAX));
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->variable($invoker->getClosure(rand(0, PHP_INT_MAX)))->isNull()
 			->if($invoker->setClosure($value = function() {}, 0))
@@ -249,7 +249,7 @@ class invoker extends atoum\test
 						$invoker->offsetExists(- rand(1, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->boolean($invoker->offsetExists(rand(0, PHP_INT_MAX)))->isFalse()
 			->if($invoker->setClosure(function() {}, 0))
@@ -280,13 +280,13 @@ class invoker extends atoum\test
 						$invoker->offsetUnset(- rand(1, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('Call number must be greater than or equal to zero')
 				->exception(function() use ($invoker, & $call) {
 						$invoker->offsetUnset($call = rand(0, PHP_INT_MAX), function() {});
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('There is no closure defined for call ' . $call)
 			->if($invoker->setClosure(function() {}))
 			->then
@@ -305,7 +305,7 @@ class invoker extends atoum\test
 						$invoker->invoke();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->isInstanceOf('atoum\exceptions\logic\invalidArgument')
 					->hasMessage('There is no closure defined for call 0')
 			->if($invoker->setClosure(function($string) { return md5($string); }))
 			->and($invoker->setClosure(function() use (& $md5) { return $md5 = uniqid(); }, 1))

--- a/tests/units/classes/test/adapter/storage.php
+++ b/tests/units/classes/test/adapter/storage.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\adapter;
+namespace atoum\tests\units\test\adapter;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\adapter\storage as testedClass
+	atoum,
+	atoum\test\adapter\storage as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/test/assertion/manager.php
+++ b/tests/units/classes/test/assertion/manager.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\assertion;
+namespace atoum\tests\units\test\assertion;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test,
-	mageekguy\atoum\test\assertion\manager as testedClass
+	atoum,
+	atoum\test,
+	atoum\test\assertion\manager as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -31,7 +31,7 @@ class manager extends atoum\test
 						$assertionManager->{$event = uniqid()};
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\assertion\manager\exception')
+					->isInstanceOf('atoum\test\assertion\manager\exception')
 					->hasMessage('There is no handler defined for event \'' . $event . '\'')
 			->if($assertionManager->setDefaultHandler(function() use (& $defaultReturn) { return ($defaultReturn = uniqid()); }))
 			->then
@@ -63,7 +63,7 @@ class manager extends atoum\test
 						$assertionManager->{$event = uniqid()}();
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\assertion\manager\exception')
+					->isInstanceOf('atoum\test\assertion\manager\exception')
 					->hasMessage('There is no handler defined for event \'' . $event . '\'')
 			->if($assertionManager->setDefaultHandler(function($event, $defaultArg) { return $defaultArg; }))
 			->then
@@ -147,7 +147,7 @@ class manager extends atoum\test
 						$assertionManager->invoke($event = uniqid());
 					}
 				)
-					->isInstanceOf('mageekguy\atoum\test\assertion\manager\exception')
+					->isInstanceOf('atoum\test\assertion\manager\exception')
 					->hasMessage('There is no handler defined for event \'' . $event . '\'')
 			->if($assertionManager->setDefaultHandler(function($event, $arg) { return $arg; }))
 			->then

--- a/tests/units/classes/test/assertion/manager/exception.php
+++ b/tests/units/classes/test/assertion/manager/exception.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\assertion\manager;
+namespace atoum\tests\units\test\assertion\manager;
 
 require_once __DIR__ . '/../../../../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubClassOf('mageekguy\atoum\exceptions\runtime');
+		$this->testedClass->isSubClassOf('atoum\exceptions\runtime');
 	}
 }

--- a/tests/units/classes/test/engine.php
+++ b/tests/units/classes/test/engine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test;
+namespace atoum\tests\units\test;
 
 require_once __DIR__ . '/../../runner.php';
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 class engine extends atoum\test

--- a/tests/units/classes/test/engines/concurrent.php
+++ b/tests/units/classes/test/engines/concurrent.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\engines;
+namespace atoum\tests\units\test\engines;
 
 require_once __DIR__ . '/../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\engines\concurrent as testedClass
+	atoum,
+	atoum\test\engines\concurrent as testedClass
 ;
 
 class concurrent extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\test\engine');
+		$this->testedClass->extends('atoum\test\engine');
 	}
 
 	public function test__construct()
@@ -22,7 +22,7 @@ class concurrent extends atoum\test
 			->if($engine = new testedClass())
 			->then
 				->object($defaultScoreFactory = $engine->getScoreFactory())->isInstanceOf('closure')
-				->object($defaultScoreFactory())->isInstanceOf('mageekguy\atoum\score')
+				->object($defaultScoreFactory())->isInstanceOf('atoum\score')
 				->object($engine->getPhp())->isEqualTo(new atoum\php())
 		;
 	}
@@ -54,9 +54,9 @@ class concurrent extends atoum\test
 	{
 		$this
 			->if($engine = new testedClass())
-			->and($engine->setPhp($php = new \mock\mageekguy\atoum\php()))
+			->and($engine->setPhp($php = new \mock\atoum\php()))
 			->then
-				->object($engine->run($test = new \mock\mageekguy\atoum\test()))->isIdenticalTo($engine)
+				->object($engine->run($test = new \mock\atoum\test()))->isIdenticalTo($engine)
 			->if($test->getMockController()->getCurrentMethod = $method = uniqid())
 			->and($test->getMockController()->getPath = $testPath = uniqid())
 			->and($test->getMockController()->getPhpPath = $phpPath = uniqid())
@@ -83,7 +83,7 @@ class concurrent extends atoum\test
 						'$test->setPhpPath(\'' . $phpPath . '\');' .
 						'$test->disableCodeCoverage();' .
 						'ob_end_clean();' .
-						'mageekguy\atoum\scripts\runner::disableAutorun();' .
+						'atoum\scripts\runner::disableAutorun();' .
 						'echo serialize($test->runTestMethod(\'' . $method . '\')->getScore());'
 					)->twice()
 					->call('__set')->withArguments('XDEBUG_CONFIG', $xdebugConfig)->twice()
@@ -94,12 +94,12 @@ class concurrent extends atoum\test
 	{
 		$this
 			->if($engine = new testedClass())
-			->and($engine->setPhp($php = new \mock\mageekguy\atoum\php()))
+			->and($engine->setPhp($php = new \mock\atoum\php()))
 			->and($this->calling($php)->run = $php)
 			->and($this->calling($php)->isRunning = false)
 			->then
 				->variable($engine->getScore())->isNull()
-			->if($engine->run($test = new \mock\mageekguy\atoum\test()))
+			->if($engine->run($test = new \mock\atoum\test()))
 			->and($this->calling($php)->isRunning = true)
 			->then
 				->variable($engine->getScore())->isNull()
@@ -113,7 +113,7 @@ class concurrent extends atoum\test
 			->and($this->calling($php)->getExitCode = $exitCode = uniqid())
 			->and($engine->run($test))
 			->then
-				->object($score = $engine->getScore())->isInstanceOf('mageekguy\atoum\score')
+				->object($score = $engine->getScore())->isInstanceOf('atoum\score')
 				->array($score->getUncompletedMethods())->isEqualTo(array(array('file' => $testPath, 'class' => get_class($test), 'method' => $method, 'exitCode' => $exitCode, 'output' => $output)))
 			->if($this->calling($php)->getStdOut = serialize($score))
 			->and($engine->run($test))

--- a/tests/units/classes/test/engines/inline.php
+++ b/tests/units/classes/test/engines/inline.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\engines;
+namespace atoum\tests\units\test\engines;
 
 require_once __DIR__ . '/../../../runner.php';
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\engines
+	atoum,
+	atoum\test\engines
 ;
 
 class inline extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\test\engine');
+		$this->testedClass->extends('atoum\test\engine');
 	}
 
 	public function testIsAsynchronous()
@@ -30,7 +30,7 @@ class inline extends atoum\test
 		$this
 			->if($engine = new engines\inline())
 			->then
-				->object($engine->run($test = new \mock\mageekguy\atoum\test()))->isIdenticalTo($engine)
+				->object($engine->run($test = new \mock\atoum\test()))->isIdenticalTo($engine)
 			->if($test->getMockController()->getCurrentMethod = $method = uniqid())
 			->and($test->getMockController()->runTestMethod = $test)
 			->then
@@ -48,13 +48,13 @@ class inline extends atoum\test
 		$this
 			->if($engine = new engines\inline())
 			->then
-				->object($engine->getScore())->isInstanceof('mageekguy\atoum\score')
-			->if($test = new \mock\mageekguy\atoum\test())
+				->object($engine->getScore())->isInstanceof('atoum\score')
+			->if($test = new \mock\atoum\test())
 			->and($test->getMockController()->getCurrentMethod = $method = uniqid())
 			->and($test->getMockController()->runTestMethod = $test)
 			->and($engine->run($test))
 			->then
-				->object($engine->getScore())->isInstanceOf('mageekguy\atoum\test\score')
+				->object($engine->getScore())->isInstanceOf('atoum\test\score')
 		;
 	}
 }

--- a/tests/units/classes/test/generator.php
+++ b/tests/units/classes/test/generator.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test;
+namespace atoum\tests\units\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\fs\path,
-	mageekguy\atoum\template,
-	mageekguy\atoum\test\generator as testedClass
+	atoum,
+	atoum\fs\path,
+	atoum\template,
+	atoum\test\generator as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -178,35 +178,35 @@ class generator extends atoum\test
 		$this
 			->if($generator = new testedClass())
 			->and($generator->setAdapter($adapter = new atoum\test\adapter()))
-			->and($generator->setPathFactory($pathFactory = new \mock\mageekguy\atoum\fs\path\factory()))
-			->and($generator->setTemplateParser($templateParser = new \mock\mageekguy\atoum\template\parser()))
+			->and($generator->setPathFactory($pathFactory = new \mock\atoum\fs\path\factory()))
+			->and($generator->setTemplateParser($templateParser = new \mock\atoum\template\parser()))
 			->then
 				->exception(function() use ($generator) { $generator->generate(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\test\generator\exception')
+					->isInstanceOf('atoum\test\generator\exception')
 					->hasMessage('Tested classes directory is undefined')
 			->if($generator->setTestedClassesDirectory($classesDirectory = uniqid()))
 			->then
 				->exception(function() use ($generator) { $generator->generate(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\test\generator\exception')
+					->isInstanceOf('atoum\test\generator\exception')
 					->hasMessage('Tests directory is undefined')
 			->if($generator->setTestClassesDirectory($testsDirectory = '/a/b/c'))
 			->then
 				->exception(function() use ($generator) { $generator->generate(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\test\generator\exception')
+					->isInstanceOf('atoum\test\generator\exception')
 					->hasMessage('Tested class namespace is undefined')
 			->if($generator->setTestedClassNamespace($testedClassNamespace = uniqid()))
 			->then
 				->exception(function() use ($generator) { $generator->generate(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\test\generator\exception')
+					->isInstanceOf('atoum\test\generator\exception')
 					->hasMessage('Test class namespace is undefined')
 			->if($generator->setTestClassNamespace($testClassNamespace = uniqid()))
-			->and($testClassesDirectoryPath = new \mock\mageekguy\atoum\fs\path('/a/b/c'))
+			->and($testClassesDirectoryPath = new \mock\atoum\fs\path('/a/b/c'))
 			->and($this->calling($testClassesDirectoryPath)->exists = true)
 			->and($this->calling($testClassesDirectoryPath)->getRealPath = $testClassesDirectoryPath)
-			->and($testedClassPath = new \mock\mageekguy\atoum\fs\path('/x/y/z/f.php'))
+			->and($testedClassPath = new \mock\atoum\fs\path('/x/y/z/f.php'))
 			->and($this->calling($testedClassPath)->putContents = $testedClassPath)
-			->and($testClassPath = new \mock\mageekguy\atoum\fs\path('/a/b/c/d/e/f.php'))
-			->and($this->calling($testClassPath)->getRealParentDirectoryPath = new \mock\mageekguy\atoum\fs\path('/a/b/c/d/e'))
+			->and($testClassPath = new \mock\atoum\fs\path('/a/b/c/d/e/f.php'))
+			->and($this->calling($testClassPath)->getRealParentDirectoryPath = new \mock\atoum\fs\path('/a/b/c/d/e'))
 			->and($this->calling($testClassPath)->getRealPath = $testClassPath)
 			->and($this->calling($testClassPath)->putContents = $testClassPath)
 			->and($this->calling($pathFactory)->build = function($path) use ($testClassesDirectoryPath, $testClassPath, $testedClassPath) {

--- a/tests/units/classes/test/generator/exception.php
+++ b/tests/units/classes/test/generator/exception.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test\generator;
+namespace atoum\tests\units\test\generator;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -12,6 +12,6 @@ class exception extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\exceptions\runtime');
+		$this->testedClass->extends('atoum\exceptions\runtime');
 	}
 }

--- a/tests/units/classes/test/score.php
+++ b/tests/units/classes/test/score.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\test;
+namespace atoum\tests\units\test;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\test\score as testedClass
+	atoum,
+	atoum\test\score as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -13,7 +13,7 @@ class score extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->isSubClassOf('mageekguy\atoum\score');
+		$this->testedClass->isSubClassOf('atoum\score');
 	}
 
 	public function test__construct()

--- a/tests/units/classes/tools/diff.php
+++ b/tests/units/classes/tools/diff.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\tools;
+namespace atoum\tests\units\tools;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\tools
+	atoum,
+	atoum\tools
 ;
 
 require_once __DIR__ . '/../../runner.php';

--- a/tests/units/classes/tools/diffs/variable.php
+++ b/tests/units/classes/tools/diffs/variable.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\tools\diffs;
+namespace atoum\tests\units\tools\diffs;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\tools
+	atoum,
+	atoum\tools
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -55,7 +55,7 @@ class variable extends atoum\test
 
 		$this->assert
 			->exception($exception)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Expected is undefined')
 		;
 
@@ -69,7 +69,7 @@ class variable extends atoum\test
 
 		$this->assert
 			->exception($exception)
-				->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+				->isInstanceOf('atoum\exceptions\runtime')
 				->hasMessage('Actual is undefined')
 		;
 

--- a/tests/units/classes/writer.php
+++ b/tests/units/classes/writer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum,
-	mock\mageekguy\atoum\writer as testedClass
+	atoum,
+	mock\atoum\writer as testedClass
 ;
 
 require_once __DIR__ . '/../runner.php';
@@ -49,11 +49,11 @@ class writer extends atoum\test
 		$this
 			->if($writer = new testedClass())
 			->then
-				->object($writer->addDecorator($decorator1 = new \mock\mageekguy\atoum\writer\decorator()))->isIdenticalTo($writer)
+				->object($writer->addDecorator($decorator1 = new \mock\atoum\writer\decorator()))->isIdenticalTo($writer)
 				->array($writer->getDecorators())->isEqualTo(array($decorator1))
 				->object($writer->addDecorator($decorator1))->isIdenticalTo($writer)
 				->array($writer->getDecorators())->isEqualTo(array($decorator1, $decorator1))
-				->object($writer->addDecorator($decorator2 = new \mock\mageekguy\atoum\writer\decorator()))->isIdenticalTo($writer)
+				->object($writer->addDecorator($decorator2 = new \mock\atoum\writer\decorator()))->isIdenticalTo($writer)
 				->array($writer->getDecorators())->isEqualTo(array($decorator1, $decorator1, $decorator2))
 		;
 	}
@@ -61,16 +61,16 @@ class writer extends atoum\test
 	public function testWrite()
 	{
 		$this
-			->if($writer = new \mock\mageekguy\atoum\writer())
+			->if($writer = new \mock\atoum\writer())
 			->then
 				->object($writer->write($message = uniqid()))->isIdenticalTo($writer)
 				->mock($writer)->call('doWrite')->withArguments($message)->once()
-			->if($writer->addDecorator($decorator1 = new \mock\mageekguy\atoum\writer\decorator()))
+			->if($writer->addDecorator($decorator1 = new \mock\atoum\writer\decorator()))
 			->and($this->calling($decorator1)->decorate = $decoratedMessage1 = uniqid())
 			->then
 				->object($writer->write($message = uniqid()))->isIdenticalTo($writer)
 				->mock($writer)->call('doWrite')->withArguments($decoratedMessage1)->once()
-			->if($writer->addDecorator($decorator2 = new \mock\mageekguy\atoum\writer\decorator()))
+			->if($writer->addDecorator($decorator2 = new \mock\atoum\writer\decorator()))
 			->and($this->calling($decorator2)->decorate = $decoratedMessage2 = uniqid())
 			->then
 				->object($writer->write($message = uniqid()))->isIdenticalTo($writer)

--- a/tests/units/classes/writers/file.php
+++ b/tests/units/classes/writers/file.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers;
+namespace atoum\tests\units\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers\file as testedClass
+	atoum,
+	atoum\writers\file as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,8 +15,8 @@ class file extends atoum\test
 	{
 		$this
 			->testedClass
-				->implements('mageekguy\atoum\report\writers\realtime')
-				->implements('mageekguy\atoum\report\writers\asynchronous')
+				->implements('atoum\report\writers\realtime')
+				->implements('atoum\report\writers\asynchronous')
 		;
 	}
 
@@ -33,7 +33,7 @@ class file extends atoum\test
 			->if($file = new testedClass())
 			->then
 				->string($file->getFilename())->isEqualTo('atoum.log')
-				->object($file->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($file->getAdapter())->isInstanceOf('atoum\adapter')
 			->if($file = new testedClass(null, $adapter = new atoum\test\adapter()))
 			->then
 				->object($file->getAdapter())->isIdenticalTo($adapter)
@@ -42,7 +42,7 @@ class file extends atoum\test
 			->if($file = new testedClass($filename = uniqid()))
 			->then
 				->string($file->getFilename())->isEqualTo($filename)
-				->object($file->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($file->getAdapter())->isInstanceOf('atoum\adapter')
 		;
 	}
 
@@ -106,7 +106,7 @@ class file extends atoum\test
 			->and($adapter->resetCalls())
 			->then
 				->exception(function() use ($file) { $file->write(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to open file \'' . $file->getFilename() . '\'')
 				->error->notExists()
 			->if($adapter->fopen = $resource = uniqid())
@@ -114,7 +114,7 @@ class file extends atoum\test
 			->and($adapter->resetCalls())
 			->then
 				->exception(function() use ($file) { $file->write(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to lock file \'' . $file->getFilename() . '\'')
 			->if($file = new testedClass(null, $adapter))
 			->and($adapter->flock = true)
@@ -125,7 +125,7 @@ class file extends atoum\test
 			->and($adapter->resetCalls())
 			->then
 				->exception(function() use ($file) { $file->write(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to write in file \'' . $file->getFilename() . '\'')
 				->adapter($adapter)
 					->call('fopen')->withArguments($file->getFilename(), 'c')->once()
@@ -158,7 +158,7 @@ class file extends atoum\test
 			->and($adapter->resetCalls())
 			->then
 				->exception(function() use ($file) { $file->clear(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to open file \'' . $file->getFilename() . '\'')
 			->if($adapter->fopen = $resource = uniqid())
 			->and($adapter->flock = true)
@@ -167,7 +167,7 @@ class file extends atoum\test
 			->and($adapter->resetCalls())
 			->then
 				->exception(function() use ($file) { $file->clear(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->isInstanceOf('atoum\exceptions\runtime')
 					->hasMessage('Unable to truncate file \'' . $file->getFilename() . '\'')
 				->adapter($adapter)
 					->call('fopen')->withArguments($file->getFilename(), 'c')->once()

--- a/tests/units/classes/writers/http.php
+++ b/tests/units/classes/writers/http.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers;
+namespace atoum\tests\units\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers\http as testedClass
+	atoum,
+	atoum\writers\http as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -15,8 +15,8 @@ class http extends atoum\test
 	{
 		$this
 			->testedClass
-				->isSubclassOf('\\mageekguy\\atoum\\writer')
-				->implements('mageekguy\atoum\report\writers\asynchronous')
+				->isSubclassOf('\\atoum\\writer')
+				->implements('atoum\report\writers\asynchronous')
 		;
 	}
 
@@ -44,7 +44,7 @@ class http extends atoum\test
 						$writer->write(uniqid());
 					}
 				)
-					->isInstanceOf('\\mageekguy\\atoum\\exceptions\\runtime')
+					->isInstanceOf('\\atoum\\exceptions\\runtime')
 					->hasMessage('No URL set for HTTP writer')
 			->if($writer->setUrl($url = uniqid()))
 			->then
@@ -97,8 +97,8 @@ class http extends atoum\test
 		$this
 			->if($adapter = new atoum\test\adapter())
 			->and($adapter->file_get_contents = '')
-			->and($report = new \mock\mageekguy\atoum\reports\asynchronous())
-			->and($writer = new \mock\mageekguy\atoum\writers\http($adapter))
+			->and($report = new \mock\atoum\reports\asynchronous())
+			->and($writer = new \mock\atoum\writers\http($adapter))
 			->and($writer->setUrl(uniqid()))
 			->then
 				->object($writer->writeAsynchronousReport($report))->isIdenticalTo($writer)

--- a/tests/units/classes/writers/mail.php
+++ b/tests/units/classes/writers/mail.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers;
+namespace atoum\tests\units\writers;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\mock,
-	mageekguy\atoum\writers,
-	mageekguy\atoum\mailers
+	atoum,
+	atoum\mock,
+	atoum\writers,
+	atoum\mailers
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -18,9 +18,9 @@ class mail extends atoum\test
 		$this
 			->if($writer = new writers\mail())
 			->then
-				->object($writer->getMailer())->isInstanceOf('mageekguy\atoum\mailers\mail')
-				->object($writer->getLocale())->isInstanceOf('mageekguy\atoum\locale')
-				->object($writer->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($writer->getMailer())->isInstanceOf('atoum\mailers\mail')
+				->object($writer->getLocale())->isInstanceOf('atoum\locale')
+				->object($writer->getAdapter())->isInstanceOf('atoum\adapter')
 			->if($writer = new writers\mail($mailer = new atoum\mailers\mail(), $locale = new atoum\locale(), $adapter = new atoum\adapter()))
 			->then
 				->object($writer->getMailer())->isIdenticalTo($mailer)
@@ -33,8 +33,8 @@ class mail extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\writer')
-				->implements('mageekguy\atoum\report\writers\asynchronous')
+				->extends('atoum\writer')
+				->implements('atoum\report\writers\asynchronous')
 		;
 	}
 
@@ -61,7 +61,7 @@ class mail extends atoum\test
 	public function testWrite()
 	{
 		$this
-			->if($mailer = new \mock\mageekguy\atoum\mailer())
+			->if($mailer = new \mock\atoum\mailer())
 			->and($mailer->getMockController()->send = $mailer)
 			->and($writer = new writers\mail())
 			->and($writer->setMailer($mailer))
@@ -75,11 +75,11 @@ class mail extends atoum\test
 	{
 		$this
 			->if($mailer = new atoum\mailers\mail())
-			->and($writer = new \mock\mageekguy\atoum\writers\mail($mailer, $locale = new \mock\mageekguy\atoum\locale(), $adapter = new atoum\test\adapter()))
+			->and($writer = new \mock\atoum\writers\mail($mailer, $locale = new \mock\atoum\locale(), $adapter = new atoum\test\adapter()))
 			->and($writer->getMockController()->write = $writer)
 			->and($adapter->date = function($arg) { return $arg; })
 			->then
-				->object($writer->writeAsynchronousReport($report = new \mock\mageekguy\atoum\reports\asynchronous()))->isIdenticalTo($writer)
+				->object($writer->writeAsynchronousReport($report = new \mock\atoum\reports\asynchronous()))->isIdenticalTo($writer)
 				->mock($writer)->call('write')->withArguments((string) $report)->once()
 				->string($mailer->getSubject())->isEqualTo('Unit tests report, the Y-m-d at H:i:s')
 				->mock($locale)
@@ -87,7 +87,7 @@ class mail extends atoum\test
 					->call('_')->withArguments('Y-m-d')->once()
 					->call('_')->withArguments('H:i:s')->once()
 			->if($mailer = new atoum\mailers\mail())
-			->and($writer = new \mock\mageekguy\atoum\writers\mail($mailer, $locale = new \mock\mageekguy\atoum\locale(), $adapter = new atoum\test\adapter()))
+			->and($writer = new \mock\atoum\writers\mail($mailer, $locale = new \mock\atoum\locale(), $adapter = new atoum\test\adapter()))
 			->and($writer->getMockController()->write = $writer)
 			->then
 				->object($writer->writeAsynchronousReport($report->setTitle($title = uniqid())))->isIdenticalTo($writer)

--- a/tests/units/classes/writers/std.php
+++ b/tests/units/classes/writers/std.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers;
+namespace atoum\tests\units\writers;
 
 use
-	mageekguy\atoum,
-	mock\mageekguy\atoum\writers\std as testedClass
+	atoum,
+	mock\atoum\writers\std as testedClass
 ;
 
 require __DIR__ . '/../../runner.php';
@@ -13,7 +13,7 @@ class std extends atoum\test
 {
 	public function testClass()
 	{
-		$this->testedClass->extends('mageekguy\atoum\writer');
+		$this->testedClass->extends('atoum\writer');
 	}
 
 	public function test__construct()
@@ -73,7 +73,7 @@ class std extends atoum\test
 	public function testClear()
 	{
 		$this
-			->if($std = new testedClass($cli = new \mock\mageekguy\atoum\cli(), $adapter = new atoum\test\adapter()))
+			->if($std = new testedClass($cli = new \mock\atoum\cli(), $adapter = new atoum\test\adapter()))
 			->and($adapter->fwrite = function() {})
 			->and($this->calling($cli)->isTerminal = true)
 			->and($this->calling($std)->init = $std)

--- a/tests/units/classes/writers/std/err.php
+++ b/tests/units/classes/writers/std/err.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers\std;
+namespace atoum\tests\units\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers\std\err as testedClass
+	atoum,
+	atoum\writers\std\err as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,9 +15,9 @@ class err extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\writers\std')
-				->implements('mageekguy\atoum\report\writers\realtime')
-				->implements('mageekguy\atoum\report\writers\asynchronous')
+				->extends('atoum\writers\std')
+				->implements('atoum\report\writers\realtime')
+				->implements('atoum\report\writers\asynchronous')
 		;
 	}
 

--- a/tests/units/classes/writers/std/out.php
+++ b/tests/units/classes/writers/std/out.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace mageekguy\atoum\tests\units\writers\std;
+namespace atoum\tests\units\writers\std;
 
 use
-	mageekguy\atoum,
-	mageekguy\atoum\writers\std\out as testedClass
+	atoum,
+	atoum\writers\std\out as testedClass
 ;
 
 require_once __DIR__ . '/../../../runner.php';
@@ -15,9 +15,9 @@ class out extends atoum\test
 	{
 		$this
 			->testedClass
-				->extends('mageekguy\atoum\writers\std')
-				->implements('mageekguy\atoum\report\writers\realtime')
-				->implements('mageekguy\atoum\report\writers\asynchronous')
+				->extends('atoum\writers\std')
+				->implements('atoum\report\writers\realtime')
+				->implements('atoum\report\writers\asynchronous')
 		;
 	}
 

--- a/tests/units/resources/phing/AtoumTask.php
+++ b/tests/units/resources/phing/AtoumTask.php
@@ -16,7 +16,7 @@ namespace tests\units
 
 	require_once __DIR__ . '/../../runner.php';
 
-	define('mageekguy\atoum\phing\task\path', atoum\mock\streams\fs\file::get());
+	define('atoum\phing\task\path', atoum\mock\streams\fs\file::get());
 
 	require_once __DIR__ . '/../../../../resources/phing/AtoumTask.php';
 
@@ -27,7 +27,7 @@ namespace tests\units
 			$this
 				->given($task = new testedClass())
 				->then
-					->object($task->getRunner())->isInstanceOf('mageekguy\atoum\runner')
+					->object($task->getRunner())->isInstanceOf('atoum\runner')
 					->variable($task->getBootstrap())->isNull()
 					->boolean($task->getCodeCoverage())->isFalse()
 					->variable($task->getAtoumPharPath())->isNull()
@@ -73,7 +73,7 @@ namespace tests\units
 					->object($task->getRunner())->isIdenticalTo($runner)
 					->object($task->setRunner())->isIdenticalTo($task)
 					->object($task->getRunner())
-						->isInstanceOf('mageekguy\atoum\runner')
+						->isInstanceOf('atoum\runner')
 						->isNotIdenticalTo($runner)
 			;
 		}
@@ -102,7 +102,7 @@ namespace tests\units
 		{
 			$this
 				->mockGenerator->shuntParentClassCalls()
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($this->calling($runner)->run = new atoum\score())
 				->and($task = new testedClass($runner))
 				->then
@@ -148,7 +148,7 @@ namespace tests\units
 					->object($task->execute())->isIdenticalTo($task)
 					->mock($runner)
 						->call('addReport')->twice()
-				->if($score = new \mock\mageekguy\atoum\score())
+				->if($score = new \mock\atoum\score())
 				->and($this->calling($runner)->run = $score)
 				->and($this->calling($score)->getUncompletedMethodNumber = rand(1, PHP_INT_MAX))
 				->then
@@ -201,10 +201,10 @@ namespace tests\units
 		{
 			$this
 				->mockGenerator->shuntParentClassCalls()
-				->if($runner = new \mock\mageekguy\atoum\runner())
+				->if($runner = new \mock\atoum\runner())
 				->and($this->calling($runner)->run = new atoum\score())
 				->and($task = new \mock\AtoumTask($runner))
-				->and($this->calling($task)->configureDefaultReport = $report = new \mock\mageekguy\atoum\reports\realtime\phing())
+				->and($this->calling($task)->configureDefaultReport = $report = new \mock\atoum\reports\realtime\phing())
 				->and($this->calling($task)->configureCoverageTreemapField = $field = new atoum\report\fields\runner\coverage\treemap(uniqid(), uniqid()))
 				->and($task->setCodeCoverageTreemapPath(uniqid()))
 				->then
@@ -219,11 +219,11 @@ namespace tests\units
 			$this
 				->if($task = new testedClass())
 				->then
-					->object($task->configureDefaultReport())->isInstanceOf('mageekguy\atoum\reports\realtime\phing')
+					->object($task->configureDefaultReport())->isInstanceOf('atoum\reports\realtime\phing')
 				->if($report = new atoum\reports\realtime\phing())
 				->then
 					->object($task->configureDefaultReport($report))->isIdenticalTo($report)
-				->if($report = new \mock\mageekguy\atoum\reports\realtime\phing())
+				->if($report = new \mock\atoum\reports\realtime\phing())
 				->then
 					->object($task->configureDefaultReport($report))->isIdenticalTo($report)
 					->mock($report)
@@ -290,7 +290,7 @@ namespace tests\units
 		{
 			$this
 				->if($task = new testedClass())
-				->and($report = new \mock\mageekguy\atoum\reports\asynchronous())
+				->and($report = new \mock\atoum\reports\asynchronous())
 				->then
 					->object($task->configureAsynchronousReport($report, uniqid()))->isIdenticalTo($report)
 					->mock($report)
@@ -303,7 +303,7 @@ namespace tests\units
 			$this
 				->given($task = new testedClass())
 				->then
-					->object($field = $task->configureCoverageTreemapField($path = uniqid()))->isInstanceOf('\\mageekguy\\atoum\\report\\fields\\runner\\coverage\\treemap')
+					->object($field = $task->configureCoverageTreemapField($path = uniqid()))->isInstanceOf('\\atoum\\report\\fields\\runner\\coverage\\treemap')
 					->string($field->getDestinationDirectory())->isEqualTo($path)
 					->string($field->getTreemapUrl())->isEqualTo('file://' . $path . '/index.html/')
 				->if($field = $task->configureCoverageTreemapField($path = uniqid(), $url = uniqid()))

--- a/tests/units/runner.php
+++ b/tests/units/runner.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace mageekguy\atoum\tests\units;
+namespace atoum\tests\units;
 
 use
-	mageekguy\atoum
+	atoum
 ;
 
 require_once __DIR__ . '/../../scripts/runner.php';


### PR DESCRIPTION
Remove all mageekguy reference, expect in classloader to keep retro-compatibility with mageekguy\atoum namespace.

mageekguy.atoum.phar was renammed to atoum.phar

Documentation (readme file) is also modified.

All tests are green.

Is it the biggest PR you've received ? 
