### PR TITLE
advanced arguments asserter API

### DIFF
--- a/classes/asserters/adapter.php
+++ b/classes/asserters/adapter.php
@@ -7,33 +7,37 @@ use
 	mageekguy\atoum\php,
 	mageekguy\atoum\asserter,
 	mageekguy\atoum\exceptions,
-	mageekguy\atoum\test,
-	mageekguy\atoum\tools\arguments
+	mageekguy\atoum\test
 ;
 
 class adapter extends atoum\asserter
 {
-	protected $adapter = null;
-	protected $call = null;
-	protected $beforeMethodCalls = array();
-	protected $afterMethodCalls = array();
-	protected $beforeFunctionCalls = array();
-	protected $afterFunctionCalls = array();
+	protected $adapter;
+	protected $callAsserter;
 
-	public function setWith($adapter)
+	public function __call($method, $arguments)
 	{
-		$this->adapter = $adapter;
-
-		if ($this->adapter instanceof \mageekguy\atoum\test\adapter === false)
+		switch ($method)
 		{
-			$this->fail(sprintf($this->getLocale()->_('%s is not a test adapter'), $this->getTypeOf($this->adapter)));
-		}
-		else
-		{
-			$this->pass();
-		}
+			case 'withArguments':
+			case 'withIdenticalArguments':
+			case 'withAnyArguments':
+			case 'withoutAnyArgument':
+			case 'beforeMethodCall':
+			case 'afterMethodCall':
+			case 'withAnyMethodCallsBefore':
+			case 'withAnyMethodCallsAfter':
+			case 'withAnyFunctionCallsBefore':
+			case 'withAnyFunctionCallsAfter':
+				return call_user_func_array(array($this->getCallAsserter(), $method), $arguments);
 
-		return $this;
+			case 'beforeFunctionCall':
+			case 'afterFunctionCall':
+				return call_user_func_array(array($this->getCallAsserter(), $method), array($arguments[0], $this->adapter));
+
+			default:
+				return parent::__call($method, $arguments);
+		}
 	}
 
 	public function reset()
@@ -46,197 +50,40 @@ class adapter extends atoum\asserter
 		return $this;
 	}
 
+	public function getCallAsserter()
+	{
+		if ($this->adapterIsSet()->callAsserter === null)
+		{
+			$this->callAsserter = new call\adapter($this);
+		}
+
+		return $this->callAsserter;
+	}
+
+	public function setWith($adapter)
+	{
+		$this->adapter = $adapter;
+
+		if ($this->adapter instanceof atoum\test\adapter === false)
+		{
+			$this->fail(sprintf($this->getLocale()->_('%s is not a test adapter'), $this->getTypeOf($this->adapter)));
+		}
+		else
+		{
+			$this->pass();
+		}
+
+		return $this;
+	}
+
 	public function getAdapter()
 	{
 		return $this->adapter;
 	}
 
-	public function beforeMethodCall($methodName, atoum\mock\aggregator $mock)
-	{
-		$this->adapterIsSet()->beforeMethodCalls[] = $beforeMethodCall = new adapter\call\mock($this, $mock, $methodName);
-
-		return $beforeMethodCall;
-	}
-
-	public function getBeforeMethodCalls()
-	{
-		return $this->beforeMethodCalls;
-	}
-
-	public function withAnyMethodCallsBefore()
-	{
-		$this->beforeMethodCalls = array();
-
-		return $this;
-	}
-
-	public function afterMethodCall($methodName, atoum\mock\aggregator $mock)
-	{
-		$this->adapterIsSet()->afterMethodCalls[] = $afterMethodCall = new adapter\call\mock($this, $mock, $methodName);
-
-		return $afterMethodCall;
-	}
-
-	public function getAfterMethodCalls()
-	{
-		return $this->afterMethodCalls;
-	}
-
-	public function withAnyMethodCallsAfter()
-	{
-		$this->afterMethodCalls = array();
-
-		return $this;
-	}
-
-	public function beforeFunctionCall($methodName)
-	{
-		$this->adapterIsSet()->beforeFunctionCalls[] = $beforeFunctionCall = new adapter\call\adapter($this, $this->adapter, $methodName);
-
-		return $beforeFunctionCall;
-	}
-
-	public function getBeforeFunctionCalls()
-	{
-		return $this->beforeFunctionCalls;
-	}
-
-	public function withAnyFunctionCallsBefore()
-	{
-		$this->beforeFunctionCalls = array();
-
-		return $this;
-	}
-
-	public function afterFunctionCall($methodName)
-	{
-		$this->adapterIsSet()->afterFunctionCalls[] = $afterFunctionCall = new adapter\call\adapter($this, $this->adapter, $methodName);
-
-		return $afterFunctionCall;
-	}
-
-	public function getAfterFunctionCalls()
-	{
-		return $this->afterFunctionCalls;
-	}
-
-	public function withAnyFunctionCallsAfter()
-	{
-		$this->afterFunctionCalls = array();
-
-		return $this;
-	}
-
 	public function call($function)
 	{
-		if ($this->adapterIsSet()->call === null)
-		{
-			$this->call = new php\call($function);
-		}
-		else
-		{
-			$this->call
-					->setFunction($function)
-					->unsetArguments()
-			;
-		}
-
-		return $this;
-	}
-
-	public function getCall()
-	{
-		return ($this->call === null ? null : clone $this->call);
-	}
-
-	public function withArguments()
-	{
-		$this->callIsSet()->call->setArguments(func_get_args());
-
-		return $this;
-	}
-
-	public function withIdenticalArguments()
-	{
-		$this->callIsSet()->call->setArguments(func_get_args())->identical();
-
-		return $this;
-	}
-
-	public function withAnyArguments()
-	{
-		$this->callIsSet()->call->unsetArguments();
-
-		return $this;
-	}
-
-	public function withoutAnyArgument()
-	{
-		$this->callIsSet()->call->setArguments(array());
-
-		return $this;
-	}
-
-	public function once($failMessage = null)
-	{
-		return $this->exactly(1, $failMessage);
-	}
-
-	public function twice($failMessage = null)
-	{
-		return $this->exactly(2, $failMessage);
-	}
-
-	public function thrice($failMessage = null)
-	{
-		return $this->exactly(3, $failMessage);
-	}
-
-	public function atLeastOnce($failMessage = null)
-	{
-		$this->assertOnBeforeAndAfterCalls($calls = $this->callIsSet()->adapter->getCalls($this->call->getFunction(), $this->call->getArguments()));
-
-		if (($callsNumber = sizeof($calls)) >= 1)
-		{
-			$this->pass();
-		}
-		else
-		{
-			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('function %s is called 0 time'), $this->call) . $this->getCallsAsString());
-		}
-
-		return $this;
-	}
-
-	public function exactly($number, $failMessage = null)
-	{
-		$this->assertOnBeforeAndAfterCalls($calls = $this->callIsSet()->adapter->getCalls($this->call->getFunction(), $this->call->getArguments()));
-
-		if (($callsNumber = sizeof($calls)) === $number)
-		{
-			$this->pass();
-		}
-		else
-		{
-			$this->fail($failMessage !== null ? $failMessage : sprintf(
-					$this->getLocale()->__(
-						'function %s is called %d time instead of %d',
-						'function %s is called %d times instead of %d',
-						$callsNumber
-					),
-					$this->call,
-					$callsNumber,
-					$number
-				) . $this->getCallsAsString()
-			);
-		}
-
-		return $this;
-	}
-
-	public function never($failMessage = null)
-	{
-		return $this->exactly(0, $failMessage);
+		return $this->getCallAsserter()->setWith(new php\call($function, null, $this->adapter));
 	}
 
 	protected function adapterIsSet()
@@ -247,112 +94,5 @@ class adapter extends atoum\asserter
 		}
 
 		return $this;
-	}
-
-	protected function callIsSet()
-	{
-		if ($this->adapterIsSet()->call === null)
-		{
-			throw new exceptions\logic('Called function is undefined');
-		}
-
-		return $this;
-	}
-
-	protected function assertOnBeforeAndAfterCalls($calls)
-	{
-		if (sizeof($calls) > 0)
-		{
-			foreach ($this->beforeMethodCalls as $beforeMethodCall)
-			{
-				$firstCall = $beforeMethodCall->getFirstCall();
-
-				if ($firstCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $beforeMethodCall));
-				}
-
-				if (key($calls) > $firstCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called before method %s'), $this->call, $beforeMethodCall));
-				}
-
-				$this->pass();
-			}
-
-			foreach ($this->beforeFunctionCalls as $beforeFunctionCall)
-			{
-				$firstCall = $beforeFunctionCall->getFirstCall();
-
-				if ($firstCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $beforeFunctionCall));
-				}
-
-				if (key($calls) > $firstCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called before function %s'), $this->call, $beforeFunctionCall));
-				}
-
-				$this->pass();
-			}
-
-			foreach ($this->afterMethodCalls as $afterMethodCall)
-			{
-				$lastCall = $afterMethodCall->getLastCall();
-
-				if ($lastCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $afterMethodCall));
-				}
-
-				if (key($calls) < $lastCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called after method %s'), $this->call, $afterMethodCall));
-				}
-
-				$this->pass();
-			}
-
-			foreach ($this->afterFunctionCalls as $afterFunctionCall)
-			{
-				$lastCall = $afterFunctionCall->getLastCall();
-
-				if ($lastCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $afterFunctionCall));
-				}
-
-				if (key($calls) < $lastCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('function %s is not called after function %s'), $this->call, $afterFunctionCall));
-				}
-
-				$this->pass();
-			}
-		}
-
-		return $this;
-	}
-
-	protected function getCallsAsString()
-	{
-		$string = '';
-
-		if (($calls  = $this->adapter->getCalls($this->call->getFunction())) !== null)
-		{
-			$format = '[%' . strlen((string) sizeof($calls)) . 's] %s';
-
-			$phpCalls = array();
-
-			foreach (array_values($calls) as $call => $arguments)
-			{
-				$phpCalls[] = sprintf($format, $call + 1, new php\call($this->call->getFunction(), $arguments));
-			}
-
-			$string = PHP_EOL . join(PHP_EOL, $phpCalls);
-		}
-
-		return $string;
 	}
 }

--- a/classes/asserters/adapter/call/adapter.php
+++ b/classes/asserters/adapter/call/adapter.php
@@ -11,12 +11,12 @@ use
 
 class adapter extends php\call
 {
-	protected $adapterAsserter = null;
+	protected $callAsserter = null;
 	protected $adapter = null;
 
-	public function __construct(asserters\adapter $adapterAsserter, test\adapter $adapter, $function)
+	public function __construct(asserters\call\adapter $callAsserter, test\adapter $adapter, $function)
 	{
-		$this->adapterAsserter = $adapterAsserter;
+		$this->callAsserter = $callAsserter;
 		$this->adapter = $adapter;
 
 		parent::__construct($function);
@@ -24,17 +24,12 @@ class adapter extends php\call
 
 	public function __call($method, $arguments)
 	{
-		if (method_exists($this->adapterAsserter, $method) === false)
-		{
-			throw new exceptions\logic\invalidArgument('Method ' . get_class($this->adapterAsserter) . '::' . $method . '() does not exist');
-		}
-
-		return call_user_func_array(array($this->adapterAsserter, $method), $arguments);
+		return call_user_func_array(array($this->callAsserter, $method), $arguments);
 	}
 
-	public function getAdapterAsserter()
+	public function getCallAsserter()
 	{
-		return $this->adapterAsserter;
+		return $this->callAsserter;
 	}
 
 	public function getAdapter()

--- a/classes/asserters/adapter/call/mock.php
+++ b/classes/asserters/adapter/call/mock.php
@@ -11,28 +11,23 @@ use
 
 class mock extends php\call
 {
-	protected $adapterAsserter = null;
+	protected $callAsserter = null;
 
-	public function __construct(asserters\adapter $adapterAsserter, atoum\mock\aggregator $mockAggregator, $function)
+	public function __construct(asserters\call\adapter $callAsserter, atoum\mock\aggregator $mockAggregator, $function)
 	{
-		$this->adapterAsserter = $adapterAsserter;
+		$this->callAsserter = $callAsserter;
 
 		parent::__construct($function, null, $mockAggregator);
 	}
 
 	public function __call($method, $arguments)
 	{
-		if (method_exists($this->adapterAsserter, $method) === false)
-		{
-			throw new exceptions\logic\invalidArgument('Method ' . get_class($this->adapterAsserter) . '::' . $method . '() does not exist');
-		}
-
-		return call_user_func_array(array($this->adapterAsserter, $method), $arguments);
+		return call_user_func_array(array($this->callAsserter, $method), $arguments);
 	}
 
-	public function getAdapterAsserter()
+	public function getCallAsserter()
 	{
-		return $this->adapterAsserter;
+		return $this->callAsserter;
 	}
 
 	public function withArguments()

--- a/classes/asserters/call.php
+++ b/classes/asserters/call.php
@@ -11,10 +11,43 @@ use
 abstract class call extends atoum\asserter
 {
 	protected $call;
+	protected $arguments;
+
+	public function __call($method, $arguments)
+	{
+		switch ($method)
+		{
+			case 'with':
+			case 'and':
+				return $this->callIsSet();
+
+			case 'arguments':
+				$asserter = $this->getArguments();
+
+				if (sizeof($arguments) === 0) {
+					return $asserter;
+				}
+
+				return $asserter[$arguments[0]];
+
+			default:
+				return parent::__call($method, $arguments);
+		}
+	}
+
+	public function __get($asserter)
+	{
+		return $this->__call($asserter, array());
+	}
 
 	public function setWith($call)
 	{
 		$this->call = $call;
+
+		if ($this->call instanceof php\call === false)
+		{
+			$this->fail(sprintf($this->generator->getLocale()->_('%s is not a php call'), $this->getTypeOf($this->call)));
+		}
 
 		return $this;
 	}
@@ -95,6 +128,8 @@ abstract class call extends atoum\asserter
 	{
 		return $this->exactly(0, $failMessage);
 	}
+
+	abstract public function getArguments();
 
 	abstract public function exactly($number, $failMessage = null);
 

--- a/classes/asserters/call.php
+++ b/classes/asserters/call.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace mageekguy\atoum\asserters;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\exceptions
+;
+
+abstract class call extends atoum\asserter
+{
+	protected $call;
+
+	public function setWith($call)
+	{
+		$this->call = $call;
+
+		return $this;
+	}
+
+	protected function callIsSet()
+	{
+		if ($this->call === null)
+		{
+			throw new exceptions\logic('Called function is undefined');
+		}
+
+		return $this;
+	}
+
+	public function getCall()
+	{
+		return ($this->call === null ? null : clone $this->call);
+	}
+
+	public function withArguments()
+	{
+		$this->callIsSet()->call->setArguments(func_get_args())->notIdentical();
+
+		return $this;
+	}
+
+	public function withIdenticalArguments()
+	{
+		$this->callIsSet()->call->setArguments(func_get_args())->identical();
+
+		return $this;
+	}
+
+	public function withAnyArguments()
+	{
+		$this->callIsSet()->call->unsetArguments();
+
+		return $this;
+	}
+
+	public function withoutAnyArgument()
+	{
+		$this->callIsSet()->call->setArguments(array());
+
+		return $this;
+	}
+
+	public function withAtLeastArguments(array $arguments)
+	{
+		$this->callIsSet()->call->setArguments($arguments)->notIdentical();
+
+		return $this;
+	}
+
+	public function withAtLeastIdenticalArguments(array $arguments)
+	{
+		$this->callIsSet()->call->setArguments($arguments)->identical();
+
+		return $this;
+	}
+
+	public function once($failMessage = null)
+	{
+		return $this->exactly(1, $failMessage);
+	}
+
+	public function twice($failMessage = null)
+	{
+		return $this->exactly(2, $failMessage);
+	}
+
+	public function thrice($failMessage = null)
+	{
+		return $this->exactly(3, $failMessage);
+	}
+
+	public function never($failMessage = null)
+	{
+		return $this->exactly(0, $failMessage);
+	}
+
+	abstract public function exactly($number, $failMessage = null);
+
+	abstract public function atLeastOnce($failMessage = null);
+}

--- a/classes/asserters/call/adapter.php
+++ b/classes/asserters/call/adapter.php
@@ -6,7 +6,6 @@ use
 	mageekguy\atoum,
 	mageekguy\atoum\php,
 	mageekguy\atoum\test,
-	mageekguy\atoum\mock,
 	mageekguy\atoum\asserter,
 	mageekguy\atoum\asserters,
 	mageekguy\atoum\exceptions

--- a/classes/asserters/call/adapter.php
+++ b/classes/asserters/call/adapter.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace mageekguy\atoum\asserters\call;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\test,
+	mageekguy\atoum\mock,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\exceptions
+;
+
+class adapter extends asserters\call
+{
+	protected $adapterAsserter;
+	protected $beforeMethodCalls = array();
+	protected $afterMethodCalls = array();
+	protected $beforeFunctionCalls = array();
+	protected $afterFunctionCalls = array();
+
+	public function __construct(asserters\adapter $adapterAsserter, asserter\generator $generator = null)
+	{
+		parent::__construct($generator ?: $adapterAsserter->getGenerator());
+
+		$this->adapterAsserter = $adapterAsserter;
+	}
+
+	public function __call($method, $arguments)
+	{
+		return call_user_func_array(array($this->adapterAsserter, $method), $arguments);
+	}
+
+	public function getAdapterAsserter()
+	{
+		return $this->adapterAsserter;
+	}
+
+	public function beforeMethodCall($methodName, atoum\mock\aggregator $mock)
+	{
+		$this->beforeMethodCalls[] = $beforeMethodCall = new asserters\adapter\call\mock($this, $mock, $methodName);
+
+		return $beforeMethodCall;
+	}
+
+	public function getBeforeMethodCalls()
+	{
+		return $this->beforeMethodCalls;
+	}
+
+	public function withAnyMethodCallsBefore()
+	{
+		$this->beforeMethodCalls = array();
+
+		return $this;
+	}
+
+	public function afterMethodCall($methodName, atoum\mock\aggregator $mock)
+	{
+		$this->afterMethodCalls[] = $afterMethodCall = new asserters\adapter\call\mock($this, $mock, $methodName);
+
+		return $afterMethodCall;
+	}
+
+	public function getAfterMethodCalls()
+	{
+		return $this->afterMethodCalls;
+	}
+
+	public function withAnyMethodCallsAfter()
+	{
+		$this->afterMethodCalls = array();
+
+		return $this;
+	}
+
+	public function beforeFunctionCall($methodName)
+	{
+		$this->beforeFunctionCalls[] = $beforeFunctionCall = new asserters\adapter\call\adapter($this, $this->adapterAsserter->getAdapter(), $methodName);
+
+		return $beforeFunctionCall;
+	}
+
+	public function getBeforeFunctionCalls()
+	{
+		return $this->beforeFunctionCalls;
+	}
+
+	public function withAnyFunctionCallsBefore()
+	{
+		$this->beforeFunctionCalls = array();
+
+		return $this;
+	}
+
+	public function afterFunctionCall($methodName)
+	{
+		$this->afterFunctionCalls[] = $afterFunctionCall = new asserters\adapter\call\adapter($this, $this->adapterAsserter->getAdapter(), $methodName);
+
+		return $afterFunctionCall;
+	}
+
+	public function getAfterFunctionCalls()
+	{
+		return $this->afterFunctionCalls;
+	}
+
+	public function withAnyFunctionCallsAfter()
+	{
+		$this->afterFunctionCalls = array();
+
+		return $this;
+	}
+
+	public function exactly($number, $failMessage = null)
+	{
+		$this->assertOnBeforeAndAfterCalls($calls = $this->callIsSet()->call->getObject()->getCalls($this->call->getFunction(), $this->call->getArguments()));
+
+		if (($callsNumber = sizeof($calls)) === $number)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf(
+						$this->getLocale()->__(
+							'function %s is called %d time instead of %d',
+							'function %s is called %d times instead of %d',
+							$callsNumber
+						),
+						$this->call,
+						$callsNumber,
+						$number
+					) . $this->getCallsAsString()
+			);
+		}
+
+		return $this->adapterAsserter;
+	}
+
+	public function atLeastOnce($failMessage = null)
+	{
+		$this->assertOnBeforeAndAfterCalls($calls = $this->callIsSet()->call->getObject()->getCalls($this->call->getFunction(), $this->call->getArguments()));
+
+		if (($callsNumber = sizeof($calls)) >= 1)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('function %s is called 0 time'), $this->call) . $this->getCallsAsString());
+		}
+
+		return $this->adapterAsserter;
+	}
+
+	protected function getCallsAsString()
+	{
+		$string = '';
+
+		if (($calls  = $this->call->getObject()->getCalls($this->call->getFunction())) !== null)
+		{
+			$format = '[%' . strlen((string) sizeof($calls)) . 's] %s';
+
+			$phpCalls = array();
+
+			foreach (array_values($calls) as $call => $arguments)
+			{
+				$phpCalls[] = sprintf($format, $call + 1, new php\call($this->call->getFunction(), $arguments));
+			}
+
+			$string = PHP_EOL . join(PHP_EOL, $phpCalls);
+		}
+
+		return $string;
+	}
+
+	protected function assertOnBeforeAndAfterCalls($calls)
+	{
+		if (sizeof($calls) > 0)
+		{
+			foreach ($this->beforeMethodCalls as $beforeMethodCall)
+			{
+				$firstCall = $beforeMethodCall->getFirstCall();
+
+				if ($firstCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $beforeMethodCall));
+				}
+
+				if (key($calls) > $firstCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called before method %s'), $this->call, $beforeMethodCall));
+				}
+
+				$this->pass();
+			}
+
+			foreach ($this->beforeFunctionCalls as $beforeFunctionCall)
+			{
+				$firstCall = $beforeFunctionCall->getFirstCall();
+
+				if ($firstCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $beforeFunctionCall));
+				}
+
+				if (key($calls) > $firstCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called before function %s'), $this->call, $beforeFunctionCall));
+				}
+
+				$this->pass();
+			}
+
+			foreach ($this->afterMethodCalls as $afterMethodCall)
+			{
+				$lastCall = $afterMethodCall->getLastCall();
+
+				if ($lastCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $afterMethodCall));
+				}
+
+				if (key($calls) < $lastCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called after method %s'), $this->call, $afterMethodCall));
+				}
+
+				$this->pass();
+			}
+
+			foreach ($this->afterFunctionCalls as $afterFunctionCall)
+			{
+				$lastCall = $afterFunctionCall->getLastCall();
+
+				if ($lastCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called'), $afterFunctionCall));
+				}
+
+				if (key($calls) < $lastCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('function %s is not called after function %s'), $this->call, $afterFunctionCall));
+				}
+
+				$this->pass();
+			}
+		}
+
+		return $this;
+	}
+}

