### PR TITLE
Exclude namespaces from coverage

### DIFF
--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -406,9 +406,33 @@ class coverage implements \countable, \serializable
 			);
 		}
 
+		$namespaceRegex = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)*/';
+		if (1 !== preg_match($namespaceRegex, $namespace)) {
+			throw new exceptions\runtime\unexpectedValue(sprintf('"%s" is not a valid namespace', $namespace));
+		}
+
 		if (in_array($namespace, $this->excludedNamespaces) === false)
 		{
 			$this->excludedNamespaces[] = $namespace;
+		}
+
+		return $this;
+	}
+
+	public function excludeNamespaces($namespaces)
+	{
+		$namespaces = (array) $namespaces;
+
+		foreach ($namespaces as $namespace)
+		{
+			if (is_array($namespace))
+			{
+				$this->excludeNamespaces($namespace);
+			}
+			else
+			{
+				$this->excludeNamespace($namespace);
+			}
 		}
 
 		return $this;

--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -406,8 +406,8 @@ class coverage implements \countable, \serializable
 			);
 		}
 
-		$namespaceRegex = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)*/';
-		if (1 !== preg_match($namespaceRegex, $namespace)) {
+		$namespaceRegex = '/^\\\?(?<identifier>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:\\\(?1))*/';
+		if (preg_match($namespaceRegex, $namespace) === 0) {
 			throw new exceptions\runtime\unexpectedValue(sprintf('"%s" is not a valid namespace', $namespace));
 		}
 
@@ -419,10 +419,8 @@ class coverage implements \countable, \serializable
 		return $this;
 	}
 
-	public function excludeNamespaces($namespaces)
+	public function excludeNamespaces(array $namespaces)
 	{
-		$namespaces = (array) $namespaces;
-
 		foreach ($namespaces as $namespace)
 		{
 			if (is_array($namespace))

--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -398,6 +398,13 @@ class coverage implements \countable, \serializable
 	public function excludeNamespace($namespace)
 	{
 		$namespace = trim((string) $namespace, '\\');
+		$namespaceRegex = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)*/';
+
+		if (1 !== preg_match($namespaceRegex, $namespace)) {
+			throw new exceptions\runtime\unexpectedValue(
+				sprintf('"%s" is not a valid namespace', $namespace)
+			);
+		}
 
 		if (in_array($namespace, $this->excludedNamespaces) === false)
 		{

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -697,7 +697,7 @@ class runner extends atoum\script\configurable
 							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
 						}
 
-						$script->excludeNamespacesFromCoverage($namespaces);
+						$script->getRunner()->getCoverage()->excludeNamespaces($namespaces);
 					},
 					array('-nccfns', '--no-code-coverage-for-namespaces'),
 					'<namespace>...',

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -697,7 +697,7 @@ class runner extends atoum\script\configurable
 							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
 						}
 
-						$script->getRunner()->getCoverage()->excludeNamespaces((array) $namespaces);
+						$script->excludeNamespacesFromCoverage($namespaces);
 					},
 					array('-nccfns', '--no-code-coverage-for-namespaces'),
 					'<namespace>...',

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -697,7 +697,7 @@ class runner extends atoum\script\configurable
 							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
 						}
 
-						$script->getRunner()->getCoverage()->excludeNamespaces($namespaces);
+						$script->getRunner()->getCoverage()->excludeNamespaces((array) $namespaces);
 					},
 					array('-nccfns', '--no-code-coverage-for-namespaces'),
 					'<namespace>...',

--- a/tests/units/classes/score/coverage.php
+++ b/tests/units/classes/score/coverage.php
@@ -1268,14 +1268,16 @@ class coverage extends atoum\test
 				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace))
 				->object($coverage->excludeNamespace('\\' . ($anotherNamespace = 'AnotherNamespace')))->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace, $anotherNamespace))
