### PR TITLE
Fix uncomplete methods reporting in TAP report

### DIFF
--- a/classes/report/fields/test/event/tap.php
+++ b/classes/report/fields/test/event/tap.php
@@ -76,8 +76,20 @@ class tap extends report\fields\event
 
 				case test::uncompleted:
 					$lastUncompleteMethod = $observable->getScore()->getLastUncompleteMethod();
-					$this->testLine = 'not ok ' . ++$this->testPoint . ' - ' . trim($lastUncompleteMethod['class']) . '::' . trim($lastUncompleteMethod['method']) . '()' . PHP_EOL . '# ' . str_replace(PHP_EOL, PHP_EOL . '# ', trim($lastUncompleteMethod['output'])) . PHP_EOL;
-                    $this->testLine .= '# ' . $lastUncompleteMethod['file'] . PHP_EOL;
+					$lastError = $observable->getScore()->getLastErroredMethod();
+
+					$this->testLine = 'not ok ' . ++$this->testPoint . ' - ' . trim($lastUncompleteMethod['class']) . '::' . trim($lastUncompleteMethod['method']) . '()' . PHP_EOL;
+
+					if ($lastError['class'] === $lastUncompleteMethod['class'] && $lastError['method'] === $lastUncompleteMethod['method'])
+					{
+						$this->testLine .= '# ' . $lastError['type'] . ' : ' .  str_replace(PHP_EOL, PHP_EOL . '# ', trim($lastError['message'])) . PHP_EOL;
+					}
+					else
+					{
+						$this->testLine .= '# ' . str_replace(PHP_EOL, PHP_EOL . '# ', trim($lastUncompleteMethod['output']) ?: 'uncomplete method') . PHP_EOL;
+					}
+
+					$this->testLine .= '# ' . $lastUncompleteMethod['file'] . PHP_EOL;
 					break;
 
 				case test::skipped:

--- a/tests/units/classes/report/fields/test/event/tap.php
+++ b/tests/units/classes/report/fields/test/event/tap.php
@@ -419,16 +419,24 @@ class tap extends atoum\test
                     'file' => $file,
                     'class' => $class,
 					'method' => $method,
-					'exitCode' => $exitCode = rand(1, PHP_INT_MAX),
+					'exitCode' => rand(1, PHP_INT_MAX),
 					'output' => $output = uniqid()
 				)
 			)
-			->and($this->calling($score)->getLastUncompleteMethod[2] = array(
+			->and($this->calling($score)->getLastUncompleteMethod[2] = $this->calling($score)->getLastUncompleteMethod[3] = array(
                     'file' => $file,
                     'class' => $class,
 					'method' => $otherMethod,
-					'exitCode' => $otherExitCode = rand(1, PHP_INT_MAX),
+					'exitCode' => rand(1, PHP_INT_MAX),
 					'output' => $otherOutput = uniqid()
+				)
+			)
+			->and($this->calling($score)->getLastUncompleteMethod[4] = array(
+					'file' => $file,
+					'class' => $class,
+					'method' => $thirdMethod = uniqid(),
+					'exitCode' => $thirdExitCode = rand(1, PHP_INT_MAX),
+					'output' => null
 				)
 			)
 			->and($field = new testedClass())
@@ -443,6 +451,20 @@ class tap extends atoum\test
 			->if($field->handleEvent(atoum\test::uncompleted, $test))
 			->then
 				->castToString($field)->isEqualTo('not ok 2 - ' . $class . '::' . $otherMethod . '()' . PHP_EOL . '# ' . $otherOutput . PHP_EOL . '# ' . $file . PHP_EOL)
+			->if($this->calling($score)->getLastErroredMethod = array(
+					'errorFile' => $file,
+					'class' => $class,
+					'method' => $otherMethod,
+					'type' => $errorType = 'error', //uniqid()
+					'message' => ($errorMessageFirstLine = 'line1') . PHP_EOL . ($errorMessageSecondLine = 'line2')
+				)
+			)
+			->and($field->handleEvent(atoum\test::uncompleted, $test))
+			->then
+				->castToString($field)->isEqualTo('not ok 3 - ' . $class . '::' . $otherMethod . '()' . PHP_EOL . '# ' . $errorType . ' : ' . $errorMessageFirstLine . PHP_EOL . '# ' . $errorMessageSecondLine . PHP_EOL . '# ' . $file . PHP_EOL)
+			->if($field->handleEvent(atoum\test::uncompleted, $test))
+			->then
+				->castToString($field)->isEqualTo('not ok 4 - ' . $class . '::' . $thirdMethod . '()' . PHP_EOL . '# uncomplete method' . PHP_EOL . '# ' . $file . PHP_EOL)
 		;
 	}
 


### PR DESCRIPTION
Uncomplete method were not correctluy reported in TAP report: when a PHP Fatal error occurs, the method is marked as uncomplete ut the reason is stored in the score as an error (which seems OK) and the TAP report was not reporting anything about that.

The report now correctly checks for the message when it finds an uncomplete method displaying it to the user (or should I say the parser as TAP is not meant to be read by humans).

This should fix part of an issue in Netbeans : [#235280](https://netbeans.org/bugzilla/show_bug.cgi?id=235280)
