### PR TITLE
Add a test factory to atoum's runner

### DIFF
--- a/classes/runner.php
+++ b/classes/runner.php
@@ -23,6 +23,7 @@ class runner implements observable
 	protected $testGenerator = null;
 	protected $globIteratorFactory = null;
 	protected $reflectionClassFactory = null;
+	protected $testFactory = null;
 	protected $observers = null;
 	protected $reports = null;
 	protected $reportSet = null;
@@ -53,6 +54,7 @@ class runner implements observable
 			->setTestDirectoryIterator()
 			->setGlobIteratorFactory()
 			->setReflectionClassFactory()
+			->setTestFactory()
 		;
 
 		$this->observers = new \splObjectStorage();
@@ -374,6 +376,20 @@ class runner implements observable
 		return $this;
 	}
 
+	public function getTestFactory()
+	{
+		return $this->testFactory;
+	}
+
+	public function setTestFactory($testFactory = null)
+	{
+		$this->testFactory = $testFactory ?: function($testClass) {
+			return new $testClass();
+		};
+
+		return $this;
+	}
+
 	public function run(array $namespaces = array(), array $tags = array(), array $runTestClasses = array(), array $runTestMethods = array(), $testBaseClass = null)
 	{
 		$this->includeTestPaths();
@@ -415,7 +431,7 @@ class runner implements observable
 
 		foreach ($runTestClasses as $runTestClass)
 		{
-			$test = new $runTestClass();
+			$test = call_user_func($this->testFactory, $runTestClass);
 
 			if (static::isIgnored($test, $namespaces, $tags) === false && ($methods = self::getMethods($test, $runTestMethods, $tags)))
 			{

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -40,6 +40,8 @@ class runner extends atoum\test
 				->object($defaultGlobIteratorFactory($pattern = uniqid()))->isEqualTo(new \globIterator($pattern))
 				->object($defaultReflectionClassFactory = $runner->getReflectionClassFactory())->isInstanceOf('closure')
 				->object($defaultReflectionClassFactory($this))->isEqualTo(new \reflectionClass($this))
+				->object($defaultTestFactory = $runner->getTestFactory())->isInstanceOf('closure')
+				->object($defaultTestFactory(__CLASS__))->isInstanceOf($this)
 				->variable($runner->getRunningDuration())->isNull()
 				->boolean($runner->codeCoverageIsEnabled())->isTrue()
 				->variable($runner->getDefaultReportTitle())->isNull()


### PR DESCRIPTION
With this patch, tests are not anymore directly instanciated in runner.

It now uses a tiny factory in the form of a simple closure which has to return the test instance.
This allows us to be a bit more flexible when extending atoum.

For example, in the AtoumBundle, to resolve the atoum/AtoumBundle#46, we have to inject a parameter coming from the command line or the Symfony configuration to the test instance.

To do that, I overrode atoum's runner, adding the method require in my own runner class to store the parameter. But then, I could not pass it to the tests without copying much code from the original runner.

Here is a quick example on how it is implemented:

``` php
<?php
namespace atoum\AtoumBundle\Scripts;

class Runner extends atoum\scripts\runner
{
    public function setRunner(atoum\runner $runner = null)
    {
        return parent::setRunner($runner)->setTestFactory();
    }

    public function setTestFactory(\Closure $factory = null)
    {
        $this->runner->setTestFactory($factory ?: $this->getDefaultTestFactory());

        return $this;
    }

    public function getDefaultTestFactory()
    {
        return function($testClass) use ($self) {
            $test = new $testClass();

            if ($test instanceof WebTestCase) {
                $test->setKernelEnvironment($self->getEnvironment());
            }

            return $test;
        };
    }

    //...
}
```

_See atoum/AtoumBundle#46 on atoum/AtoumBundle for the full implementation_

With this implementation, I can easily make my own initialization on tests instances.
