### PR TITLE
Remove bug in phpArray asserter.

### DIFF
--- a/classes/asserter.php
+++ b/classes/asserter.php
@@ -124,11 +124,6 @@ abstract class asserter
 		return $this;
 	}
 
-	public function handleNativeType()
-	{
-		return false;
-	}
-
 	public function setWith($mixed)
 	{
 		return $this->reset();

--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -28,7 +28,7 @@ class phpArray extends asserters\variable implements \arrayAccess
 			default:
 				$asserter = parent::__get($asserter);
 
-				if ($asserter->handleNativeType() === false)
+				if ($asserter instanceof asserters\variable === false)
 				{
 					$this->resetInnerAsserter();
 

--- a/classes/asserters/variable.php
+++ b/classes/asserters/variable.php
@@ -245,11 +245,6 @@ class variable extends atoum\asserter
 		return $this;
 	}
 
-	public function handleNativeType()
-	{
-		return true;
-	}
-
 	protected function valueIsSet($message = 'Value is undefined')
 	{
 		if ($this->isSet === false)

--- a/classes/test/asserter/generator.php
+++ b/classes/test/asserter/generator.php
@@ -20,12 +20,12 @@ class generator extends asserter\generator
 
 	public function __get($property)
 	{
-		return $this->test->getAssertionManager()->invoke($property);
+		return $this->test->__get($property);
 	}
 
 	public function __call($method, $arguments)
 	{
-		return $this->test->getAssertionManager()->invoke($method, $arguments);
+		return $this->test->__call($method, $arguments);
 	}
 
 	public function setTest(atoum\test $test)

--- a/tests/units/classes/asserter.php
+++ b/tests/units/classes/asserter.php
@@ -140,13 +140,4 @@ class asserter extends atoum\test
 				->mock($locale)->call('_')->withArguments('array(%s)')->once()
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/adapter.php
+++ b/tests/units/classes/asserters/adapter.php
@@ -613,13 +613,4 @@ class adapter extends atoum\test
 				->object($asserter->never())->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/boolean.php
+++ b/tests/units/classes/asserters/boolean.php
@@ -103,13 +103,4 @@ class boolean extends atoum\test
 					->boolean($asserter->getValue())->isTrue()
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/castToString.php
+++ b/tests/units/classes/asserters/castToString.php
@@ -60,13 +60,4 @@ class castToString extends atoum\test
 				->castToString($asserter)->isEqualTo('string(' . strlen(($string = (string) $object)) . ') \'' . $string . '\'')
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/dateInterval.php
+++ b/tests/units/classes/asserters/dateInterval.php
@@ -156,13 +156,4 @@ class dateInterval extends atoum\test
 					->hasMessage('Interval ' . $asserter . ' is not equal to ' . $interval->format('%Y/%M/%D %H:%I:%S'))
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/dateTime.php
+++ b/tests/units/classes/asserters/dateTime.php
@@ -232,13 +232,4 @@ class dateTime extends atoum\test
 				->object($asserter->hasDateAndTime(1981, 2, 13, 1, 2, 3))->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/error.php
+++ b/tests/units/classes/asserters/error.php
@@ -214,13 +214,4 @@ class error extends atoum\test
 					->isInstanceOf('mageekguy\atoum\score')
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/exception.php
+++ b/tests/units/classes/asserters/exception.php
@@ -167,13 +167,4 @@ class exception extends atoum\test
 				->object(sut::getLastValue())->isIdenticalTo($otherException)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/extension.php
+++ b/tests/units/classes/asserters/extension.php
@@ -111,13 +111,4 @@ class extension extends atoum\test
 				->object($asserter->isLoaded())->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/float.php
+++ b/tests/units/classes/asserters/float.php
@@ -128,15 +128,6 @@ class float extends atoum\test
 		;
 	}
 
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
-
 	/**
 	 * @dataProvider dataProviderNearlyEqualTo
 	 */

--- a/tests/units/classes/asserters/hash.php
+++ b/tests/units/classes/asserters/hash.php
@@ -125,13 +125,4 @@ class hash extends atoum\test
 					->hasMessage(sprintf($generator->getLocale()->_('%s does not match given pattern'), $asserter))
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/integer.php
+++ b/tests/units/classes/asserters/integer.php
@@ -137,13 +137,4 @@ class integer extends atoum\test
 					->hasMessage(sprintf($generator->getLocale()->_('%s is not less than or equal to %s'), $asserter, $asserter->getTypeOf(- PHP_INT_MAX)))
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -932,13 +932,4 @@ class mock extends atoum\test
 				->object($asserter->never())->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/mysqlDateTime.php
+++ b/tests/units/classes/asserters/mysqlDateTime.php
@@ -32,13 +32,4 @@ class mysqlDateTime extends atoum\test
 			->string($asserter->getValue())->isEqualTo($value)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/object.php
+++ b/tests/units/classes/asserters/object.php
@@ -130,13 +130,4 @@ class object extends atoum\test
 				->object($asserter->toString())->isInstanceOf('mageekguy\atoum\asserters\castToString')
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/output.php
+++ b/tests/units/classes/asserters/output.php
@@ -48,13 +48,4 @@ class output extends atoum\test
 				->string($asserter->getCharlist())->isEqualTo("\010")
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/phpArray.php
+++ b/tests/units/classes/asserters/phpArray.php
@@ -122,15 +122,6 @@ class phpArray extends atoum\test
 		;
 	}
 
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new \mock\mageekguy\atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
-
 	public function testSetWith()
 	{
 		$this

--- a/tests/units/classes/asserters/phpClass.php
+++ b/tests/units/classes/asserters/phpClass.php
@@ -319,13 +319,4 @@ class phpClass extends atoum\test
 				->object($asserter->hasMethod(uniqid()))->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/phpFunction.php
+++ b/tests/units/classes/asserters/phpFunction.php
@@ -134,13 +134,4 @@ class phpFunction extends atoum\test
 				->object($asserter->isCalled())->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/sizeOf.php
+++ b/tests/units/classes/asserters/sizeOf.php
@@ -43,13 +43,4 @@ class sizeOf extends atoum\test
 				->integer($asserter->getValue())->isEqualTo(sizeof($countable))
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/stream.php
+++ b/tests/units/classes/asserters/stream.php
@@ -90,13 +90,4 @@ class stream extends atoum\test
 				->object($asserter->isWrited())->isIdenticalTo($asserter)
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/string.php
+++ b/tests/units/classes/asserters/string.php
@@ -389,13 +389,4 @@ class string extends atoum\test
 					->isEqualTo(strlen($str))
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }

--- a/tests/units/classes/asserters/testedClass.php
+++ b/tests/units/classes/asserters/testedClass.php
@@ -27,13 +27,4 @@ class testedClass extends atoum\test
 					->hasMessage('Unable to call method ' . get_class($asserter) . '::setWith()')
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new asserters\testedClass(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isFalse()
-		;
-	}
 }

--- a/tests/units/classes/asserters/utf8String.php
+++ b/tests/units/classes/asserters/utf8String.php
@@ -412,15 +412,6 @@ class utf8String extends atoum\test
 		;
 	}
 
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
-
 	private function getRandomUtf8String()
 	{
 		$characters = 'àâäéèêëîïôöùüŷÿ';

--- a/tests/units/classes/asserters/variable.php
+++ b/tests/units/classes/asserters/variable.php
@@ -341,13 +341,4 @@ class variable extends atoum\test
 					->hasMessage(sprintf($generator->getLocale()->_('%s is true'), $asserter))
 		;
 	}
-
-	public function testHandleNativeType()
-	{
-		$this
-			->if($asserter = new sut(new atoum\asserter\generator()))
-			->then
-				->boolean($asserter->handleNativeType())->isTrue()
-		;
-	}
 }


### PR DESCRIPTION
Without this patch, it's not possible to write something like:

``` php
$this->in(array(
         0 => array(
            0 => array(
           1 => array('foo', 'bar')
       ),
       1 => array(1, new \mock\object())
         ),
         1 => 'foobar'
      )
   )
)
->then
   ->array[0][0][1]->isEqualTo(array('foo', 'bar'))
;
```