--- a/classes/asserters/call/adapter.php
+++ b/classes/asserters/call/adapter.php
@@ -28,12 +28,29 @@ class adapter extends asserters\call
 
 	public function __call($method, $arguments)
 	{
-		return call_user_func_array(array($this->adapterAsserter, $method), $arguments);
+		try
+		{
+			return call_user_func_array(array($this->adapterAsserter, $method), $arguments);
+		}
+		catch (exceptions\logic\invalidArgument $e)
+		{
+			return parent::__call($method, $arguments);
+		}
 	}
 
 	public function getAdapterAsserter()
 	{
 		return $this->adapterAsserter;
+	}
+
+	public function getArguments()
+	{
+		if ($this->callIsSet()->arguments === null)
+		{
+			$this->arguments = new arguments($this);
+		}
+
+		return $this->arguments->setWith($this->call->getObject());
 	}
 
 	public function beforeMethodCall($methodName, atoum\mock\aggregator $mock)

--- a/classes/asserters/call/arguments.php
+++ b/classes/asserters/call/arguments.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace mageekguy\atoum\asserters\call;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\exceptions
+;
+
+class arguments extends asserter implements \arrayAccess
+{
+	protected $callee;
+	protected $callAsserter;
+	protected $arguments = array();
+	protected $currentArgument;
+
+	public function __construct(asserters\call $callAsserter, asserter\generator $generator = null)
+	{
+		$this->callAsserter = $callAsserter;
+
+		parent::__construct($generator ?: $callAsserter->getGenerator());
+	}
+
+	public function __call($method, $arguments)
+	{
+		return call_user_func_array(array($this->callAsserter, $method), $arguments);
+	}
+
+	public function __get($asserter)
+	{
+		return $this->callAsserter->$asserter;
+	}
+
+	public function setWith($adapter)
+	{
+		$this->callee = $adapter;
+
+		if ($this->callee instanceof atoum\test\adapter === false)
+		{
+			$this->fail(sprintf($this->generator->getLocale()->_('%s is not a test adapter'), $this->getTypeOf($this->callee)));
+		}
+
+		return $this;
+	}
+
+	public function getCallee()
+	{
+		return $this->callee;
+	}
+
+	public function getCallAsserter()
+	{
+		return $this->callAsserter;
+	}
+
+	public function getArgumentAsserter($argument)
+	{
+		return $this->arguments[$this->checkArgument($argument)];
+	}
+
+	public function offsetSet($argument, $value)
+	{
+		return $this->atArgument($argument)->isEqualTo($value);
+	}
+
+	public function offsetGet($call)
+	{
+		return $this->atArgument($call);
+	}
+
+	public function offsetUnset($argument)
+	{
+		unset($this->arguments[$argument]);
+
+		return $this;
+	}
+
+	public function offsetExists($argument)
+	{
+		return array_key_exists($argument, $this->arguments);
+	}
+
+	public function atArgument($argument)
+	{
+		$this->currentArgument = self::checkArgument($argument);
+
+		return $this;
+	}
+
+	protected static function checkArgument($argument)
+	{
+		$call = (int) $argument;
+
+		if ($call < 0)
+		{
+			throw new exceptions\logic\invalidArgument('Argument number must be greater than or equal to zero');
+		}
+
+		return $call;
+	}
+
+	public function isIdenticalTo($expected)
+	{
+		$this->arguments[$this->currentArgument] = static::curry('variable', __FUNCTION__, $expected, $this->generator);
+
+		return $this;
+	}
+
+	public function isEqualTo($expected)
+	{
+		$this->arguments[$this->currentArgument] = static::curry('variable', __FUNCTION__, $expected, $this->generator);
+
+		return $this;
+	}
+
+	public function isNull()
+	{
+		return $this->isIdenticalTo(null);
+	}
+
+	public function isInstanceOf($expected)
+	{
+		if (static::isObject($expected) === false && class_exists($expected) === false && interface_exists($expected) === false)
+		{
+			throw new exceptions\logic('Argument of ' . __METHOD__ . '() must be a class instance or a class name');
+		}
+
+		$this->arguments[$this->currentArgument] = static::curry('object', __FUNCTION__, $expected, $this->generator);
+
+		return $this;
+	}
+
+	protected static function curry($asserter, $assertion, $expected, asserter\generator $generator = null)
+	{
+		$generator = $generator ?: new asserter\generator();
+
+		return function($actual) use ($asserter, $assertion, $expected, $generator) {
+			try {
+				$generator->getAsserterInstance($asserter)->setGenerator()->setWith($actual)->$assertion($expected);
+
+				return true;
+			}
+			catch(atoum\asserter\exception $e)
+			{
+				return false;
+			}
+		};
+	}
+
+
+	public function isCallable()
+	{
+		$generator = $this->generator;
+		$this->arguments[$this->currentArgument] = function($actual) use ($generator) {
+			try {
+				$generator->getAsserterInstance('variable')->setGenerator()->setWith($actual)->isCallable();
+
+				return true;
+			}
+			catch(atoum\asserter\exception $e)
+			{
+				return false;
+			}
+		};
+
+		return $this;
+	}
+
+	public function isArray()
+	{
+		$generator = $this->generator;
+		$this->arguments[$this->currentArgument] = function($actual) use ($generator) {
+			try {
+				$generator->array($actual)->setGenerator();
+
+				return true;
+			}
+			catch(atoum\asserter\exception $e)
+			{
+				return false;
+			}
+		};
+
+		return $this;
+	}
+
+	public function once($failMessage = null)
+	{
+		return $this->exactly(1, $failMessage);
+	}
+
+	public function twice($failMessage = null)
+	{
+		return $this->exactly(1, $failMessage);
+	}
+
+	public function thrice($failMessage = null)
+	{
+		return $this->exactly(1, $failMessage);
+	}
+
+	public function never($failMessage = null)
+	{
+		return $this->exactly(0, $failMessage);
+	}
+
+	public function exactly($number, $failMessage = null)
+	{
+		$call = $this->getCallAsserter()->getCall();
+		$calls = $this->callee->getCalls($call->getFunction());
+
+		foreach ($calls as $c => $arguments)
+		{
+			foreach ($arguments as $argument => $value) {
+				if (array_key_exists($argument, $this->arguments) &&  $this->arguments[$argument]($value) === false)
+				{
+					unset($calls[$c]);
+					break;
+				}
+			}
+		}
+
+		if (($callsNumber = sizeof($calls)) === $number)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf(
+					$this->generator->getLocale()->__(
+						'function %s is called %d time instead of %d',
+						'function %s is called %d times instead of %d',
+						$callsNumber
+					),
+					$call,
+					$callsNumber,
+					$number
+				) . $this->getCallsAsString($call)
+			);
+		}
+
+
+		return $this;
+	}
+
+	protected function getCallsAsString($call)
+	{
+		$string = '';
+
+		if (($calls  = $this->callee->getCalls($call->getFunction())) !== null)
+		{
+			$format = '[%' . strlen((string) sizeof($calls)) . 's] %s';
+
+			$phpCalls = array();
+
+			foreach (array_values($calls) as $c => $arguments)
+			{
+				$phpCalls[] = sprintf($format, $c + 1, new php\call($call->getFunction(), $arguments));
+			}
+
+			$string = PHP_EOL . join(PHP_EOL, $phpCalls);
+		}
+
+		return $string;
+	}
+
+	protected static function isObject($value)
+	{
+		return (is_object($value) === true);
+	}
+} 

--- a/classes/asserters/call/mock.php
+++ b/classes/asserters/call/mock.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace mageekguy\atoum\asserters\call;
+
+use
+	mageekguy\atoum\php,
+	mageekguy\atoum\test,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\exceptions
+;
+
+class mock extends asserters\call
+{
+	protected $mockAsserter;
+	protected $beforeMethodCalls = array();
+	protected $afterMethodCalls = array();
+	protected $beforeFunctionCalls = array();
+	protected $afterFunctionCalls = array();
+
+	public function __construct(asserters\mock $mockAsserter, asserter\generator $generator = null)
+	{
+		parent::__construct($generator ?: $mockAsserter->getGenerator());
+
+		$this->mockAsserter = $mockAsserter;
+	}
+
+	public function __call($method, $arguments)
+	{
+		return call_user_func_array(array($this->mockAsserter, $method), $arguments);
+	}
+
+	public function getMockAsserter()
+	{
+		return $this->mockAsserter;
+	}
+
+	public function beforeMethodCall($methodName)
+	{
+		$this->mockIsSet()->beforeMethodCalls[] = $beforeMethodCall = new asserters\mock\call\mock($this, $this->mockIsSet()->mockAsserter->getMock(), $methodName);
+
+		return $beforeMethodCall;
+	}
+
+	public function getBeforeMethodCalls()
+	{
+		return $this->beforeMethodCalls;
+	}
+
+	public function withAnyMethodCallsBefore()
+	{
+		$this->beforeMethodCalls = array();
+
+		return $this;
+	}
+
+	public function afterMethodCall($methodName)
+	{
+		$this->mockIsSet()->afterMethodCalls[] = $afterMethodCall = new asserters\mock\call\mock($this, $this->mockIsSet()->mockAsserter->getMock(), $methodName);
+
+		return $afterMethodCall;
+	}
+
+	public function getAfterMethodCalls()
+	{
+		return $this->afterMethodCalls;
+	}
+
+	public function withAnyMethodCallsAfter()
+	{
+		$this->afterMethodCalls = array();
+
+		return $this;
+	}
+
+	public function beforeFunctionCall($functionName, test\adapter $adapter)
+	{
+		$this->mockIsSet()->beforeFunctionCalls[] = $beforeFunctionCall = new asserters\mock\call\adapter($this, $adapter, $functionName);
+
+		return $beforeFunctionCall;
+	}
+
+	public function getBeforeFunctionCalls()
+	{
+		return $this->beforeFunctionCalls;
+	}
+
+	public function withAnyFunctionCallsBefore()
+	{
+		$this->beforeFunctionCalls = array();
+
+		return $this;
+	}
+
+	public function afterFunctionCall($functionName, test\adapter $adapter)
+	{
+		$this->mockIsSet()->afterFunctionCalls[] = $afterFunctionCall = new asserters\mock\call\adapter($this, $adapter, $functionName);
+
+		return $afterFunctionCall;
+	}
+
+	public function getAfterFunctionCalls()
+	{
+		return $this->afterFunctionCalls;
+	}
+
+	public function withAnyFunctionCallsAfter()
+	{
+		$this->afterFunctionCalls = array();
+
+		return $this;
+	}
+
+	public function exactly($number, $failMessage = null)
+	{
+		$calls = $this->assertOnBeforeAndAfterCalls();
+
+		if (($callsNumber = sizeof($calls)) == $number)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf(
+					$this->getLocale()->__(
+						'method %s is called %d time instead of %d',
+						'method %s is called %d times instead of %d',
+						$callsNumber
+					),
+					$this->call,
+					$callsNumber,
+					$number
+				) . $this->getCallsAsString()
+			);
+		}
+
+		return $this;
+	}
+
+	public function atLeastOnce($failMessage = null)
+	{
+		$calls = $this->assertOnBeforeAndAfterCalls();
+
+		if (($callsNumber = sizeof($calls)) >= 1)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('method %s is called 0 time'), $this->call) . $this->getCallsAsString());
+		}
+
+		return $this;
+	}
+
+
+	protected function assertOnBeforeAndAfterCalls()
+	{
+		$calls = $this->callIsSet()->mockAsserter->getMock()->getMockController()->getCalls($this->call->getFunction(), $this->call->getArguments(), $this->call->isIdentical());
+
+		if (sizeof($calls) > 0)
+		{
+			foreach ($this->beforeMethodCalls as $beforeMethodCall)
+			{
+				$firstCall = $beforeMethodCall->getFirstCall();
+
+				if ($firstCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $beforeMethodCall));
+				}
+
+				if (key($calls) > $firstCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called before method %s'), $this->call, $beforeMethodCall));
+				}
+
+				$this->pass();
+			}
+
+			foreach ($this->beforeFunctionCalls as $beforeFunctionCall)
+			{
+				$firstCall = $beforeFunctionCall->getFirstCall();
+
+				if ($firstCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $beforeFunctionCall));
+				}
+
+				if (key($calls) > $firstCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called before function %s'), $this->call, $beforeFunctionCall));
+				}
+
+				$this->pass();
+			}
+
+			foreach ($this->afterMethodCalls as $afterMethodCall)
+			{
+				$lastCall = $afterMethodCall->getLastCall();
+
+				if ($lastCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $afterMethodCall));
+				}
+
+				if (key($calls) < $lastCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called after method %s'), $this->call, $afterMethodCall));
+				}
+
+				$this->pass();
+			}
+
+			foreach ($this->afterFunctionCalls as $afterFunctionCall)
+			{
+				$lastCall = $afterFunctionCall->getLastCall();
+
+				if ($lastCall === null)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $afterFunctionCall));
+				}
+
+				if (key($calls) < $lastCall)
+				{
+					$this->fail(sprintf($this->getLocale()->_('method %s is not called after function %s'), $this->call, $afterFunctionCall));
+				}
+
+				$this->pass();
+			}
+		}
+
+		$this->beforeMethodCalls = array();
+		$this->afterMethodCalls = array();
+		$this->beforeFunctionCalls = array();
+		$this->afterFunctionCalls = array();
+
+		return $calls;
+	}
+
+	protected function callIsSet()
+	{
+		if ($this->mockIsSet()->call === null)
+		{
+			throw new exceptions\logic('Called method is undefined');
+		}
+
+		return $this;
+	}
+
+	protected function mockIsSet()
+	{
+		if ($this->mockAsserter->getMock() === null)
+		{
+			throw new exceptions\logic('Mock is undefined');
+		}
+
+		return $this;
+	}
+
+	protected function getCallsAsString()
+	{
+		$string = '';
+
+		if (($calls  = $this->mockAsserter->getMock()->getMockController()->getCalls($this->call->getFunction())) !== null)
+		{
+			$format = '[%' . strlen((string) sizeof($calls)) . 's] %s';
+
+			$phpCalls = array();
+
+			foreach (array_values($calls) as $call => $arguments)
+			{
+				$phpCalls[] = sprintf($format, $call + 1, new php\call($this->call->getFunction(), $arguments, $this->mockAsserter->getMock()));
+			}
+
+			$string = PHP_EOL . join(PHP_EOL, $phpCalls);
+		}
+
+		return $string;
+	}
+}

