### PR TITLE
Fix coveralls report test and a typo on the header name

### DIFF
--- a/classes/reports/asynchronous/coveralls.php
+++ b/classes/reports/asynchronous/coveralls.php
@@ -88,7 +88,7 @@ class coveralls extends atoum\reports\asynchronous
 			->setUrl(static::defaultCoverallsApiUrl)
 			->setMethod(static::defaultCoverallsApiMethod)
 			->setParameter(static::defaultCoverallsApiParameter)
-			->addHeader('Content-type', 'multipart/form-data')
+			->addHeader('Content-Type', 'multipart/form-data')
 		;
 
 		return parent::addWriter($writer);

--- a/tests/units/classes/reports/asynchronous/coveralls.php
+++ b/tests/units/classes/reports/asynchronous/coveralls.php
@@ -244,7 +244,7 @@ class coveralls extends atoum\test
 					->call('setUrl')->withArguments(testedClass::defaultCoverallsApiUrl)->once()
 					->call('setMethod')->withArguments(testedClass::defaultCoverallsApiMethod)->once()
 					->call('setParameter')->withArguments(testedClass::defaultCoverallsApiParameter)->once()
-					->call('addHeader')->withArguments('Content-Type', 'multipart/form-data')
+					->call('addHeader')->withArguments('Content-Type', 'multipart/form-data')->once()
 		;
 	}
 }


### PR DESCRIPTION
`Content-Type` header is now compliant to what is described in [RFC2616 ](http://tools.ietf.org/html/rfc2616#page-124)