-				->exception(function() use ($coverage) {
-					$coverage->excludeNamespace(rand(1, PHP_INT_MAX));
+				->exception(function() use ($coverage, & $namespace) {
+					$coverage->excludeNamespace($namespace = rand(1, PHP_INT_MAX));
 				})
 					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
-				->exception(function() use ($coverage) {
-					$coverage->excludeNamespace('\0Namespace');
+					->hasMessage(sprintf('"%s" is not a valid namespace', $namespace))
+				->exception(function() use ($coverage, & $namespace) {
+					$coverage->excludeNamespace($namespace = '\0Namespace');
 				})
 					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+					->hasMessage(sprintf('"%s" is not a valid namespace', trim($namespace, '\\')))
 		;
 	}
 

--- a/tests/units/classes/score/coverage.php
+++ b/tests/units/classes/score/coverage.php
@@ -245,7 +245,7 @@ class coverage extends atoum\test
 			->and($coverage->setReflectionClassFactory(function() use ($class) { return $class; }))
 			->and($coverage->addXdebugDataForTest($this, $xdebugData))
 			->and($coverage->excludeClass($excludedClass =uniqid()))
-			->and($coverage->excludeNamespace($excludedNamespace= uniqid()))
+			->and($coverage->excludeNamespace($excludedNamespace = 'My\Namespace'))
 			->and($coverage->excludeDirectory($excludedDirectory = uniqid()))
 			->then
 				->array($coverage->getClasses())->isNotEmpty()
@@ -283,7 +283,7 @@ class coverage extends atoum\test
 			->then
 				->object($coverage->resetExcludedNamespaces())->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEmpty()
-			->if($coverage->excludeNamespace(uniqid()))
+			->if($coverage->excludeNamespace('My\Namespace'))
 			->then
 				->object($coverage->resetExcludedNamespaces())->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEmpty()
@@ -1260,14 +1260,22 @@ class coverage extends atoum\test
 		$this
 			->if($coverage = new testedClass())
 			->then
-				->object($coverage->excludeNamespace($namespace = uniqid()))->isIdenticalTo($coverage)
+				->object($coverage->excludeNamespace($namespace = 'My\Namespace'))->isIdenticalTo($coverage)
 				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace))
-				->object($coverage->excludeNamespace($otherNamespace = rand(1, PHP_INT_MAX)))->isIdenticalTo($coverage)
-				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, (string) $otherNamespace))
+				->object($coverage->excludeNamespace($otherNamespace = 'My\Other\Namespace'))->isIdenticalTo($coverage)
+				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace))
 				->object($coverage->excludeNamespace($namespace))->isIdenticalTo($coverage)
-				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, (string) $otherNamespace))
-				->object($coverage->excludeNamespace('\\' . ($anotherNamespace = uniqid()) . '\\'))->isIdenticalTo($coverage)
-				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, (string) $otherNamespace, $anotherNamespace))
+				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace))
+				->object($coverage->excludeNamespace('\\' . ($anotherNamespace = 'AnotherNamespace')))->isIdenticalTo($coverage)
+				->array($coverage->getExcludedNamespaces())->isEqualTo(array($namespace, $otherNamespace, $anotherNamespace))
+				->exception(function() use ($coverage) {
+					$coverage->excludeNamespace(rand(1, PHP_INT_MAX));
+				})
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
+				->exception(function() use ($coverage) {
+					$coverage->excludeNamespace('\0Namespace');
+				})
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime\unexpectedValue')
 		;
 	}
 
@@ -1306,7 +1314,7 @@ class coverage extends atoum\test
 			->if($coverage = new testedClass())
 			->then
 				->boolean($coverage->isInExcludedNamespaces(uniqid()))->isFalse()
-			->if($coverage->excludeNamespace($namespace = uniqid()))
+			->if($coverage->excludeNamespace($namespace = 'My\Namespace'))
 			->then
 				->boolean($coverage->isInExcludedNamespaces(uniqid()))->isFalse()
 				->boolean($coverage->isInExcludedNamespaces($namespace . '\\' . uniqid()))->isTrue()

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -903,7 +903,15 @@ class runner extends atoum\test
 					->call('excludeNamespace')->withArguments($namespace)->once()
 				->object($configurator->noCodeCoverageForNamespaces($namespace = '\A' . uniqid()))->isIdenticalTo($configurator)
 			->if($this->resetMock($coverage))
+			->then
 				->object($configurator->noCodeCoverageForNamespaces(array($namespace, $otherNamespace = 'A' . uniqid())))->isIdenticalTo($configurator)
+				->mock($coverage)
+					->call('excludeNamespace')
+						->withArguments($namespace)->once()
+						->withArguments($otherNamespace)->once()
+			->if($this->resetMock($coverage))
+			->then
+				->object($configurator->noCodeCoverageForNamespaces($namespace, $otherNamespace))->isIdenticalTo($configurator)
 				->mock($coverage)
 					->call('excludeNamespace')
 						->withArguments($namespace)->once()


### PR DESCRIPTION
Only a merged/rebased version of the work done on atoum/atoum#290

Tested with the following configuration file:

``` php
<?php

$script
    ->noCodeCoverageForNamespaces('mageekguy\atoum\cli')
    ->noCodeCoverageForNamespaces(array('mageekguy\atoum\fs', 'mageekguy\atoum\iterators\filters'))
;
```

and running the following command:

``` sh
$ bin/atoum -d tests/units/classes/cli tests/units/classes/iterators tests/units/classes/fs
```

atoum only reports coverage on `mageekguy\atoum\iterators\recursives` which is what I expect.