--- a/classes/asserters/call/mock.php
+++ b/classes/asserters/call/mock.php
@@ -27,12 +27,29 @@ class mock extends asserters\call
 
 	public function __call($method, $arguments)
 	{
-		return call_user_func_array(array($this->mockAsserter, $method), $arguments);
+		try
+		{
+			return call_user_func_array(array($this->mockAsserter, $method), $arguments);
+		}
+		catch (exceptions\logic\invalidArgument $e)
+		{
+			return parent::__call($method, $arguments);
+		}
 	}
 
 	public function getMockAsserter()
 	{
 		return $this->mockAsserter;
+	}
+
+	public function getArguments()
+	{
+		if ($this->callIsSet()->arguments === null)
+		{
+			$this->arguments = new arguments($this);
+		}
+
+		return $this->arguments->setWith($this->call->getObject()->getMockController());
 	}
 
 	public function beforeMethodCall($methodName)

--- a/classes/asserters/mock.php
+++ b/classes/asserters/mock.php
@@ -7,18 +7,39 @@ use
 	mageekguy\atoum\php,
 	mageekguy\atoum\test,
 	mageekguy\atoum\asserter,
-	mageekguy\atoum\exceptions,
-	mageekguy\atoum\tools\arguments
+	mageekguy\atoum\exceptions
 ;
 
 class mock extends atoum\asserter
 {
-	protected $mock = null;
-	protected $call = null;
-	protected $beforeFunctionCalls = array();
-	protected $afterFunctionCalls = array();
-	protected $beforeMethodCalls = array();
-	protected $afterMethodCalls = array();
+	protected $mock;
+	protected $callAsserter;
+
+	public function __call($method, $arguments)
+	{
+		switch ($method)
+		{
+			case 'beforeMethodCall':
+			case 'afterMethodCall':
+				return call_user_func_array(array($this->getCallAsserter(), $method), array($arguments[0], $this->mock));
+
+			case 'withArguments':
+			case 'withIdenticalArguments':
+			case 'withAnyArguments':
+			case 'withoutAnyArgument':
+			case 'withAtLeastArguments':
+			case 'withAnyMethodCallsBefore':
+			case 'withAnyMethodCallsAfter':
+			case 'withAnyFunctionCallsBefore':
+			case 'withAnyFunctionCallsAfter':
+			case 'beforeFunctionCall':
+			case 'afterFunctionCall':
+				return call_user_func_array(array($this->getCallAsserter(), $method), $arguments);
+
+			default:
+				return parent::__call($method, $arguments);
+		}
+	}
 
 	public function reset()
 	{
@@ -28,11 +49,6 @@ class mock extends atoum\asserter
 		}
 
 		return $this;
-	}
-
-	public function getCall()
-	{
-		return ($this->call === null ? null : clone $this->call);
 	}
 
 	public function setWith($mock)
@@ -54,82 +70,6 @@ class mock extends atoum\asserter
 	public function getMock()
 	{
 		return $this->mock;
-	}
-
-	public function beforeMethodCall($methodName)
-	{
-		$this->mockIsSet()->beforeMethodCalls[] = $beforeMethodCall = new mock\call\mock($this, $this->mock, $methodName);
-
-		return $beforeMethodCall;
-	}
-
-	public function getBeforeMethodCalls()
-	{
-		return $this->beforeMethodCalls;
-	}
-
-	public function withAnyMethodCallsBefore()
-	{
-		$this->beforeMethodCalls = array();
-
-		return $this;
-	}
-
-	public function afterMethodCall($methodName)
-	{
-		$this->mockIsSet()->afterMethodCalls[] = $afterMethodCall = new mock\call\mock($this, $this->mock, $methodName);
-
-		return $afterMethodCall;
-	}
-
-	public function getAfterMethodCalls()
-	{
-		return $this->afterMethodCalls;
-	}
-
-	public function withAnyMethodCallsAfter()
-	{
-		$this->afterMethodCalls = array();
-
-		return $this;
-	}
-
-	public function beforeFunctionCall($functionName, test\adapter $adapter)
-	{
-		$this->mockIsSet()->beforeFunctionCalls[] = $beforeFunctionCall = new mock\call\adapter($this, $adapter, $functionName);
-
-		return $beforeFunctionCall;
-	}
-
-	public function getBeforeFunctionCalls()
-	{
-		return $this->beforeFunctionCalls;
-	}
-
-	public function withAnyFunctionCallsBefore()
-	{
-		$this->beforeFunctionCalls = array();
-
-		return $this;
-	}
-
-	public function afterFunctionCall($functionName, test\adapter $adapter)
-	{
-		$this->mockIsSet()->afterFunctionCalls[] = $afterFunctionCall = new mock\call\adapter($this, $adapter, $functionName);
-
-		return $afterFunctionCall;
-	}
-
-	public function getAfterFunctionCalls()
-	{
-		return $this->afterFunctionCalls;
-	}
-
-	public function withAnyFunctionCallsAfter()
-	{
-		$this->afterFunctionCalls = array();
-
-		return $this;
 	}
 
 	public function wasCalled($failMessage = null)
@@ -160,126 +100,19 @@ class mock extends atoum\asserter
 		return $this;
 	}
 
+	public function getCallAsserter()
+	{
+		if ($this->mockIsSet()->callAsserter === null)
+		{
+			$this->callAsserter = new call\mock($this);
+		}
+
+		return $this->callAsserter;
+	}
+
 	public function call($function)
 	{
-		if ($this->mockIsSet()->call === null)
-		{
-			$this->call = new php\call($function, null, $this->mock);
-		}
-		else
-		{
-			$this->call
-				->setFunction($function)
-				->setObject($this->mock)
-				->unsetArguments()
-			;
-		}
-
-		return $this;
-	}
-
-	public function withArguments()
-	{
-		$this->calledMethodNameIsSet()->call->setArguments(func_get_args())->notIdentical();
-
-		return $this;
-	}
-
-	public function withIdenticalArguments()
-	{
-		$this->calledMethodNameIsSet()->call->setArguments(func_get_args())->identical();
-
-		return $this;
-	}
-
-	public function withAtLeastArguments(array $arguments)
-	{
-		$this->calledMethodNameIsSet()->call->setArguments($arguments)->notIdentical();
-
-		return $this;
-	}
-
-	public function withAtLeastIdenticalArguments(array $arguments)
-	{
-		$this->calledMethodNameIsSet()->call->setArguments($arguments)->identical();
-
-		return $this;
-	}
-
-	public function withAnyArguments()
-	{
-		$this->calledMethodNameIsSet()->call->unsetArguments();
-
-		return $this;
-	}
-
-	public function withoutAnyArgument()
-	{
-		$this->calledMethodNameIsSet()->call->setArguments(array());
-
-		return $this;
-	}
-
-	public function once($failMessage = null)
-	{
-		return $this->exactly(1, $failMessage);
-	}
-
-	public function twice($failMessage = null)
-	{
-		return $this->exactly(2, $failMessage);
-	}
-
-	public function thrice($failMessage = null)
-	{
-		return $this->exactly(3, $failMessage);
-	}
-
-	public function atLeastOnce($failMessage = null)
-	{
-		$calls = $this->assertOnBeforeAndAfterCalls();
-
-		if (($callsNumber = sizeof($calls)) >= 1)
-		{
-			$this->pass();
-		}
-		else
-		{
-			$this->fail($failMessage !== null ? $failMessage : sprintf($this->getLocale()->_('method %s is called 0 time'), $this->call) . $this->getCallsAsString());
-		}
-
-		return $this;
-	}
-
-	public function exactly($number, $failMessage = null)
-	{
-		$calls = $this->assertOnBeforeAndAfterCalls();
-
-		if (($callsNumber = sizeof($calls)) == $number)
-		{
-			$this->pass();
-		}
-		else
-		{
-			$this->fail($failMessage !== null ? $failMessage : sprintf(
-					$this->getLocale()->__(
-						'method %s is called %d time instead of %d',
-						'method %s is called %d times instead of %d',
-						$callsNumber
-					),
-					$this->call,
-					$callsNumber,
-					$number
-				) . $this->getCallsAsString()
-			);
-		}
-
-		return $this;
-	}
-
-	public function never($failMessage = null)
-	{
-		return $this->exactly(0, $failMessage);
+		return $this->getCallAsserter()->setWith(new php\call($function, null, $this->mock));
 	}
 
 	protected function mockIsSet()
@@ -290,119 +123,5 @@ class mock extends atoum\asserter
 		}
 
 		return $this;
-	}
-
-	protected function calledMethodNameIsSet()
-	{
-		if ($this->mockIsSet()->call === null)
-		{
-			throw new exceptions\logic('Called method is undefined');
-		}
-
-		return $this;
-	}
-
-	protected function assertOnBeforeAndAfterCalls()
-	{
-		$calls = $this->calledMethodNameIsSet()->mock->getMockController()->getCalls($this->call->getFunction(), $this->call->getArguments(), $this->call->isIdentical());
-
-		if (sizeof($calls) > 0)
-		{
-			foreach ($this->beforeMethodCalls as $beforeMethodCall)
-			{
-				$firstCall = $beforeMethodCall->getFirstCall();
-
-				if ($firstCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $beforeMethodCall));
-				}
-
-				if (key($calls) > $firstCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called before method %s'), $this->call, $beforeMethodCall));
-				}
-
-				$this->pass();
-			}
-
-			foreach ($this->beforeFunctionCalls as $beforeFunctionCall)
-			{
-				$firstCall = $beforeFunctionCall->getFirstCall();
-
-				if ($firstCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $beforeFunctionCall));
-				}
-
-				if (key($calls) > $firstCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called before function %s'), $this->call, $beforeFunctionCall));
-				}
-
-				$this->pass();
-			}
-
-			foreach ($this->afterMethodCalls as $afterMethodCall)
-			{
-				$lastCall = $afterMethodCall->getLastCall();
-
-				if ($lastCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $afterMethodCall));
-				}
-
-				if (key($calls) < $lastCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called after method %s'), $this->call, $afterMethodCall));
-				}
-
-				$this->pass();
-			}
-
-			foreach ($this->afterFunctionCalls as $afterFunctionCall)
-			{
-				$lastCall = $afterFunctionCall->getLastCall();
-
-				if ($lastCall === null)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called'), $afterFunctionCall));
-				}
-
-				if (key($calls) < $lastCall)
-				{
-					$this->fail(sprintf($this->getLocale()->_('method %s is not called after function %s'), $this->call, $afterFunctionCall));
-				}
-
-				$this->pass();
-			}
-		}
-
-		$this->beforeMethodCalls = array();
-		$this->afterMethodCalls = array();
-		$this->beforeFunctionCalls = array();
-		$this->afterFunctionCalls = array();
-
-		return $calls;
-	}
-
-	protected function getCallsAsString()
-	{
-		$string = '';
-
-		if (($calls  = $this->mock->getMockController()->getCalls($this->call->getFunction())) !== null)
-		{
-			$format = '[%' . strlen((string) sizeof($calls)) . 's] %s';
-
-			$phpCalls = array();
-
-			foreach (array_values($calls) as $call => $arguments)
-			{
-				$phpCalls[] = sprintf($format, $call + 1, new php\call($this->call->getFunction(), $arguments, $this->mock));
-			}
-
-			$string = PHP_EOL . join(PHP_EOL, $phpCalls);
-		}
-
-		return $string;
 	}
 }

--- a/classes/asserters/mock/call/adapter.php
+++ b/classes/asserters/mock/call/adapter.php
@@ -14,7 +14,7 @@ class adapter extends php\call
 	protected $mockAsserter = null;
 	protected $adapter = null;
 
-	public function __construct(asserters\mock $mockAsserter, test\adapter $adapter, $function)
+	public function __construct(asserters\call\mock $mockAsserter, test\adapter $adapter, $function)
 	{
 		$this->mockAsserter = $mockAsserter;
 		$this->adapter = $adapter;
@@ -24,11 +24,6 @@ class adapter extends php\call
 
 	public function __call($method, $arguments)
 	{
-		if (method_exists($this->mockAsserter, $method) === false)
-		{
-			throw new exceptions\logic\invalidArgument('Method ' . get_class($this->mockAsserter) . '::' . $method . '() does not exist');
-		}
-
 		return call_user_func_array(array($this->mockAsserter, $method), $arguments);
 	}
 

--- a/classes/asserters/mock/call/mock.php
+++ b/classes/asserters/mock/call/mock.php
@@ -13,7 +13,7 @@ class mock extends php\call
 {
 	protected $mockAsserter = null;
 
-	public function __construct(asserters\mock $mockAsserter, atoum\mock\aggregator $mockAggregator, $function)
+	public function __construct(asserters\call\mock $mockAsserter, atoum\mock\aggregator $mockAggregator, $function)
 	{
 		$this->mockAsserter = $mockAsserter;
 
@@ -22,11 +22,6 @@ class mock extends php\call
 
 	public function __call($function, $arguments)
 	{
-		if (method_exists($this->mockAsserter, $function) === false)
-		{
-			throw new exceptions\logic\invalidArgument('Method ' . get_class($this->mockAsserter) . '::' . $function . '() does not exist');
-		}
-
 		return call_user_func_array(array($this->mockAsserter, $function), $arguments);
 	}
 

--- a/tests/units/classes/asserters/adapter.php
+++ b/tests/units/classes/asserters/adapter.php
@@ -7,7 +7,8 @@ use
 	mageekguy\atoum\php,
 	mageekguy\atoum\test,
 	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\asserters\adapter as testedClass
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -22,23 +23,21 @@ class adapter extends atoum\test
 	public function test__construct()
 	{
 		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
 				->object($asserter->getLocale())->isIdenticalTo($generator->getLocale())
 				->object($asserter->getGenerator())->isIdenticalTo($generator)
-				->variable($asserter->getCall())->isNull()
 				->variable($asserter->getAdapter())->isNull()
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
-				->array($asserter->getAfterMethodCalls())->isEmpty()
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->getCallAsserter(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
 		;
 	}
 
 	public function testSetWith()
 	{
 		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
 				->assert('Set the asserter with something else than an adapter throw an exception')
 					->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
@@ -54,7 +53,7 @@ class adapter extends atoum\test
 	public function testReset()
 	{
 		$this
-			->if($asserter = new asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass(new asserter\generator()))
 			->then
 				->variable($asserter->getAdapter())->isNull()
 				->object($asserter->reset())->isIdenticalTo($asserter)
@@ -76,93 +75,95 @@ class adapter extends atoum\test
 		;
 	}
 
-	public function testCall()
+	public function testGetCallAsserter()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass())
 			->then
-				->exception(function() use ($asserter) { $asserter->call(uniqid()); })
+				->exception(function() use ($asserter) { $asserter->getCallAsserter(); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
-				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function))
-			->if($asserter->withArguments())
+				->object($asserter->getCallAsserter())->isEqualTo(new asserters\call\adapter($asserter))
+		;
+	}
+
+	public function testCall()
+	{
+		$this
+			->if($asserter = new testedClass())
 			->then
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array()))
-				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function))
+				->exception(function() use ($asserter) { $asserter->call(uniqid()); })
+					->isInstanceOf('atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
+			->if($asserter->setWith($adapter = new test\adapter()))
+			->then
+				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter->getCallAsserter())
 		;
 	}
 
 	public function testWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass())
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
-			->if($asserter->call($function = uniqid()))
+			->if($call = $asserter->call($function = uniqid()))
 			->then
