### PR TITLE
Exclude namespace method should accept only string

### DIFF
--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -398,6 +398,13 @@ class coverage implements \countable, \serializable
 	public function excludeNamespace($namespace)
 	{
 		$namespace = trim((string) $namespace, '\\');
+		$namespaceRegex = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)*/';
+
+		if (1 !== preg_match($namespaceRegex, $namespace)) {
+			throw new exceptions\runtime\unexpectedValue(
+				sprintf('"%s" is not a valid namespace', $namespace)
+			);
+		}
 
 		if (in_array($namespace, $this->excludedNamespaces) === false)
 		{

--- a/tests/units/classes/score/coverage.php
+++ b/tests/units/classes/score/coverage.php
@@ -245,7 +245,7 @@ class coverage extends atoum\test
 			->and($coverage->setReflectionClassFactory(function() use ($class) { return $class; }))
 			->and($coverage->addXdebugDataForTest($this, $xdebugData))
 			->and($coverage->excludeClass($excludedClass =uniqid()))
-			->and($coverage->excludeNamespace($excludedNamespace= uniqid()))
+			->and($coverage->excludeNamespace($excludedNamespace = 'My\Namespace'))
 			->and($coverage->excludeDirectory($excludedDirectory = uniqid()))
 			->then
 				->array($coverage->getClasses())->isNotEmpty()
@@ -283,7 +283,7 @@ class coverage extends atoum\test
 			->then
 				->object($coverage->resetExcludedNamespaces())->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEmpty()
-			->if($coverage->excludeNamespace(uniqid()))
+			->if($coverage->excludeNamespace('My\Namespace'))
 			->then
 				->object($coverage->resetExcludedNamespaces())->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEmpty()
@@ -1260,14 +1260,22 @@ class coverage extends atoum\test
 		$this
 			->if($coverage = new testedClass())
 			->then
-				->object($coverage->excludeNamespace($namespace = uniqid()))->isIdenticalTo($coverage)
+				->object($coverage->excludeNamespace($namespace = 'My\Namespace'))->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace))
-				->object($coverage->excludeNamespace($otherNamespace = rand(1, PHP_INT_MAX)))->isIdenticalTo($coverage)
-				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, (string) $otherNamespace))
+				->object($coverage->excludeNamespace($otherNamespace = 'My\Other\Namespace'))->isIdenticalTo($coverage)
+				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace))
 				->object($coverage->excludeNamespace($namespace))->isIdenticalTo($coverage)
-				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, (string) $otherNamespace))
-				->object($coverage->excludeNamespace('\\' . ($anotherNamespace = uniqid()) . '\\'))->isIdenticalTo($coverage)
-				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, (string) $otherNamespace, $anotherNamespace))
+				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace))
+				->object($coverage->excludeNamespace('\\' . ($anotherNamespace = 'AnotherNamespace')))->isIdenticalTo($coverage)
+				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace, $anotherNamespace))
+				->exception(function() use ($coverage) {
+					$coverage->excludeNamespace(rand(1, PHP_INT_MAX));
+				})
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+				->exception(function() use ($coverage) {
+					$coverage->excludeNamespace('\0Namespace');
+				})
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
 		;
 	}
 
@@ -1306,7 +1314,7 @@ class coverage extends atoum\test
 			->if($coverage = new testedClass())
 			->then
 				->boolean($coverage->isInExcludedNamespaces(uniqid()))->isFalse()
-			->if($coverage->excludeNamespace($namespace = uniqid()))
+			->if($coverage->excludeNamespace($namespace = 'My\Namespace'))
 			->then
 				->boolean($coverage->isInExcludedNamespaces(uniqid()))->isFalse()
 				->boolean($coverage->isInExcludedNamespaces($namespace . '\\' . uniqid()))->isTrue()


### PR DESCRIPTION
To be sure method "noCodeCoverageForNamespaces" is correctly called by users in their atoum.php we **need** to throw exception if method arguments are not correct.
