### PR TITLE
Improve coverage templates

### DIFF
--- a/resources/templates/coverage/class.tpl
+++ b/resources/templates/coverage/class.tpl
@@ -9,7 +9,7 @@
 	</head>
 	<body>
 		<div id="header">
-			<h1>Code coverage of <a href="<tpl:relativeRootUrl />"><tpl:projectName /></a>: <tpl:className /></h1>
+			<h1>Code coverage of <a href="<tpl:relativeRootUrl />index.html"><tpl:projectName /></a>: <tpl:className /></h1>
 			<h2>Class code coverage <span><tpl:classCoverageUnavailable>n/a</tpl:classCoverageUnavailable><tpl:classCoverageAvailable><tpl:classCoverageValue />%</tpl:classCoverageAvailable></span></h2>
 		</div>
 		<div id="page">
@@ -26,7 +26,10 @@
 									<div class="bar">
 										<div class="background"></div>
 										<div class="graph" style="width: <tpl:methodCoverageValue />%"></div>
-										<div class="label"><a href="#<tpl:methodName />"><tpl:methodName /></a> <span><tpl:methodCoverageValue />%</span></div>
+										<div class="label">
+											<span class="percent"><tpl:methodCoverageValue />%</span>
+											<a href="#<tpl:methodName />"><tpl:methodName /></a>
+										</div>
 									</div>
 								</tpl:methodCoverageAvailable>
 							</li>

--- a/resources/templates/coverage/index.tpl
+++ b/resources/templates/coverage/index.tpl
@@ -33,7 +33,10 @@
 							<div class="bar">
 								<div class="background"></div>
 								<div class="graph" style="width: <tpl:classCoverageValue />%"></div>
-								<div class="label"><a href="<tpl:classUrl />"><tpl:className /></a> <span><tpl:classCoverageValue />%</span></div>
+								<div class="label">
+									<span class="percent"><tpl:classCoverageValue />%</span>
+									<a href="<tpl:classUrl />"><tpl:className /></a>
+								</div>
 							</div>
 							</tpl:classCoverageAvailable>
 						</li>

--- a/resources/templates/coverage/screen.css
+++ b/resources/templates/coverage/screen.css
@@ -11,26 +11,28 @@ a:hover {color: #3d91e7;}
 h1 {font-size: 18px; font-weight: bold; margin: 0.5em 0; color: #fff; float: left;}
 h2 {font-size: 14px; font-weight: bold; margin: 2.5em 0 0.5em 0; color: #fff; float: right;}
 h2 span {font-size: 30px;}
-h3 {font-size: 1.2em; margin: 0.5em 0;}
+h3 {font-size: 1.2em; margin: 1em 0 0.5em 0;}
 #page, #footer {margin: 2em;}
 #footer {text-align: right; color:#74bff9;}
-.summary {margin: 1em 0 0 0; border: solid 1px #ddd;}
-table {width: 100%; border-collapse: collapse; table-layout: fixed;}
+.summary {margin: 1em 0 0 0;}
+table {width: 100%; border-collapse: collapse; table-layout: fixed; box-shadow: 2px 2px 5px gray;}
 th, td {padding: 0.2em; border: solid 1px #eee;}
 th {color: #fff; background: #3d91e7;}
 td.bar {padding: 0.2em;}
 td.date {text-align: right;}
-div.bar {position: relative; width: 100%; height: 30px; padding: 0;}
+div.bar {position: relative; width: 100%; height: 2em; padding: 0;}
 div.bar div.label {position: absolute; top: 0; left: 0; background: none; padding: 6px 0 2px 4px;}
-div.bar div.graph {position: absolute; top: 0; left: 0; background: #8eff9b; height: 30px;}
-div.bar div.background {position: absolute; top: 0; left: 0; width: 100%; background: #ff8c76; height: 30px;}
-li {list-style-type: none; border: solid 1px #eee; border-left: none; border-top: none;}
+div.bar div.label .percent {width: 3em; text-align: right; display: inline-block;}
+div.bar div.graph {position: absolute; top: 0; left: 0; background: #8eff9b; height: 100%;}
+div.bar div.background {position: absolute; top: 0; left: 0; width: 100%; background: #ff8c76; height: 100%;}
+li {list-style-type: none; border: solid 1px #fff; box-shadow: 2px 2px 5px gray; margin-bottom: 1px;}
 li.classes, li.methods {margin-left: 4em;}
 table.source th.number {width: 4em;}
 table.source td {overflow: hidden; width: 100%;}
-table.source td.number {width: 4em; text-align: right; background: #ddd;}
+table.source td.number {padding: 0 10px; text-align: right; background: #c4e5ff; font-family: monospace;}
 table.source tr.notCovered td {background: #ff8c76;}
 table.source tr.covered td {background: #8eff9b;}
+table.source pre {font-family: monospace;}
 @media (max-width: 900px) {
     h1 {clear: both;}
     h2 span {font-size: 20px;}


### PR DESCRIPTION
- Force index.html url (usefull for access with file:///local/path/to/coverage type of access)
- Switch percent and class name to have percents aligned and improve human comparaison
- Add monospace font to file listing
- Update CSS

![code coverage of duplic at](https://cloud.githubusercontent.com/assets/932553/2561000/6211b404-b7f5-11e3-8fa4-5945d5e3b6f1.png)

![duplic at code coverage of duplicat backuper](https://cloud.githubusercontent.com/assets/932553/2560999/53878364-b7f5-11e3-84d0-40757bf2780a.png)