-				->object($asserter->withArguments())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array()))
-				->object($asserter->withArguments($arg1 = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1)))
-				->object($asserter->withArguments($arg1 = uniqid(), $arg2 = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1, $arg2)))
+				->object($asserter->withArguments())->isIdenticalTo($call)
+				->array($call->getCall()->getArguments())->isEmpty()
+				->object($asserter->withArguments($arg1 = uniqid()))->isIdenticalTo($call)
+				->array($call->getCall()->getArguments())->isEqualTo(array($arg1))
+				->object($asserter->withArguments($arg1 = uniqid(), $arg2 = uniqid()))->isIdenticalTo($call)
+				->array($call->getCall()->getArguments())->isEqualTo(array($arg1, $arg2))
 		;
 	}
 
 	public function testWithAnyArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass())
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
-			->if($asserter->call($function = uniqid()))
+			->if($call = $asserter->call($function = uniqid()))
 			->then
-				->object($asserter->getCall())->isEqualTo(new php\call($function))
-				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function))
-			->if($asserter->withArguments($arg = uniqid()))
-			->then
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg)))
-				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function))
+				->object($asserter->withAnyArguments())->isIdenticalTo($call)
+				->variable($call->getCall()->getArguments())->isNull()
 		;
 	}
 
 	public function testWithoutAnyArgument()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass())
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
-			->if($asserter->call($function = uniqid()))
+			->if($call = $asserter->call($function = uniqid()))
 			->then
-				->object($asserter->withoutAnyArgument())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array()))
+				->object($asserter->withoutAnyArgument())->isIdenticalTo($call)
+				->array($call->getCall()->getArguments())->isEmpty()
 		;
 	}
 
@@ -170,39 +171,42 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($mock = new \mock\dummy())
-			->and($asserter = new asserters\adapter(new asserter\generator()))
+			->and($asserter = new testedClass())
 			->then
 				->exception(function() use ($asserter, $mock) { $asserter->beforeMethodCall(uniqid(), $mock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
-				->object($asserter->beforeMethodCall('foo', $mock))->isEqualTo($beforeMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'foo'))
-				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
-				->object($asserter->beforeMethodCall('bar', $mock))->isEqualTo($otherBeforeMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'bar'))
-				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall, $otherBeforeMethodCall))
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
+				->object($asserter->beforeMethodCall('foo', $mock))->isEqualTo($beforeMethodCall = new asserters\adapter\call\mock($asserter->getCallAsserter(), $mock, 'foo'))
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
+				->object($asserter->beforeMethodCall('bar', $mock))->isEqualTo($otherBeforeMethodCall = new asserters\adapter\call\mock($asserter->getCallAsserter(), $mock, 'bar'))
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall, $otherBeforeMethodCall))
 		;
 	}
 
 	public function testWithAnyMethodCallsBefore()
 	{
 		$this
-			->if($asserter = new asserters\adapter(new asserter\generator()))
+			->if($mock = new \mock\dummy())
+			->and($asserter = new asserters\adapter())
+			->and($asserter->setWith($adapter = new test\adapter()))
 			->then
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
-				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
 			->if($asserter->setWith($adapter = new test\adapter()))
-			->and($asserter->beforeMethodCall(uniqid(), new \mock\dummy()))
+			->and($asserter->beforeMethodCall(uniqid(), $mock))
 			->then
-				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
-			->if($asserter->beforeMethodCall($method1 = uniqid(), new \mock\dummy())->beforeMethodCall($method2 = uniqid(), new \mock\dummy()))
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
+			->if($asserter->beforeMethodCall($method1 = uniqid(), $mock)->beforeMethodCall($method2 = uniqid(), $mock))
 			->then
-				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
 		;
 	}
 
@@ -210,42 +214,43 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($mock = new \mock\dummy())
-			->and($asserter = new asserters\adapter(new asserter\generator()))
+			->and($asserter = new testedClass())
 			->then
 				->exception(function() use ($asserter, $mock) { $asserter->afterMethodCall(uniqid(), $mock); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 				->if($asserter->setWith($adapter = new test\adapter()))
 				->then
-					->object($asserter->afterMethodCall('foo', $mock))->isEqualTo($afterMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'foo'))
-					->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
-					->object($asserter->afterMethodCall('bar', $mock))->isEqualTo($otherAfterMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'bar'))
-					->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall, $otherAfterMethodCall))
+					->object($asserter->afterMethodCall('foo', $mock))->isEqualTo($afterMethodCall = new asserters\adapter\call\mock($asserter->getCallAsserter(), $mock, 'foo'))
+					->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
+					->object($asserter->afterMethodCall('bar', $mock))->isEqualTo($otherAfterMethodCall = new asserters\adapter\call\mock($asserter->getCallAsserter(), $mock, 'bar'))
+					->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEqualTo(array($afterMethodCall, $otherAfterMethodCall))
 		;
 	}
 
 	public function testWithAnyMethodCallsAfter()
 	{
 		$this
-			->if($asserter = new asserters\adapter(new asserter\generator()))
+			->if($mock = new \mock\dummy())
+			->and($asserter = new testedClass(new asserter\generator()))
 			->then
-				->array($asserter->getAfterMethodCalls())->isEmpty()
-				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->withAnyMethodCallsAfter(); })
+					->isInstanceOf('atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
-			->and($asserter->afterMethodCall(uniqid(), new \mock\dummy()))
+			->and($asserter->afterMethodCall(uniqid(), $mock))
 			->then
-				->array($asserter->getAfterMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEmpty()
 			->if($asserter
-				->afterMethodCall($method1 = uniqid(), new \mock\dummy())
-				->afterMethodCall($method2 = uniqid(), new \mock\dummy())
+				->afterMethodCall($method1 = uniqid(), $mock)
+				->afterMethodCall($method2 = uniqid(), $mock)
 			)
 			->then
-				->array($asserter->getAfterMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEmpty()
 		;
 	}
 
@@ -253,42 +258,44 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($mock = new \mock\dummy())
-			->and($asserter = new asserters\adapter(new asserter\generator()))
+			->and($asserter = new testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
-				->object($asserter->beforeFunctionCall('foo'))->isEqualTo($beforeFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'foo'))
-				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall))
-				->object($asserter->beforeFunctionCall('bar'))->isEqualTo($otherBeforeFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'bar'))
-				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall, $otherBeforeFunctionCall))
+				->object($asserter->beforeFunctionCall('foo'))->isEqualTo($beforeFunctionCall = new asserters\adapter\call\adapter($asserter->getCallAsserter(), $adapter, 'foo'))
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall))
+				->object($asserter->beforeFunctionCall('bar'))->isEqualTo($otherBeforeFunctionCall = new asserters\adapter\call\adapter($asserter->getCallAsserter(), $adapter, 'bar'))
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall, $otherBeforeFunctionCall))
 		;
 	}
 
 	public function testWithAnyFunctionCallsBefore()
 	{
 		$this
-			->if($asserter = new asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass(new asserter\generator()))
 			->then
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
-				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
+					->isInstanceOf('atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
-			->and($asserter->beforeFunctionCall(uniqid()))
 			->then
-				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
+			->if($asserter->beforeFunctionCall(uniqid()))
+			->then
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
 			->if($asserter
 				->beforeFunctionCall($method1 = uniqid())
 				->beforeFunctionCall($method2 = uniqid())
 			)
 			->then
-				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
 		;
 	}
 
@@ -296,321 +303,43 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($mock = new \mock\dummy())
-			->and($asserter = new asserters\adapter(new asserter\generator()))
+			->and($asserter = new testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->isInstanceOf('atoum\exceptions\logic')
 					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
 			->then
-				->object($asserter->afterFunctionCall('foo'))->isEqualTo($afterFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'foo'))
-				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall))
-				->object($asserter->afterFunctionCall('bar'))->isEqualTo($otherAfterFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'bar'))
-				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall, $otherAfterFunctionCall))
+				->object($asserter->afterFunctionCall('foo'))->isEqualTo($afterFunctionCall = new asserters\adapter\call\adapter($asserter->getCallAsserter(), $adapter, 'foo'))
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall))
+				->object($asserter->afterFunctionCall('bar'))->isEqualTo($otherAfterFunctionCall = new asserters\adapter\call\adapter($asserter->getCallAsserter(), $adapter, 'bar'))
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall, $otherAfterFunctionCall))
 		;
 	}
 
 	public function testWithAnyFunctionCallsAfter()
 	{
 		$this
-			->if($asserter = new asserters\adapter(new asserter\generator()))
+			->if($asserter = new testedClass())
 			->then
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
-				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
+					->isInstanceOf('atoum\exceptions\logic')
+					->hasMessage('Adapter is undefined')
 			->if($asserter->setWith($adapter = new test\adapter()))
-			->and($asserter->afterFunctionCall(uniqid()))
 			->then
-				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
+			->if($asserter->afterFunctionCall(uniqid()))
+			->then
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
 			->if($asserter->afterFunctionCall($method1 = uniqid())->afterFunctionCall($method2 = uniqid()))
 			->then
-				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
-		;
-	}
-
-	public function testOnce()
-	{
-		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Adapter is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called function is undefined')
-			->if($asserter->call('md5'))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()))
-			->if($call = new php\call('md5'))
-			->and($adapter->md5($firstArgument = uniqid()))
-			->then
-				->object($asserter->once())->isIdenticalTo($asserter)
-			->if($adapter->md5($secondArgument = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
-			->if($adapter->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->and($adapter->md5($arg))
-			->then
-				->object($asserter->once())->isIdenticalTo($asserter)
-			->if($asserter->withArguments(uniqid()))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-		;
-	}
-
-	public function testTwice()
-	{
-		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Adapter is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called function is undefined')
-			->if($asserter->call('md5'))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($call = new php\call('md5'))
-			->and($adapter->md5($firstArgument = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
-			->if($adapter->md5($secondArgument = uniqid()))
-			->then
-				->object($asserter->twice())->isIdenticalTo($asserter)
-			->if($adapter->md5($thirdArgument = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)))
-			->if($adapter->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->and($adapter->md5($arg))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					 ->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-			->if($asserter->withArguments(uniqid()))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-		;
-	}
-
-	public function testThrice()
-	{
-		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Adapter is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called function is undefined')
-			->if($asserter->call('md5'))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()))
-			->if($call = new php\call('md5'))
-			->and($adapter->md5($firstArgument = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)))
-			->if($adapter->md5($secondArgument = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)))
-			->if($adapter->md5($thirdArgument = uniqid()))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-			->if($adapter->md5($fourthArgument = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArgument)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArgument)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArgument)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArgument)))
-			->if($adapter->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->and($adapter->md5($arg))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-			->if($asserter->withArguments(uniqid()))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-		;
-	}
-
-	public function testAtLeastOnce()
-	{
-		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Adapter is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called function is undefined')
-			->if($asserter->call('md5'))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
-			->if($adapter->md5(uniqid()))
-			->then
-				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
-			->if($adapter->md5(uniqid()))
-			->then
-				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
-			->if($adapter->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
-			->if($call = new php\call('md5'))
-			->and($adapter->md5($arg))
-			->then
-				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
-			->if($asserter->withArguments(uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-		;
-	}
-
-	public function testExactly()
-	{
-		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Adapter is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called function is undefined')
-			->if($asserter->call('md5'))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($call = new php\call('md5'))
-			->and($adapter->md5($arg = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-			->if($adapter->md5($otherArg = uniqid()))
-			->then
-				->object($asserter->exactly(2))->isIdenticalTo($asserter)
-			->if($adapter->md5($anOtherArg = uniqid()))
-			->then
-				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($anOtherArg)))
-			->if($adapter->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($adapter->md5($usedArg = uniqid()))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($adapter->md5($arg))
-			->then
-				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
-			->if($adapter->md5($arg))
-			->then
-				->object($asserter->exactly(2))->isIdenticalTo($asserter)
-			->if($adapter->md5($arg))
-			->then
-				->exception(function() use (& $anAnotherLine, $asserter) { $anAnotherLine = __LINE__; $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg))  . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
-		;
-	}
-
-	public function testNever()
-	{
-		$this
-			->if($asserter = new asserters\adapter($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Adapter is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called function is undefined')
-			->if($call = new php\call('md5'))
-			->and($asserter->call('md5'))
-			->then
-				->object($asserter->never())->isIdenticalTo($asserter)
-			->if($adapter->md5($usedArg = uniqid()))
-			->then
-					->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
-						->isInstanceOf('mageekguy\atoum\asserter\exception')
-						->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($adapter->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->then
-				->object($asserter->never())->isIdenticalTo($asserter)
-			->if($adapter->md5($arg))
-			->then
-				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-			->if($adapter->md5($arg))
-			->then
-				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
-			->if($asserter->withArguments(uniqid()))
-			->then
-				->object($asserter->never())->isIdenticalTo($asserter)
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
 		;
 	}
 }

--- a/tests/units/classes/asserters/adapter/call/adapter.php
+++ b/tests/units/classes/asserters/adapter/call/adapter.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../../../runner.php';
 
 use
 	mageekguy\atoum,
+	mageekguy\atoum\php,
 	mageekguy\atoum\test,
 	mageekguy\atoum\asserter,
 	mageekguy\atoum\asserters,
@@ -22,15 +23,15 @@ class adapter extends atoum\test
 	public function test__construct()
 	{
 		$this
-			->if($call = new call\adapter($adapterAsserter = new asserters\adapter(new asserter\generator()), $adapter = new test\adapter(), $function = uniqid()))
+			->if($call = new call\adapter($callAsserter = new asserters\call\adapter(new asserters\adapter()), $adapter = new test\adapter(), $function = uniqid()))
 			->then
-				->object($call->getAdapterAsserter())->isIdenticalTo($adapterAsserter)
+				->object($call->getCallAsserter())->isIdenticalTo($callAsserter)
 				->object($call->getAdapter())->isIdenticalTo($adapter)
 				->string($call->getFunction())->isEqualTo($function)
 				->variable($call->getArguments())->isNull()
-			->if($call = new call\adapter($adapterAsserter = new asserters\adapter(new asserter\generator()), $adapter = new test\adapter, $function = rand(1, PHP_INT_MAX)))
+			->if($call = new call\adapter($callAsserter = new asserters\call\adapter(new asserters\adapter()), $adapter = new test\adapter, $function = rand(1, PHP_INT_MAX)))
 			->then
-				->object($call->getAdapterAsserter())->isIdenticalTo($adapterAsserter)
+				->object($call->getCallAsserter())->isIdenticalTo($callAsserter)
 				->object($call->getAdapter())->isIdenticalTo($adapter)
 				->string($call->getFunction())->isEqualTo((string) $function)
 				->variable($call->getArguments())->isNull()
@@ -40,24 +41,24 @@ class adapter extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\adapter($adapterAsserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), new test\adapter(), uniqid()))
-			->and($adapterAsserter->getMockController()->call = $adapterAsserter)
+			->if($call = new call\adapter($callAsserter = new \mock\mageekguy\atoum\asserters\call\adapter(new asserters\adapter()),  new test\adapter(), uniqid()))
+			->and($callAsserter->getMockController()->beforeFunctionCall = $callAsserter)
 			->then
-				->object($call->call($arg = uniqid()))->isIdenticalTo($adapterAsserter)
-				->mock($adapterAsserter)
-					->call('call')->withArguments($arg)->once()
+				->object($call->beforeFunctionCall($arg = uniqid(), new test\adapter()))->isIdenticalTo($callAsserter)
+				->mock($callAsserter)
+					->call('beforeFunctionCall')->withArguments($arg)->once()
 			->if($unknownFunction = uniqid())
 			->then
 				->exception(function() use ($call, $unknownFunction) { $call->{$unknownFunction}(); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
-					->hasMessage('Method ' . get_class($adapterAsserter) . '::' . $unknownFunction . '() does not exist')
+					->hasMessage('Asserter \'' . $unknownFunction . '\' does not exist')
 		;
 	}
 
 	public function test__toString()
 	{
 		$this
-			->if($call = new call\adapter(new asserters\adapter(new asserter\generator()), new test\adapter(), $function = uniqid()))
+			->if($call = new call\adapter(new asserters\call\adapter(new asserters\adapter(new asserter\generator())), new test\adapter(), $function = uniqid()))
 			->then
 				->castToString($call)->isEqualTo($function . '()')
 		;
@@ -66,7 +67,7 @@ class adapter extends atoum\test
 	public function testWithArguments()
 	{
 		$this
-			->if($call = new call\adapter(new asserters\adapter(new asserter\generator()), new test\adapter(), uniqid()))
+			->if($call = new call\adapter(new asserters\call\adapter(new asserters\adapter(new asserter\generator())), new test\adapter(), uniqid()))
 			->then
 				->object($call->withArguments($arg = uniqid()))->isIdenticalTo($call)
 				->array($call->getArguments())->isEqualTo(array($arg))
@@ -78,7 +79,7 @@ class adapter extends atoum\test
 	public function testGetFirstCall()
 	{
 		$this
-			->if($call = new call\adapter( new asserters\adapter(new asserter\generator()), $adapter = new test\adapter(), 'md5'))
+			->if($call = new call\adapter(new asserters\call\adapter(new asserters\adapter(new asserter\generator())), $adapter = new test\adapter(), 'md5'))
 			->then
 				->variable($call->getFirstCall())->isNull()
 			->if($otherAdapter = new test\adapter())
@@ -97,7 +98,7 @@ class adapter extends atoum\test
 	public function testGetLastCall()
 	{
 		$this
-			->if($call = new call\adapter(new asserters\adapter(new asserter\generator()), $adapter = new test\adapter(), 'md5'))
+			->if($call = new call\adapter(new asserters\call\adapter(new asserters\adapter(new asserter\generator())), $adapter = new test\adapter(), 'md5'))
 			->then
 				->variable($call->getLastCall())->isNull()
 			->if($otherAdapter = new test\adapter())

--- a/tests/units/classes/asserters/adapter/call/mock.php
+++ b/tests/units/classes/asserters/adapter/call/mock.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../../../runner.php';
 
 use
 	mageekguy\atoum,
+	mageekguy\atoum\php,
 	mageekguy\atoum\asserter,
 	mageekguy\atoum\asserters,
 	mageekguy\atoum\asserters\adapter\call
@@ -21,15 +22,15 @@ class mock extends atoum\test
 	public function test__construct()
 	{
 		$this
-			->if($call = new call\mock($adapterAsserter = new asserters\adapter(new asserter\generator()), $mockAggregator = new \mock\dummy(), $methodName = uniqid()))
+			->if($call = new call\mock($callAsserter = new asserters\call\adapter(new asserters\adapter()), $mockAggregator = new \mock\dummy(), $methodName = uniqid()))
 			->then
-				->object($call->getAdapterAsserter())->isIdenticalTo($adapterAsserter)
+				->object($call->getCallAsserter())->isIdenticalTo($callAsserter)
 				->object($call->getObject())->isIdenticalTo($mockAggregator)
 				->string($call->getFunction())->isEqualTo($methodName)
 				->variable($call->getArguments())->isNull()
-			->if($call = new call\mock($adapterAsserter = new asserters\adapter(new asserter\generator()), $mockAggregator = new \mock\dummy, $methodName = rand(1, PHP_INT_MAX)))
+			->if($call = new call\mock($callAsserter = new asserters\call\adapter(new asserters\adapter()), $mockAggregator = new \mock\dummy, $methodName = rand(1, PHP_INT_MAX)))
 			->then
-				->object($call->getAdapterAsserter())->isIdenticalTo($adapterAsserter)
+				->object($call->getCallAsserter())->isIdenticalTo($callAsserter)
 				->object($call->getObject())->isIdenticalTo($mockAggregator)
 				->string($call->getFunction())->isEqualTo((string) $methodName)
 				->variable($call->getArguments())->isNull()
@@ -39,24 +40,24 @@ class mock extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\mock($adapterAsserter = new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), new \mock\dummy(), uniqid()))
-			->and($adapterAsserter->getMockController()->call = $adapterAsserter)
+			->if($call = new call\mock($callAsserter = new \mock\mageekguy\atoum\asserters\call\adapter(new asserters\adapter()), new \mock\dummy(), uniqid()))
+			->and($callAsserter->getMockController()->beforeMethodCall = $callAsserter)
 			->then
-				->object($call->call($arg = uniqid()))->isIdenticalTo($adapterAsserter)
-				->mock($adapterAsserter)
-					->call('call')->withArguments($arg)->once()
+				->object($call->beforeMethodCall($arg = uniqid(), $mock = new \mock\dummy()))->isIdenticalTo($callAsserter)
+				->mock($callAsserter)
+					->call('beforeMethodCall')->withArguments($arg, $mock)->once()
 			->if($unknownMethod = uniqid())
 			->then
 				->exception(function() use ($call, $unknownMethod) { $call->{$unknownMethod}(); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
-					->hasMessage('Method ' . get_class($adapterAsserter) . '::' . $unknownMethod . '() does not exist')
+					->hasMessage('Asserter \'' . $unknownMethod . '\' does not exist')
 		;
 	}
 
 	public function test__toString()
 	{
 		$this
-			->if($call = new call\mock(new \mock\mageekguy\atoum\asserters\adapter(new asserter\generator()), $mockAggregator = new \mock\dummy(), $function = uniqid()))
+			->if($call = new call\mock(new \mock\mageekguy\atoum\asserters\call\adapter(new asserters\adapter()), $mockAggregator = new \mock\dummy(), $function = uniqid()))
 			->then
 				->castToString($call)->isEqualTo(get_class($mockAggregator) . '::' . $function . '()')
 		;
@@ -65,7 +66,7 @@ class mock extends atoum\test
 	public function testWithArguments()
 	{
 		$this
-			->if($call = new call\mock(new asserters\adapter(new asserter\generator()), new \mock\dummy(), uniqid()))
+			->if($call = new call\mock(new asserters\call\adapter(new asserters\adapter()), new \mock\dummy(), uniqid()))
 			->then
 				->object($call->withArguments($arg = uniqid()))->isIdenticalTo($call)
 				->array($call->getArguments())->isEqualTo(array($arg))
@@ -77,7 +78,7 @@ class mock extends atoum\test
 	public function testGetFirstCall()
 	{
 		$this
-			->if($call = new call\mock(new asserters\adapter(new asserter\generator()), $mock = new \mock\dummy(), 'foo'))
+			->if($call = new call\mock(new asserters\call\adapter(new asserters\adapter()), $mock = new \mock\dummy(), 'foo'))
 			->then
 				->variable($call->getFirstCall())->isNull()
 				->when(function() { $otherMock = new \mock\dummy(); $otherMock->foo(); })
@@ -92,7 +93,7 @@ class mock extends atoum\test
 	public function testGetLastCall()
 	{
 		$this
-			->if($call = new call\mock(new asserters\adapter(new asserter\generator()), $mock = new \mock\dummy(), 'foo'))
+			->if($call = new call\mock(new asserters\call\adapter(new asserters\adapter()), $mock = new \mock\dummy(), 'foo'))
 			->then
 				->variable($call->getLastCall())->isNull()
 				->when(function() { $otherMock = new \mock\dummy(); $otherMock->foo(); })

--- a/tests/units/classes/asserters/call.php
+++ b/tests/units/classes/asserters/call.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\asserters;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\test,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\asserters,
+	mock\mageekguy\atoum\asserters\call as testedClass
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class call extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass
+				->isSubclassOf('mageekguy\atoum\asserter')
+		;
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($asserter = new testedClass())
+			->then
+				->variable($asserter->getCall())->isNull()
+		;
+	}
+
+	public function testSetWith()
+	{
+		$this
+			->if($asserter = new testedClass())
+			->then
+				->variable($asserter->getCall())->isNull()
+				->object($asserter->setWith($call = new php\call(uniqid())))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isCloneOf($call)
+		;
+	}
+
+	public function testWithArguments()
+	{
+		$this
+			->if($asserter = new testedClass())
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call($function = uniqid())))
+			->then
+				->object($asserter->withArguments())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array()))
+				->object($asserter->withArguments($arg1 = uniqid()))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1)))
+				->object($asserter->withArguments($arg1 = uniqid(), $arg2 = uniqid()))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1, $arg2)))
+		;
+	}
+
+	public function testWithAnyArguments()
+	{
+		$this
+			->if($asserter = new testedClass())
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call($function = uniqid())))
+			->then
+				->object($asserter->getCall())->isEqualTo(new php\call($function))
+				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function))
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg)))
+				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function))
+		;
+	}
+
+	public function testWithoutAnyArgument()
+	{
+		$this
+			->if($asserter = new testedClass())
+			->then
+				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call($function = uniqid())))
+			->then
+				->object($asserter->withoutAnyArgument())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array()))
+		;
+	}
+}

--- a/tests/units/classes/asserters/call.php
+++ b/tests/units/classes/asserters/call.php
@@ -32,6 +32,27 @@ class call extends atoum\test
 		;
 	}
 
+	public function test__call()
+	{
+		$this
+			->if($asserter = new testedClass())
+			->and($this->calling($asserter)->getArguments = $arguments = new \mock\mageekguy\atoum\asserters\call\arguments($asserter))
+			->then
+				->object($asserter->arguments(0))->isIdenticalTo($arguments)
+				->mock($arguments)
+					->call('offsetGet')
+						->with->arguments[0]->isEqualTo(0)->once()
+				->object($asserter->arguments[1])->isIdenticalTo($arguments)
+				->mock($arguments)
+					->call('offsetGet')
+						->with->arguments[0]->isEqualTo(1)->once()
+				->object($asserter->arguments[2])->isIdenticalTo($arguments)
+				->mock($arguments)
+					->call('offsetGet')
+						->with->arguments[0]->isEqualTo(2)->once()
+		;
+	}
+
 	public function testSetWith()
 	{
 		$this

--- a/tests/units/classes/asserters/call/adapter.php
+++ b/tests/units/classes/asserters/call/adapter.php
@@ -1,0 +1,442 @@
+<?php
+namespace mageekguy\atoum\tests\units\asserters\call;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\test,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\asserters\call\adapter as testedClass
+;
+
+require_once __DIR__ . '/../../../runner.php';
+
+class adapter extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass
+				->isSubclassOf('mageekguy\atoum\asserters\call')
+		;
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter())
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->object($asserter->getAdapterAsserter())->isIdenticalTo($adapterAsserter)
+		;
+	}
+
+	public function testOnce()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter($generator = new asserter\generator()))
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call('md5', null, $adapter = new test\adapter())))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $call))
+			->if($adapter->md5($firstArgument = uniqid()))
+			->then
+				->object($asserter->once())->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($secondArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 1'), $call) . PHP_EOL . '[1] ' . new php\call('md5', array($firstArgument)) . PHP_EOL . '[2] ' . new php\call('md5', array($secondArgument)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->and($adapter->md5($arg))
+			->then
+				->object($asserter->once())->isIdenticalTo($adapterAsserter)
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+		;
+	}
+
+	public function testTwice()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter($generator = new asserter\generator()))
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($adapter = new test\adapter()))
+			->and($asserter->setWith($call = new php\call('md5', null, $adapter)))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($adapter->md5($firstArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($firstArgument)))
+			->if($adapter->md5($secondArgument = uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($thirdArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($firstArgument)) . PHP_EOL . '[2] ' . new php\call('md5', array($secondArgument)) . PHP_EOL . '[3] ' . new php\call('md5', array($thirdArgument)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->and($adapter->md5($arg))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+		;
+	}
+
+	public function testThrice()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter($generator = new asserter\generator()))
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call('md5', null, $adapter = new test\adapter())))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($call = new php\call('md5'))
+			->and($adapter->md5($firstArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($firstArgument)))
+			->if($adapter->md5($secondArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($firstArgument)) . PHP_EOL . '[2] ' . new php\call('md5', array($secondArgument)))
+			->if($adapter->md5($thirdArgument = uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($fourthArgument = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($firstArgument)) . PHP_EOL . '[2] ' . new php\call('md5', array($secondArgument)) . PHP_EOL . '[3] ' . new php\call('md5', array($thirdArgument)) . PHP_EOL . '[4] ' . new php\call('md5', array($fourthArgument)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->and($adapter->md5($arg))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+		;
+	}
+
+	public function testNever()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter($generator = new asserter\generator()))
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call('md5', null, $adapter = new test\adapter())))
+			->then
+				->object($asserter->never())->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($usedArg = uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($usedArg)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->then
+				->object($asserter->never())->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($arg))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+			->if($adapter->md5($arg))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)) . PHP_EOL . '[2] ' . new php\call('md5', array($arg)))
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->object($asserter->never())->isIdenticalTo($adapterAsserter)
+		;
+	}
+
+	public function testAtLeastOnce()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter($generator = new asserter\generator()))
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call('md5', null, $adapter = new test\adapter())))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
+			->if($adapter->md5(uniqid()))
+			->then
+				->object($asserter->atLeastOnce())->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5(uniqid()))
+			->then
+				->object($asserter->atLeastOnce())->isIdenticalTo($adapterAsserter)
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()))
+			->if($call = new php\call('md5'))
+			->and($adapter->md5($arg))
+			->then
+				->object($asserter->atLeastOnce())->isIdenticalTo($adapterAsserter)
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+		;
+	}
+
+	public function testExactly()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter($generator = new asserter\generator()))
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($asserter->setWith($call = new php\call('md5', null, $adapter = new test\adapter())))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($call = new php\call('md5'))
+			->and($adapter->md5($arg = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)))
+			->if($adapter->md5($otherArg = uniqid()))
+			->then
+				->object($asserter->exactly(2))->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($anOtherArg = uniqid()))
+			->then
+				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($arg)) . PHP_EOL . '[2] ' . new php\call('md5', array($otherArg)) . PHP_EOL . '[3] ' . new php\call('md5', array($anOtherArg)))
+			->if($adapter->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($adapter->md5($usedArg = uniqid()))
+			->then
+				->exception(function() use (& $otherLine, $asserter) { $otherLine = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($usedArg)))
+			->if($adapter->md5($arg))
+			->then
+				->exception(function() use (& $anotherLine, $asserter) { $anotherLine = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($usedArg)) . PHP_EOL . '[2] ' . new php\call('md5', array($arg)))
+			->if($adapter->md5($arg))
+			->then
+				->object($asserter->exactly(2))->isIdenticalTo($adapterAsserter)
+			->if($adapter->md5($arg))
+			->then
+				->exception(function() use (& $anAnotherLine, $asserter) { $anAnotherLine = __LINE__; $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('function %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . new php\call('md5', array($usedArg)) . PHP_EOL . '[2] ' . new php\call('md5', array($arg)) . PHP_EOL . '[3] ' . new php\call('md5', array($arg))  . PHP_EOL . '[4] ' . new php\call('md5', array($arg)))
+		;
+	}
+
+	public function testBeforeMethodCall()
+	{
+		$this
+			->if($mock = new \mock\dummy())
+			->and($asserter = new testedClass($adapterAsserter = new asserters\adapter($generator = new asserter\generator())))
+			->and($asserter->setWith(new php\call(uniqid())))
+			->then
+				->object($asserter->beforeMethodCall('foo', $mock))->isEqualTo($beforeMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'foo'))
+				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
+				->object($asserter->beforeMethodCall('bar', $mock))->isEqualTo($otherBeforeMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'bar'))
+				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall, $otherBeforeMethodCall))
+		;
+	}
+
+	public function testWithAnyMethodCallsBefore()
+	{
+		$this
+			->if($mock = new \mock\dummy())
+			->and($asserter = new testedClass($adapterAsserter = new asserters\adapter($generator = new asserter\generator())))
+			->then
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+			->if($asserter->setWith($adapter = new test\adapter()))
+			->and($asserter->beforeMethodCall(uniqid(), $mock))
+			->then
+				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+			->if($asserter->beforeMethodCall($method1 = uniqid(), $mock)->beforeMethodCall($method2 = uniqid(), $mock))
+			->then
+				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+		;
+	}
+
+	public function testAfterMethodCall()
+	{
+		$this
+			->if($mock = new \mock\dummy())
+			->and($asserter = new testedClass(new asserters\adapter(new asserter\generator())))
+			->then
+				->object($asserter->afterMethodCall('foo', $mock))->isEqualTo($afterMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'foo'))
+				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
+				->object($asserter->afterMethodCall('bar', $mock))->isEqualTo($otherAfterMethodCall = new asserters\adapter\call\mock($asserter, $mock, 'bar'))
+				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall, $otherAfterMethodCall))
+		;
+	}
+
+	public function testWithAnyMethodCallsAfter()
+	{
+		$this
+			->if($asserter = new testedClass(new asserters\adapter(new asserter\generator())))
+			->then
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+			->if($asserter->setWith($adapter = new test\adapter()))
+			->and($asserter->afterMethodCall(uniqid(), new \mock\dummy()))
+			->then
+				->array($asserter->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+			->if($asserter
+				->afterMethodCall($method1 = uniqid(), new \mock\dummy())
+				->afterMethodCall($method2 = uniqid(), new \mock\dummy())
+			)
+			->then
+				->array($asserter->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+		;
+	}
+
+	public function testBeforeFunctionCall()
+	{
+		$this
+			->if($mock = new \mock\dummy())
+			->and($asserter = new testedClass($adapterAsserter = new asserters\adapter()))
+			->and($adapterAsserter->setWith($adapter = new test\Adapter()))
+			->then
+				->object($asserter->beforeFunctionCall('foo'))->isEqualTo($beforeFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'foo'))
+				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall))
+				->object($asserter->beforeFunctionCall('bar'))->isEqualTo($otherBeforeFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'bar'))
+				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall, $otherBeforeFunctionCall))
+		;
+	}
+
+	public function testWithAnyFunctionCallsBefore()
+	{
+		$this
+			->if($asserter = new testedClass($asserterAdapter = new asserters\adapter()))
+			->and($asserterAdapter->setWith($adapter = new test\adapter()))
+			->then
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+			->if($asserter->setWith(new php\call(uniqid(), null, $adapter)))
+			->and($asserter->beforeFunctionCall(uniqid(), $adapter))
+			->then
+				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+			->if($asserter
+				->beforeFunctionCall($method1 = uniqid(), $adapter)
+				->beforeFunctionCall($method2 = uniqid(), $adapter)
+			)
+			->then
+				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+		;
+	}
+
+	public function testAfterFunctionCall()
+	{
+		$this
+			->if($mock = new \mock\dummy())
+			->and($asserter = new testedClass($asserterAdapter = new asserters\adapter()))
+			->and($asserterAdapter->setWith($adapter = new test\adapter()))
+			->then
+				->object($asserter->afterFunctionCall('foo', $adapter = new test\adapter()))->isEqualTo($afterFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'foo'))
+				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall))
+				->object($asserter->afterFunctionCall('bar', $adapter))->isEqualTo($otherAfterFunctionCall = new asserters\adapter\call\adapter($asserter, $adapter, 'bar'))
+				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall, $otherAfterFunctionCall))
+		;
+	}
+
+	public function testWithAnyFunctionCallsAfter()
+	{
+		$this
+			->if($asserter = new testedClass($adapterAsserter = new asserters\adapter()))
+			->and($adapterAsserter->setWith($adapter = new test\adapter()))
+			->then
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+			->if($asserter->setWith(new php\call(uniqid(), null, $adapter)))
+			->and($asserter->afterFunctionCall(uniqid()))
+			->then
+				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+			->if($asserter->afterFunctionCall($method1 = uniqid())->afterFunctionCall($method2 = uniqid()))
+			->then
+				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+		;
+	}
+}

--- a/tests/units/classes/asserters/call/adapter.php
+++ b/tests/units/classes/asserters/call/adapter.php
@@ -76,7 +76,7 @@ class adapter extends atoum\test
 				->exception(function() use ($asserter) { $asserter->twice(); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
 					->hasMessage('Called function is undefined')
-			->if($asserter->setWith($adapter = new test\adapter()))
+			->if($adapterAsserter->setWith($adapter = new test\adapter()))
 			->and($asserter->setWith($call = new php\call('md5', null, $adapter)))
 			->then
 				->exception(function() use (& $line, $asserter) { $line = __LINE__; $asserter->twice(); })
@@ -311,7 +311,7 @@ class adapter extends atoum\test
 				->array($asserter->getBeforeMethodCalls())->isEmpty()
 				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
 				->array($asserter->getBeforeMethodCalls())->isEmpty()
-			->if($asserter->setWith($adapter = new test\adapter()))
+			->if($adapterAsserter->setWith($adapter = new test\adapter()))
 			->and($asserter->beforeMethodCall(uniqid(), $mock))
 			->then
 				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
@@ -341,12 +341,12 @@ class adapter extends atoum\test
 	public function testWithAnyMethodCallsAfter()
 	{
 		$this
-			->if($asserter = new testedClass(new asserters\adapter(new asserter\generator())))
+			->if($asserter = new testedClass($adapterAsserter = new asserters\adapter()))
 			->then
 				->array($asserter->getAfterMethodCalls())->isEmpty()
 				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
 				->array($asserter->getAfterMethodCalls())->isEmpty()
-			->if($asserter->setWith($adapter = new test\adapter()))
+			->if($adapterAsserter->setWith($adapter = new test\adapter()))
 			->and($asserter->afterMethodCall(uniqid(), new \mock\dummy()))
 			->then
 				->array($asserter->getAfterMethodCalls())->isNotEmpty()
@@ -437,6 +437,34 @@ class adapter extends atoum\test
 				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
 				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
 				->array($asserter->getAfterFunctionCalls())->isEmpty()
+		;
+	}
+
+	public function testWithAndArguments()
+	{
+		$this
+			->if($adapterAsserter = new asserters\adapter())
+			->and($asserter = new testedClass($adapterAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->with(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called function is undefined')
+			->if($adapterAsserter->setWith($adapter = new atoum\test\adapter()))
+			->and($asserter->setWith($call = new php\call($function = uniqid(), null, $adapter)))
+			->then
+				->object($asserter->with())->isIdenticalTo($asserter)
+				->object($asserter->with)->isIdenticalTo($asserter)
+				->object($asserter->and())->isIdenticalTo($asserter)
+				->object($asserter->and)->isIdenticalTo($asserter)
+				->object($arguments = $asserter->arguments)->isInstanceOf('mageekguy\atoum\asserters\call\arguments')
+				->object($arguments->getCallee())->isIdenticalTo($adapter)
+				->object($asserter->arguments())->isIdenticalTo($arguments)
+				->object($asserter->arguments(rand(0, PHP_INT_MAX)))->isIdenticalTo($arguments)
+				->object($asserter
+						->with->arguments[0]->isIdenticalTo(uniqid())
+						->and->arguments(1)->isEqualTo(uniqid())
+					)
+						->isIdenticalTo($asserter->getArguments())
 		;
 	}
 }

--- a/tests/units/classes/asserters/call/arguments.php
+++ b/tests/units/classes/asserters/call/arguments.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\asserters\call;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\asserters\call\arguments as testedClass
+;
+
+require_once __DIR__ . '/../../../runner.php';
+
+class invokable
+{
+	public function __invoke() {}
+
+	public function foo() {}
+}
+
+class arguments extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass
+				->isSubclassOf('mageekguy\atoum\asserter')
+		;
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->object($asserter->getCallAsserter())->isIdenticalTo($callAsserter)
+		;
+	}
+
+	public function testSetWith()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->variable($asserter->getCallee())->isNull()
+				->exception(function() use ($asserter, & $value) {
+							$asserter->setWith($value = uniqid());
+						}
+					)
+						->isInstanceof('mageekguy\atoum\asserter\exception')
+						->hasMessage($asserter->getTypeOf($value) . ' is not a test adapter')
+				->object($asserter->setWith($adapter = new atoum\test\adapter()))->isIdenticalTo($asserter)
+				->object($asserter->getCallee())->isIdenticalTo($adapter)
+		;
+	}
+
+	public function testArrayAccess()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->boolean(isset($asserter[0]))->isFalse()
+				->object($asserter[0])->isIdenticalTo($asserter)
+				->boolean(isset($asserter[0]))->isFalse()
+				->variable($asserter[0] = $value = uniqid())->isEqualTo($value)
+				->boolean(isset($asserter[0]))->isTrue()
+			->when(function() use ($asserter) { unset($asserter[0]); })
+			->then
+				->boolean(isset($asserter[0]))->isFalse()
+		;
+	}
+
+	public function testIsIdenticalTo()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->object($asserter[0]->isIdenticalTo($value = rand(0, PHP_INT_MAX)))->isIdenticalTo($asserter)
+				->object($argumentAsserter = $asserter->getArgumentAsserter(0))->isCallable()
+				->boolean($argumentAsserter(uniqid()))->isFalse()
+				->boolean($argumentAsserter((string) $value))->isFalse()
+				->boolean($argumentAsserter($value))->isTrue()
+		;
+	}
+
+	public function testIsEqualTo()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->object($asserter[0]->isEqualTo($value = rand(0, PHP_INT_MAX)))->isIdenticalTo($asserter)
+				->object($argumentAsserter = $asserter->getArgumentAsserter(0))->isCallable()
+				->boolean($argumentAsserter(uniqid()))->isFalse()
+				->boolean($argumentAsserter((string) $value))->isTrue()
+				->boolean($argumentAsserter($value))->isTrue()
+		;
+	}
+
+	public function testIsNull()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->object($asserter[0]->isNull())->isIdenticalTo($asserter)
+				->object($argumentAsserter = $asserter->getArgumentAsserter(0))->isCallable()
+				->boolean($argumentAsserter(''))->isFalse()
+				->boolean($argumentAsserter(0))->isFalse()
+				->boolean($argumentAsserter(false))->isFalse()
+				->boolean($argumentAsserter(array()))->isFalse()
+				->boolean($argumentAsserter(null))->isTrue()
+		;
+	}
+
+	public function testIsInstanceOf()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->then
+				->exception(function() use ($asserter) {
+							$asserter[0]->isInstanceOf(uniqid());
+						}
+					)
+						->isInstanceOf('mageekguy\atoum\exceptions\logic')
+						->hasMessage('Argument of ' . get_class($asserter) . '::isInstanceOf() must be a class instance or a class name')
+				->object($asserter[1]->isInstanceOf('stdClass'))->isIdenticalTo($asserter)
+				->object($argumentAsserter = $asserter->getArgumentAsserter(1))->isCallable()
+				->boolean($argumentAsserter(uniqid()))->isFalse()
+				->boolean($argumentAsserter(new \stdClass))->isTrue()
+				->boolean($argumentAsserter(new \mock\stdClass()))->isTrue()
+		;
+	}
+
+	public function testIsCallable()
+	{
+		$this
+			->if($callAsserter = new \mock\mageekguy\atoum\asserters\call())
+			->and($asserter = new testedClass($callAsserter))
+			->and($invokable = new \mageekguy\atoum\tests\units\asserters\call\invokable())
+			->then
+				->object($asserter[0]->isCallable())->isIdenticalTo($asserter)
+				->object($argumentAsserter = $asserter->getArgumentAsserter(0))->isCallable()
+				->boolean($argumentAsserter(uniqid()))->isFalse()
+				->boolean($argumentAsserter('md5'))->isTrue()
+				->boolean($argumentAsserter(new \stdClass()))->isFalse()
+				->boolean($argumentAsserter($invokable))->isTrue()
+				->boolean($argumentAsserter(array($invokable, 'foo')))->isTrue()
+				->boolean($argumentAsserter(function() {}))->isTrue()
+		;
+	}
+
+	public function testOnce()
+	{
+		$this
+			->if($callAsserter = new asserters\call\mock($mockAsserter = new asserters\mock()))
+			->and($asserter = new testedClass($callAsserter))
+			->and($mockAsserter->setWith($mock = new \mock\dummy()))
+			->and($asserter->setWith($mock->getMockController()))
+			->and($callAsserter->setWith($call = new php\call('foo', null, $mock)))
+			->and($mock->foo($random = uniqid()))
+			->then
+				->object($asserter[0]->isIdenticalTo($argument = uniqid()))->isIdenticalTo($asserter)
+				->exception(function() use ($asserter) {
+						$asserter->once();
+					}
+				)
+					->isInstanceof('mageekguy\atoum\asserter\exception')
+					->hasMessage('function ' . $call . ' is called 0 time instead of 1' . PHP_EOL . '[1] ' . new php\call('foo', array($random)))
+			->if($mock->foo($argument))
+			->then
+				->object($asserter->once())->isIdenticalTo($asserter)
+			->if($mock->foo($argument))
+			->then
+				->exception(function() use ($asserter) {
+						$asserter->once();
+					}
+				)
+					->isInstanceof('mageekguy\atoum\asserter\exception')
+					->hasMessage('function ' . $call . ' is called 2 times instead of 1' . PHP_EOL . '[1] ' . new php\call('foo', array($random)) . PHP_EOL . '[2] ' . new php\call('foo', array($argument)) . PHP_EOL . '[3] ' . new php\call('foo', array($argument)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter = new testedClass($callAsserter))
+			->and($callAsserter->setWith($call = new php\call('foo', null, $mock)))
+			->and($asserter->setWith($mock->getMockController()))
+			->and($asserter[0]->isIdenticalTo($argument))
+			->and($asserter[1]->isEqualTo($number = rand(0, PHP_INT_MAX)))
+			->and($mock->foo($argument, (string) $number))
+			->then
+				->object($asserter->once())->isIdenticalTo($asserter)
+			->if($mock->foo($argument, $number))
+			->then
+				->exception(function() use ($asserter) {
+						$asserter->once();
+					}
+				)
+					->isInstanceof('mageekguy\atoum\asserter\exception')
+					->hasMessage('function ' . $call . ' is called 2 times instead of 1' . PHP_EOL . '[1] ' . new php\call('foo', array($argument, (string) $number)) . PHP_EOL . '[2] ' . new php\call('foo', array($argument, $number)))
+		;
+	}
+} 

--- a/tests/units/classes/asserters/call/mock.php
+++ b/tests/units/classes/asserters/call/mock.php
@@ -1,0 +1,855 @@
+<?php
+namespace mageekguy\atoum\tests\units\asserters\call;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php,
+	mageekguy\atoum\test,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\asserters\call\mock as testedClass
+;
+
+require_once __DIR__ . '/../../../runner.php';
+
+class dummy
+{
+	public function foo($arg) {}
+	public function bar($arg) {}
+	public function fooWithSeveralArguments($arg1, $arg2, $arg3, $arg4, $arg5) {}
+}
+
+class mock extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass
+				->isSubclassOf('mageekguy\atoum\asserters\call')
+		;
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock())
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->object($asserter->getMockAsserter())->isIdenticalTo($mockAsserter)
+		;
+	}
+
+	public function testOnce()
+	{
+		$this
+			->if->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call('foo', null, $mock)))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
+			->if($call = new php\call('foo', null, $mock))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->object($asserter->once())->isIdenticalTo($asserter)
+			->if($mock->foo($otherUsedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($usedArg = uniqid()))
+			->and($mock->foo($usedArg))
+			->then
+				->object($asserter->once())->isIdenticalTo($asserter)
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->beforeMethodCall('bar'))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
+			->if($mock->foo(uniqid()))
+				->object($asserter->once())->isIdenticalTo($asserter)
+			/*
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->bar(uniqid()))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called before method %s'), $asserter->getCall(), current($asserter->getBeforeMethodCalls())))
+			*/
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->foo(uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->object($asserter->once())->isIdenticalTo($asserter)
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->afterMethodCall('bar'))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
+			/*
+			->if($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getAfterMethodCalls())))
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->foo(uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called after method %s'), $asserter->getCall(), current($asserter->getAfterMethodCalls())))
+			*/
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->bar(uniqid()))
+			->and($mock->foo(uniqid()))
+			->then
+				->object($asserter->once())->isIdenticalTo($asserter)
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto'))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->once(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+		;
+	}
+
+	public function testTwice()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call('foo', null, $mock)))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($call = new php\call('foo', null, $mock))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($secondArg = uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mock->foo($thirdArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->beforeMethodCall('bar'))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($mock->foo($usedArg = uniqid()))
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo(uniqid()))
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->foo($usedArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->afterMethodCall('bar'))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->bar(uniqid()))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto'))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->twice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+			->and($mock->foo(uniqid()))
+			->if($mock->bar($arg))
+			->then
+				->object($asserter->twice())->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testThrice()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call('foo', null, $mock)))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($call = new php\call('foo', null, $mock))
+			->and($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($secondArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
+			->if($mock->foo($thirdArg = uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mock->foo($fourthArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArg)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->beforeMethodCall('bar'))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo($usedArg))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->foo($firstArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
+			->if($mock->foo($secondArg = uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
+			->if($mock->foo(uniqid()))
+			->and($mock->bar(uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->afterMethodCall('bar'))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
+			->if($mock->getMockController()->resetCalls())
+			->and($mock->bar(uniqid()))
+			->and($mock->foo($firstArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
+			->if($mock->bar(uniqid()))
+			->and($mock->foo($secondArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+			->if($mockAsserter = new asserters\mock($generator))
+			->and($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter = $mockAsserter->call('foo'))
+			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto'))
+			->and($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+			->if($mock->foo(uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->thrice(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
+			->and($mock->foo(uniqid()))
+			->if($mock->bar($arg))
+			->then
+				->object($asserter->thrice())->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testAtLeastOnce()
+	{
+
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call('foo', null, $mock)))
+			->then
+				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
+			->if($mock->foo(uniqid()))
+			->then
+				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
+			->if($call = new php\call('foo', null, $mock))
+			->if( $mock->foo($usedArg))
+			->then
+				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
+			->if($asserter->withArguments($otherArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+		;
+	}
+
+	public function testNever()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith($call = new php\call('foo', null, $mock)))
+			->then
+				->object($asserter->never())->isIdenticalTo($asserter)
+			->if($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->then
+				->object($asserter->never())->isIdenticalTo($asserter)
+			->if($mock->foo($arg))
+			->then
+				->exception(function() use ($asserter) { $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
+			->if($mock->foo($arg))
+			->then
+				->exception(function() use ($asserter) { $asserter->never(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
+			->if($mock->foo($arg))
+			->then
+				->exception(function() use ($asserter, & $message) { $asserter->never($message = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($message)
+			->if($asserter->withArguments(uniqid()))
+			->then
+				->object($asserter->never())->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testExactly()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith($call = new php\call('foo', null, $mock)))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $call))
+			->if($mock->foo($usedArg = 'A'))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $call) . PHP_EOL . '[1] ' . new php\call('foo', array($usedArg), $mock))
+			->if($mock->foo($otherUsedArg = 'B'))
+			->then
+				->object($asserter->exactly(2))->isIdenticalTo($asserter)
+			->if($mock->foo($anOtherUsedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $call) . PHP_EOL . '[1] ' . new php\call('foo', array($usedArg), $mock) . PHP_EOL . '[2] ' . new php\call('foo', array($otherUsedArg), $mock) . PHP_EOL . '[3] ' . new php\call('foo', array($anOtherUsedArg), $mock))
+			->if($mock->getMockController()->resetCalls())
+			->and($asserter->withArguments($arg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $call))
+			->if($mock->foo($usedArg = uniqid()))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $call) . PHP_EOL . '[1] ' . new php\call('foo', array($usedArg), $mock))
+			->if($mock->foo($arg))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $call) . PHP_EOL . '[1] ' . new php\call('foo', array($usedArg), $mock) . PHP_EOL . '[2] ' . new php\call('foo', array($arg), $mock))
+			->if($mock->foo($arg))
+			->then
+				->object($asserter->exactly(2))->isIdenticalTo($asserter)
+			->if($mock->foo($arg))
+			->then
+				->exception(function() use ($asserter) { $asserter->exactly(2); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $call) . PHP_EOL . '[1] ' . new php\call('foo', array($usedArg), $mock) . PHP_EOL . '[2] ' . new php\call('foo', array($arg), $mock) . PHP_EOL . '[3] ' . new php\call('foo', array($arg), $mock) . PHP_EOL . '[4] ' . new php\call('foo', array($arg), $mock))
+			->if($asserter->setWith($call = new php\call('fooWithSeveralArguments', null, $mock)))
+			->then
+				->object($asserter->exactly(0))->isIdenticalTo($asserter)
+				->exception(function() use ($asserter) { $asserter->exactly(1); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $call))
+			->if($mock->fooWithSeveralArguments(1, 2, 3, 4, 5))
+				->exception(function() use ($asserter) { $asserter->exactly(0); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $call) . PHP_EOL . '[1] ' . new php\call('fooWithSeveralArguments', array(1, 2, 3, 4, 5), $mock))
+				->object($asserter->exactly(1))->isIdenticalTo($asserter)
+				->object($asserter->withArguments(1, 2, 3, 4, 5)->exactly(1))->isIdenticalTo($asserter)
+				->object($asserter->withAtLeastArguments(array(1 => 2, 3 => 4))->exactly(1))->isIdenticalTo($asserter)
+				->object($asserter->withAtLeastArguments(array(1 => 2, 3 => rand(6, PHP_INT_MAX)))->exactly(0))->isIdenticalTo($asserter)
+				->exception(function() use ($asserter) { $asserter->withAtLeastArguments(array(1 => 2, 3 => 4))->exactly(0); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $call) . PHP_EOL . '[1] ' . new php\call('fooWithSeveralArguments', array(1, 2, 3, 4, 5), $mock))
+				->object($asserter->withIdenticalArguments(1, 2, 3, 4, 5)->exactly(1))->isIdenticalTo($asserter)
+				->exception(function() use ($asserter) { $asserter->withAtLeastIdenticalArguments(array(1 => '2', 3 => 4))->exactly(1); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $call) . PHP_EOL . '[1] ' . new php\call('fooWithSeveralArguments', array(1, 2, 3, 4, 5), $mock))
+		;
+	}
+
+	public function testBeforeMethodCall()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->beforeMethodCall(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->object($asserter->beforeMethodCall('foo'))->isEqualTo($beforeMethodCall = new asserters\mock\call\mock($asserter, $mock, 'foo'))
+				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
+				->object($asserter->beforeMethodCall('bar'))->isEqualTo($otherBeforeMethodCall = new asserters\mock\call\mock($asserter, $mock, 'bar'))
+				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall, $otherBeforeMethodCall))
+		;
+	}
+
+	public function testWithAnyMethodCallsBefore()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+			->if($mockAsserter->setWith(new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->beforeMethodCall(uniqid()))
+			->then
+				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+			->if($asserter
+				->beforeMethodCall(uniqid())
+				->beforeMethodCall(uniqid())
+			)
+			->then
+				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeMethodCalls())->isEmpty()
+		;
+	}
+
+	public function testAfterMethodCall()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->afterMethodCall(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->object($asserter->afterMethodCall('foo'))->isEqualTo($afterMethodCall = new asserters\mock\call\mock($asserter, $mock, 'foo'))
+				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
+				->object($asserter->afterMethodCall('bar'))->isEqualTo($otherAfterMethodCall = new asserters\mock\call\mock($asserter, $mock, 'bar'))
+				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall, $otherAfterMethodCall))
+		;
+	}
+
+	public function testWithAnyMethodCallsAfter()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($asserter->afterMethodCall($function = uniqid()))
+			->then
+				->array($asserter->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+			->if($asserter
+				->afterMethodCall($function1 = uniqid())
+				->afterMethodCall($function2 = uniqid())
+			)
+			->then
+				->array($asserter->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterMethodCalls())->isEmpty()
+		;
+	}
+
+	public function testBeforeFunctionCall()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($adapter = new test\adapter())
+			->then
+				->object($asserter->beforeFunctionCall('foo', $adapter))->isEqualTo($beforeFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'foo'))
+				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall))
+				->object($asserter->beforeFunctionCall('bar', $adapter))->isEqualTo($otherBeforeFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'bar'))
+				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall, $otherBeforeFunctionCall))
+		;
+	}
+
+	public function testWithAnyFunctionCallsBefore()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($adapter = new test\adapter())
+			->and($asserter->beforeFunctionCall($function = uniqid(), $adapter))
+			->then
+				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+			->if($asserter
+				->beforeFunctionCall($function1 = uniqid(), $adapter)
+				->beforeFunctionCall($function2 = uniqid(), $adapter)
+			)
+			->then
+				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
+				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+		;
+	}
+
+	public function testAfterFunctionCall()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($adapter = new test\adapter())
+			->then
+				->object($asserter->afterFunctionCall('foo', $adapter))->isEqualTo($afterFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'foo'))
+				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall))
+				->object($asserter->afterFunctionCall('bar', $adapter))->isEqualTo($otherAfterFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'bar'))
+				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall, $otherAfterFunctionCall))
+		;
+	}
+
+	public function testWithAnyFunctionCallsAfter()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock($generator = new asserter\generator()))
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->and($adapter = new test\adapter())
+			->and($asserter->afterFunctionCall($function = uniqid(), $adapter))
+			->then
+				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+			->if($asserter
+				->afterFunctionCall($function1 = uniqid(), $adapter)
+				->afterFunctionCall($function2 = uniqid(), $adapter)
+			)
+			->then
+				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
+				->array($asserter->getAfterFunctionCalls())->isEmpty()
+		;
+	}
+
+	public function testWithArguments()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock())
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call($function = uniqid(), null, $mock)))
+			->then
+				->object($asserter->withArguments())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array(), $mock))
+				->object($asserter->withArguments($arg1 = uniqid()))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1), $mock))
+				->object($asserter->withArguments($arg1 = uniqid(), $arg2 = uniqid()))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1, $arg2), $mock))
+		;
+	}
+
+	public function testWithAtLeastArguments()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock())
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call($function = uniqid(), null, $mock)))
+			->then
+				->object($asserter->withAtLeastArguments($arguments = array(1 => uniqid())))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, $arguments, $mock))
+				->object($asserter->withAtLeastArguments($arguments = array(2 => uniqid(), 5 => uniqid())))->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, $arguments, $mock))
+		;
+	}
+
+	public function testWithAnyArguments()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock())
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call($function = uniqid(), null, $mock)))
+			->then
+				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
+				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
+			->if($asserter->withArguments($arg = uniqid()))
+			->then
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg), $mock))
+				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
+		;
+	}
+
+	public function testWithoutAnyArgument()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock())
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith(new php\call($function = uniqid(), null, $mock)))
+			->then
+				->object($asserter->withoutAnyArgument())->isIdenticalTo($asserter)
+				->object($asserter->getCall())->isEqualTo(new php\call($function, array(), $mock))
+		;
+	}
+}

--- a/tests/units/classes/asserters/call/mock.php
+++ b/tests/units/classes/asserters/call/mock.php
@@ -852,4 +852,35 @@ class mock extends atoum\test
 				->object($asserter->getCall())->isEqualTo(new php\call($function, array(), $mock))
 		;
 	}
+
+	public function testWithAndArguments()
+	{
+		$this
+			->if($mockAsserter = new asserters\mock())
+			->and($asserter = new testedClass($mockAsserter))
+			->then
+				->exception(function() use ($asserter) { $asserter->with(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+			->if($mockAsserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
+			->then
+				->exception(function() use ($asserter) { $asserter->with(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Called method is undefined')
+			->if($asserter->setWith($call = new php\call($function = uniqid(), null, $mock)))
+			->then
+				->object($asserter->with())->isIdenticalTo($asserter)
+				->object($asserter->with)->isIdenticalTo($asserter)
+				->object($asserter->and())->isIdenticalTo($asserter)
+				->object($asserter->and)->isIdenticalTo($asserter)
+				->object($arguments = $asserter->arguments())->isInstanceOf('mageekguy\atoum\asserters\call\arguments')
+				->object($arguments->getCallee())->isIdenticalTo($mock->getMockController())
+				->object($asserter->arguments)->isIdenticalTo($arguments)
+				->object($asserter
+						->with->arguments[0]->isIdenticalTo(uniqid())
+						->and->arguments(1)->isEqualTo(uniqid())
+					)
+						->isIdenticalTo($asserter->getArguments())
+		;
+	}
 }

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -7,7 +7,8 @@ use
 	mageekguy\atoum\php,
 	mageekguy\atoum\test,
 	mageekguy\atoum\asserter,
-	mageekguy\atoum\asserters
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\asserters\mock as testedClass;
 ;
 
 require_once __DIR__ . '/../../runner.php';
@@ -34,9 +35,9 @@ class mock extends atoum\test
 				->object($asserter->getLocale())->isIdenticalTo($generator->getLocale())
 				->object($asserter->getGenerator())->isIdenticalTo($generator)
 				->variable($asserter->getMock())->isNull()
-				->variable($asserter->getCall())->isNull()
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->getCallAsserter(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
 		;
 	}
 
@@ -126,91 +127,99 @@ class mock extends atoum\test
 	public function testBeforeMethodCall()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeMethodCall(uniqid()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
 			->then
-				->object($asserter->beforeMethodCall('foo'))->isEqualTo($beforeMethodCall = new asserters\mock\call\mock($asserter, $mock, 'foo'))
-				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
-				->object($asserter->beforeMethodCall('bar'))->isEqualTo($otherBeforeMethodCall = new asserters\mock\call\mock($asserter, $mock, 'bar'))
-				->array($asserter->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall, $otherBeforeMethodCall))
+				->object($asserter->beforeMethodCall('foo'))->isEqualTo($beforeMethodCall = new asserters\mock\call\mock($asserter->getCallAsserter(), $mock, 'foo'))
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall))
+				->object($asserter->beforeMethodCall('bar'))->isEqualTo($otherBeforeMethodCall = new asserters\mock\call\mock($asserter->getCallAsserter(), $mock, 'bar'))
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEqualTo(array($beforeMethodCall, $otherBeforeMethodCall))
 		;
 	}
 
 	public function testWithAnyMethodCallsBefore()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
-				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->beforeMethodCall(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
 			->if($asserter->setWith(new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall(uniqid()))
 			->then
-				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
+			->if($asserter->beforeMethodCall(uniqid()))
+			->then
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
 			->if($asserter
 				->beforeMethodCall(uniqid())
 				->beforeMethodCall(uniqid())
 			)
 			->then
-				->array($asserter->getBeforeMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeMethodCalls())->isEmpty()
 		;
 	}
 
 	public function testAfterMethodCall()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterMethodCall(uniqid()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
 					->hasMessage('Mock is undefined')
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
 			->then
-				->object($asserter->afterMethodCall('foo'))->isEqualTo($afterMethodCall = new asserters\mock\call\mock($asserter, $mock, 'foo'))
-				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
-				->object($asserter->afterMethodCall('bar'))->isEqualTo($otherAfterMethodCall = new asserters\mock\call\mock($asserter, $mock, 'bar'))
-				->array($asserter->getAfterMethodCalls())->isEqualTo(array($afterMethodCall, $otherAfterMethodCall))
+				->object($asserter->afterMethodCall('foo'))->isEqualTo($afterMethodCall = new asserters\mock\call\mock($asserter->getCallAsserter(), $mock, 'foo'))
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEqualTo(array($afterMethodCall))
+				->object($asserter->afterMethodCall('bar'))->isEqualTo($otherAfterMethodCall = new asserters\mock\call\mock($asserter->getCallAsserter(), $mock, 'bar'))
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEqualTo(array($afterMethodCall, $otherAfterMethodCall))
 		;
 	}
 
 	public function testWithAnyMethodCallsAfter()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
-				->array($asserter->getAfterMethodCalls())->isEmpty()
-				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->withAnyMethodCallsAfter(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->afterMethodCall($function = uniqid()))
 			->then
-				->array($asserter->getAfterMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEmpty()
+			->if($asserter->afterMethodCall($function = uniqid()))
+			->then
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEmpty()
 			->if($asserter
 				->afterMethodCall($function1 = uniqid())
 				->afterMethodCall($function2 = uniqid())
 			)
 			->then
-				->array($asserter->getAfterMethodCalls())->isNotEmpty()
-				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterMethodCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isNotEmpty()
+				->object($asserter->withAnyMethodCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterMethodCalls())->isEmpty()
 		;
 	}
 
 	public function testBeforeFunctionCall()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->beforeFunctionCall(uniqid(), new test\adapter()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
@@ -218,43 +227,47 @@ class mock extends atoum\test
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->then
-				->object($asserter->beforeFunctionCall('foo', $adapter))->isEqualTo($beforeFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'foo'))
-				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall))
-				->object($asserter->beforeFunctionCall('bar', $adapter))->isEqualTo($otherBeforeFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'bar'))
-				->array($asserter->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall, $otherBeforeFunctionCall))
+				->object($asserter->beforeFunctionCall('foo', $adapter))->isEqualTo($beforeFunctionCall = new asserters\mock\call\adapter($asserter->getCallAsserter(), $adapter, 'foo'))
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall))
+				->object($asserter->beforeFunctionCall('bar', $adapter))->isEqualTo($otherBeforeFunctionCall = new asserters\mock\call\adapter($asserter->getCallAsserter(), $adapter, 'bar'))
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEqualTo(array($beforeFunctionCall, $otherBeforeFunctionCall))
 		;
 	}
 
 	public function testWithAnyFunctionCallsBefore()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
-				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->withAnyMethodCallsAfter(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($adapter = new test\adapter())
+			->then
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
+			->if($adapter = new test\adapter())
 			->and($asserter->beforeFunctionCall($function = uniqid(), $adapter))
 			->then
-				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
 			->if($asserter
 				->beforeFunctionCall($function1 = uniqid(), $adapter)
 				->beforeFunctionCall($function2 = uniqid(), $adapter)
 			)
 			->then
-				->array($asserter->getBeforeFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter)
-				->array($asserter->getBeforeFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsBefore())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getBeforeFunctionCalls())->isEmpty()
 		;
 	}
 
 	public function testAfterFunctionCall()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->afterFunctionCall(uniqid(), new test\adapter()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
@@ -262,36 +275,40 @@ class mock extends atoum\test
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
 			->and($adapter = new test\adapter())
 			->then
-				->object($asserter->afterFunctionCall('foo', $adapter))->isEqualTo($afterFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'foo'))
-				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall))
-				->object($asserter->afterFunctionCall('bar', $adapter))->isEqualTo($otherAfterFunctionCall = new asserters\mock\call\adapter($asserter, $adapter, 'bar'))
-				->array($asserter->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall, $otherAfterFunctionCall))
+				->object($asserter->afterFunctionCall('foo', $adapter))->isEqualTo($afterFunctionCall = new asserters\mock\call\adapter($asserter->getCallAsserter(), $adapter, 'foo'))
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall))
+				->object($asserter->afterFunctionCall('bar', $adapter))->isEqualTo($otherAfterFunctionCall = new asserters\mock\call\adapter($asserter->getCallAsserter(), $adapter, 'bar'))
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEqualTo(array($afterFunctionCall, $otherAfterFunctionCall))
 		;
 	}
 
 	public function testWithAnyFunctionCallsAfter()
 	{
 		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
+			->if($asserter = new testedClass($generator = new asserter\generator()))
 			->then
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
-				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->exception(function() use ($asserter) { $asserter->withAnyFunctionCallsAfter(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($adapter = new test\adapter())
+			->then
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
+			->if($adapter = new test\adapter())
 			->and($asserter->afterFunctionCall($function = uniqid(), $adapter))
 			->then
-				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
 			->if($asserter
 				->afterFunctionCall($function1 = uniqid(), $adapter)
 				->afterFunctionCall($function2 = uniqid(), $adapter)
 			)
 			->then
-				->array($asserter->getAfterFunctionCalls())->isNotEmpty()
-				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter)
-				->array($asserter->getAfterFunctionCalls())->isEmpty()
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isNotEmpty()
+				->object($asserter->withAnyFunctionCallsAfter())->isIdenticalTo($asserter->getCallAsserter())
+				->array($asserter->getCallAsserter()->getAfterFunctionCalls())->isEmpty()
 		;
 	}
 
@@ -305,20 +322,14 @@ class mock extends atoum\test
 					->hasMessage('Mock is undefined')
 			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
 			->then
-				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter)
-			->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
-			->if($asserter->withArguments())
-			->then
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array(), $mock))
-				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
+				->object($asserter->call($function = uniqid()))->isIdenticalTo($asserter->getCallAsserter())
 		;
 	}
 
 	public function testWithArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
@@ -330,19 +341,19 @@ class mock extends atoum\test
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
-				->object($asserter->withArguments())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array(), $mock))
-				->object($asserter->withArguments($arg1 = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1), $mock))
-				->object($asserter->withArguments($arg1 = uniqid(), $arg2 = uniqid()))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg1, $arg2), $mock))
+				->object($asserter->withArguments())->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, array(), $mock))
+				->object($asserter->withArguments($arg1 = uniqid()))->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, array($arg1), $mock))
+				->object($asserter->withArguments($arg1 = uniqid(), $arg2 = uniqid()))->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, array($arg1, $arg2), $mock))
 		;
 	}
 
 	public function testWithAtLeastArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
@@ -354,17 +365,17 @@ class mock extends atoum\test
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
-				->object($asserter->withAtLeastArguments($arguments = array(1 => uniqid())))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, $arguments, $mock))
-				->object($asserter->withAtLeastArguments($arguments = array(2 => uniqid(), 5 => uniqid())))->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, $arguments, $mock))
+				->object($asserter->withAtLeastArguments($arguments = array(1 => uniqid())))->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, $arguments, $mock))
+				->object($asserter->withAtLeastArguments($arguments = array(2 => uniqid(), 5 => uniqid())))->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, $arguments, $mock))
 		;
 	}
 
 	public function testWithAnyArguments()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withArguments(uniqid()); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
@@ -376,21 +387,21 @@ class mock extends atoum\test
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
-				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
-				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, null, $mock))
+				->object($asserter->withAnyArguments())->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, null, $mock))
 			->if($asserter->withArguments($arg = uniqid()))
 			->then
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array($arg), $mock))
-				->object($asserter->withAnyArguments())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, null, $mock))
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, array($arg), $mock))
+				->object($asserter->withAnyArguments())->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, null, $mock))
 		;
 	}
 
 	public function testWithoutAnyArgument()
 	{
 		$this
-			->if($asserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()))
+			->if($asserter = new testedClass(new asserter\generator()))
 			->then
 				->exception(function() use ($asserter) { $asserter->withoutAnyArgument(); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
@@ -402,534 +413,8 @@ class mock extends atoum\test
 					->hasMessage('Called method is undefined')
 			->if($asserter->call($function = uniqid()))
 			->then
-				->object($asserter->withoutAnyArgument())->isIdenticalTo($asserter)
-				->object($asserter->getCall())->isEqualTo(new php\call($function, array(), $mock))
-		;
-	}
-
-	public function testOnce()
-	{
-		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called method is undefined')
-			->if($asserter->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
-			->if($call = new php\call('foo', null, $mock))
-			->and($mock->foo($usedArg = uniqid()))
-			->then
-				->object($asserter->once())->isIdenticalTo($asserter)
-			->if($mock->foo($otherUsedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)))
-			->if($mock->getMockController()->resetCalls())
-			->and($asserter->withArguments($usedArg = uniqid()))
-			->and($mock->foo($usedArg))
-			->then
-				->object($asserter->once())->isIdenticalTo($asserter)
-			->if($asserter->withArguments($arg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall('bar')->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
-			->if($mock->foo(uniqid()))
-				->object($asserter->once())->isIdenticalTo($asserter)
-			/*
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->bar(uniqid()))
-			->and($mock->foo(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called before method %s'), $asserter->getCall(), current($asserter->getBeforeMethodCalls())))
-			*/
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->foo(uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->object($asserter->once())->isIdenticalTo($asserter)
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->afterMethodCall('bar')->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
-			/*
-			->if($mock->foo(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getAfterMethodCalls())))
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->foo(uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called after method %s'), $asserter->getCall(), current($asserter->getAfterMethodCalls())))
-			*/
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->bar(uniqid()))
-			->and($mock->foo(uniqid()))
-			->then
-				->object($asserter->once())->isIdenticalTo($asserter)
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
-			->and($mock->foo(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->once(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
-		;
-	}
-
-	public function testTwice()
-	{
-		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called method is undefined')
-			->if($asserter->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($call = new php\call('foo', null, $mock))
-			->and($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($secondArg = uniqid()))
-			->then
-				->object($asserter->twice())->isIdenticalTo($asserter)
-			->if($mock->foo($thirdArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)))
-			->if($mock->getMockController()->resetCalls())
-			->and($asserter->withArguments($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($mock->foo($usedArg))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($usedArg))
-			->then
-				->object($asserter->twice())->isIdenticalTo($asserter)
-			->if($mock->foo($usedArg))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
-			->if($asserter->withArguments($arg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)))
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall('bar')->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($mock->foo($usedArg = uniqid()))
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo(uniqid()))
-				->object($asserter->twice())->isIdenticalTo($asserter)
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->foo($usedArg = uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($usedArg = uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->object($asserter->twice())->isIdenticalTo($asserter)
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->afterMethodCall('bar')->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->bar(uniqid()))
-			->and($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo(uniqid()))
-			->then
-				->object($asserter->twice())->isIdenticalTo($asserter)
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
-			->and($mock->foo(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->twice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
-			->and($mock->foo(uniqid()))
-			->if($mock->bar($arg))
-			->then
-				->object($asserter->twice())->isIdenticalTo($asserter)
-		;
-	}
-
-	public function testThrice()
-	{
-		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called method is undefined')
-			->if($asserter->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
-			->if($call = new php\call('foo', null, $mock))
-			->and($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($secondArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
-			->if($mock->foo($thirdArg = uniqid()))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-			->if($mock->foo($fourthArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($thirdArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($fourthArg)))
-			->if($mock->getMockController()->resetCalls())
-			->and($asserter->withArguments($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
-			->if($mock->foo($usedArg))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($usedArg))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($usedArg))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-			->if($mock->foo($usedArg))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 4 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
-			->if($asserter->withArguments($arg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[4] ' . $call->setArguments(array($usedArg)))
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall('bar')->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
-			->if($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($usedArg))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo(uniqid()))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->foo($firstArg = uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
-			->if($mock->foo($secondArg = uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
-			->if($mock->foo(uniqid()))
-			->and($mock->bar(uniqid()))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->afterMethodCall('bar')->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 3'), $asserter->getCall()))
-			->if($mock->getMockController()->resetCalls())
-			->and($mock->bar(uniqid()))
-			->and($mock->foo($firstArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)))
-			->if($mock->bar(uniqid()))
-			->and($mock->foo($secondArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 3'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($firstArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($secondArg)))
-			->if($mock->foo(uniqid()))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->and($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->and($asserter->beforeMethodCall('bar')->withArguments($arg = 'toto')->call('foo'))
-			->and($mock->foo(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
-			->if($mock->foo(uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->thrice(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is not called'), current($asserter->getBeforeMethodCalls())))
-			->and($mock->foo(uniqid()))
-			->if($mock->bar($arg))
-			->then
-				->object($asserter->thrice())->isIdenticalTo($asserter)
-		;
-	}
-
-	public function testAtLeastOnce()
-	{
-
-		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called method is undefined')
-			->if($asserter->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
-			->if($mock->foo(uniqid()))
-			->then
-				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
-			->if($mock->foo(uniqid()))
-			->then
-				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
-			->if($mock->getMockController()->resetCalls())
-			->and($asserter->withArguments($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()))
-			->if($call = new php\call('foo', null, $mock))
-			->if( $mock->foo($usedArg))
-			->then
-				->object($asserter->atLeastOnce())->isIdenticalTo($asserter)
-			->if($asserter->withArguments($otherArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->atLeastOnce(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-		;
-	}
-
-	public function testExactly()
-	{
-		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called method is undefined')
-			->if($asserter->call('foo'))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($call = new php\call('foo', null, $mock))
-			->and($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($otherUsedArg = uniqid()))
-			->then
-				->object($asserter->exactly(2))->isIdenticalTo($asserter)
-			->if($mock->foo($anOtherUsedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($otherUsedArg)) . PHP_EOL . '[3] ' . $call->setArguments(array($anOtherUsedArg)))
-			->if($mock->getMockController()->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()))
-			->if($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->foo($arg))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
-			->if($mock->foo($arg))
-			->then
-				->object($asserter->exactly(2))->isIdenticalTo($asserter)
-			->if($mock->foo($arg))
-			->then
-				->exception(function() use ($asserter) { $asserter->exactly(2); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 3 times instead of 2'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)) . PHP_EOL . '[3] ' . $call->setArguments(array($arg)) . PHP_EOL . '[4] ' . $call->setArguments(array($arg)))
-			->if($call = new php\call('fooWithSeveralArguments', null, $mock))
-			->and($asserter->call('fooWithSeveralArguments'))
-			->then
-				->object($asserter->exactly(0))->isIdenticalTo($asserter)
-				->exception(function() use ($asserter) { $asserter->exactly(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()))
-			->if($mock->fooWithSeveralArguments(1, 2, 3, 4, 5))
-				->exception(function() use ($asserter) { $asserter->exactly(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array(1, 2, 3, 4, 5)))
-				->object($asserter->exactly(1))->isIdenticalTo($asserter)
-				->object($asserter->withArguments(1, 2, 3, 4, 5)->exactly(1))->isIdenticalTo($asserter)
-				->object($asserter->withAtLeastArguments(array(1 => 2, 3 => 4))->exactly(1))->isIdenticalTo($asserter)
-				->object($asserter->withAtLeastArguments(array(1 => 2, 3 => rand(6, PHP_INT_MAX)))->exactly(0))->isIdenticalTo($asserter)
-				->exception(function() use ($asserter) { $asserter->withAtLeastArguments(array(1 => 2, 3 => 4))->exactly(0); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array(1, 2, 3, 4, 5)))
-				->object($asserter->withIdenticalArguments(1, 2, 3, 4, 5)->exactly(1))->isIdenticalTo($asserter)
-				->exception(function() use ($asserter) { $asserter->withAtLeastIdenticalArguments(array(1 => '2', 3 => 4))->exactly(1); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 0 time instead of 1'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array(1, 2, 3, 4, 5)))
-		;
-	}
-
-	public function testNever()
-	{
-		$this
-			->if($asserter = new asserters\mock($generator = new asserter\generator()))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Mock is undefined')
-			->if($asserter->setWith($mock = new \mock\mageekguy\atoum\tests\units\asserters\dummy()))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\exceptions\logic')
-					->hasMessage('Called method is undefined')
-			->if($asserter->call('foo'))
-			->then
-				->object($asserter->never())->isIdenticalTo($asserter)
-			->if($call = new php\call('foo', null, $mock))
-			->and($mock->foo($usedArg = uniqid()))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($usedArg)))
-			->if($mock->getMockController()->resetCalls())
-			->and($asserter->withArguments($arg = uniqid()))
-			->then
-				->object($asserter->never())->isIdenticalTo($asserter)
-			->if($mock->foo($arg))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 1 time instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)))
-			->if($mock->foo($arg))
-			->then
-				->exception(function() use ($asserter) { $asserter->never(); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage(sprintf($generator->getLocale()->_('method %s is called 2 times instead of 0'), $asserter->getCall()) . PHP_EOL . '[1] ' . $call->setArguments(array($arg)) . PHP_EOL . '[2] ' . $call->setArguments(array($arg)))
-			->if($mock->foo($arg))
-			->then
-				->exception(function() use ($asserter, & $message) { $asserter->never($message = uniqid()); })
-					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage($message)
-			->if($asserter->withArguments(uniqid()))
-			->then
-				->object($asserter->never())->isIdenticalTo($asserter)
+				->object($asserter->withoutAnyArgument())->isIdenticalTo($asserter->getCallAsserter())
+				->object($asserter->getCallAsserter()->getCall())->isEqualTo(new php\call($function, array(), $mock))
 		;
 	}
 }

--- a/tests/units/classes/asserters/mock/call/adapter.php
+++ b/tests/units/classes/asserters/mock/call/adapter.php
@@ -23,7 +23,7 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($call = new call\adapter(
-					$mockAsserter = new asserters\mock(new asserter\generator()),
+					$mockAsserter = new asserters\call\mock(new asserters\mock()),
 					$adapter = new test\adapter(),
 					$function = uniqid()
 				)
@@ -39,12 +39,7 @@ class adapter extends atoum\test
 	public function test__call()
 	{
 		$this
-			->if($call = new call\adapter(
-					$mockAsserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()),
-					new test\adapter(),
-					uniqid()
-				)
-			)
+			->if($call = new call\adapter(new asserters\call\mock($mockAsserter = new \mock\mageekguy\atoum\asserters\mock()), new test\adapter(), uniqid()))
 			->and($mockAsserter->getMockController()->call = $mockAsserter)
 			->then
 				->object($call->call($arg = uniqid()))->isIdenticalTo($mockAsserter)
@@ -52,12 +47,9 @@ class adapter extends atoum\test
 					->call('call')->withArguments($arg)->once()
 			->if($unknownFunction = uniqid())
 			->then
-				->exception(function() use ($call, $unknownFunction) {
-							$call->{$unknownFunction}();
-						}
-					)
-						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
-						->hasMessage('Method ' . get_class($mockAsserter) . '::' . $unknownFunction . '() does not exist')
+				->exception(function() use ($call, $unknownFunction) { $call->{$unknownFunction}(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->hasMessage('Asserter \'' . $unknownFunction . '\' does not exist')
 		;
 	}
 
@@ -65,7 +57,7 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($call = new call\adapter(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					new test\adapter(),
 					uniqid()
 				)
@@ -82,7 +74,7 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($call = new call\adapter(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					$adapter = new test\adapter(),
 					'md5'
 				)
@@ -102,7 +94,7 @@ class adapter extends atoum\test
 	{
 		$this
 			->if($call = new call\adapter(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					$adapter = new test\adapter(),
 					'md5'
 				)

--- a/tests/units/classes/asserters/mock/call/mock.php
+++ b/tests/units/classes/asserters/mock/call/mock.php
@@ -27,7 +27,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					$mockAsserter = new asserters\mock(new asserter\generator()),
+					$mockAsserter = new asserters\call\mock(new asserters\mock()),
 					$mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					$function = uniqid()
 				)
@@ -44,7 +44,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					$mockAsserter = new \mock\mageekguy\atoum\asserters\mock(new asserter\generator()),
+					new asserters\call\mock($mockAsserter = new \mock\mageekguy\atoum\asserters\mock()),
 					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
@@ -61,7 +61,7 @@ class mock extends atoum\test
 						}
 					)
 						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
-						->hasMessage('Method ' . get_class($mockAsserter) . '::' . $unknownMethod . '() does not exist')
+						->hasMessage('Asserter \'' . $unknownMethod . '\' does not exist')
 		;
 	}
 
@@ -69,7 +69,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					$mockAggregator = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					$function = uniqid()
 				)
@@ -83,7 +83,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
@@ -100,7 +100,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
@@ -117,7 +117,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					uniqid()
 				)
@@ -133,7 +133,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					$mock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					'foo'
 				)
@@ -155,7 +155,7 @@ class mock extends atoum\test
 	{
 		$this
 			->if($call = new testedClass(
-					new asserters\mock(new asserter\generator()),
+					new asserters\call\mock(new asserters\mock()),
 					$mock = new \mock\mageekguy\atoum\tests\units\asserters\mock\call\dummy(),
 					'foo'
 				)


### PR DESCRIPTION
While working on the phpunit bridge, I ran into a situation I can't handle with the current arguments asserter API on mocks.

Here is an example phpunit test that I can't support ATM:

```php
<?php
class UniqueEntityValidatorTest extends DoctrineOrmTestCase
{
    protected function createValidatorFactory($uniqueValidator)
    {
        $validatorFactory = $this->getMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
        $validatorFactory
            ->expects($this->any())
            ->method('getInstance')
            ->with($this->isInstanceOf('Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity'))
            ->will($this->returnValue($uniqueValidator))
        ;

        return $validatorFactory;
    }
}
?>
```

The part that is responsible is the ```->with($this->isInstanceOf('\A\Class'))```. With atoum, when asserting on calls arguments, we can only check their values (```withArguments``` / ```withIdenticalArguments```). Here, we want to check that the argument was an instance of ```\A\Class```

I think the use case is valid, sometimes we only want to check that something was given as a parameter in a more lazy way. 

I also tried to figure out a clean API and I came to something like:

```php
<?php
use \A\Class as testedClass;

$this
    ->if($mock = new \mock\Something())
    ->and($sut = new testedClass($mock))
    ->then
        ->variable($sut->doSomething())->isNull()
        ->mock($mock)
            ->call('init')->withArguments
                ->at(0)->isInstanceOf('\\A\\Class')
                ->at(1)->isCallable()
                ->at(2)->isArray()->isEmpty()
                ->at(3)->isIdenticalTo('non_random_stuff')
                ->at(4)->isEqualTo('non_random_stuff')
                ->once()
;
```

I was just thinking about something like that... let me know what you think about that.