### PR TITLE
Extension API

### DIFF
--- a/classes/extension.php
+++ b/classes/extension.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace mageekguy\atoum;
+
+interface extension extends observer
+{
+	public function setRunner(runner $runner);
+	public function setTest(test $test);
+}

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -41,6 +41,7 @@ class runner implements observable
 	protected $failIfVoidMethods = false;
 	protected $failIfSkippedMethods = false;
 	protected $disallowUndefinedMethodInInterface = false;
+	protected $extensions = null;
 
 	private $start = null;
 	private $stop = null;
@@ -62,6 +63,7 @@ class runner implements observable
 
 		$this->observers = new \splObjectStorage();
 		$this->reports = new \splObjectStorage();
+		$this->extensions = new \splObjectStorage();
 	}
 
 	public function setAdapter(adapter $adapter = null)
@@ -511,6 +513,7 @@ class runner implements observable
 				if ($testMethodNumber > 0)
 				{
 					$tests[] = $test;
+					$test->addExtensions($this->extensions);
 
 					$this->testNumber++;
 					$this->testMethodNumber += $testMethodNumber;
@@ -748,6 +751,45 @@ class runner implements observable
 		}
 
 		return $reports;
+	}
+
+	public function getExtensions()
+	{
+		return iterator_to_array($this->extensions);
+	}
+
+	public function removeExtension(atoum\extension $extension)
+	{
+		$this->extensions->detach($extension);
+
+		return $this->removeObserver($extension);
+	}
+
+	public function removeExtensions()
+	{
+		foreach ($this->extensions as $extension)
+		{
+			$this->removeObserver($extension);
+		}
+
+		$this->extensions = new \splObjectStorage();
+
+		return $this;
+	}
+
+
+	public function addExtension(atoum\extension $extension)
+	{
+		if ($this->extensions->contains($extension) === false)
+		{
+			$extension->setRunner($this);
+
+			$this->extensions->attach($extension);
+
+			$this->addObserver($extension);
+		}
+
+		return $this;
 	}
 
 	public static function isIgnored(test $test, array $namespaces, array $tags)

--- a/classes/test.php
+++ b/classes/test.php
@@ -3,6 +3,7 @@
 namespace mageekguy\atoum;
 
 use
+	mageekguy\atoum,
 	mageekguy\atoum\test,
 	mageekguy\atoum\mock,
 	mageekguy\atoum\asserter,
@@ -60,7 +61,7 @@ abstract class test implements observable, \countable
 	private $path = '';
 	private $class = '';
 	private $classNamespace = '';
-	private $observers = array();
+	private $observers = null;
 	private $tags = array();
 	private $phpVersions = array();
 	private $mandatoryExtensions = array();
@@ -76,6 +77,7 @@ abstract class test implements observable, \countable
 	private $xdebugConfig = null;
 	private $codeCoverage = false;
 	private $classHasNotVoidMethods = false;
+	private $extensions = null;
 
 	private static $namespace = null;
 	private static $methodPrefix = null;
@@ -98,6 +100,9 @@ abstract class test implements observable, \countable
 			->setAsserterCallManager()
 			->enableCodeCoverage()
 		;
+
+		$this->observers = new \splObjectStorage();
+		$this->extensions = new \splObjectStorage();
 
 		$class = ($reflectionClassFactory ? $reflectionClassFactory($this) : new \reflectionClass($this));
 
@@ -892,9 +897,21 @@ abstract class test implements observable, \countable
 
 	public function addObserver(observer $observer)
 	{
-		$this->observers[] = $observer;
+		$this->observers->attach($observer);
 
 		return $this;
+	}
+
+	public function removeObserver(atoum\observer $observer)
+	{
+		$this->observers->detach($observer);
+
+		return $this;
+	}
+
+	public function getObservers()
+	{
+		return iterator_to_array($this->observers);
 	}
 
 	public function callObservers($event)
@@ -1356,7 +1373,7 @@ abstract class test implements observable, \countable
 
 	public static function getNamespace()
 	{
-		return self::$namespace ?: self::defaultNamespace;
+		return self::$namespace ?: static::defaultNamespace;
 	}
 
 	public static function setMethodPrefix($methodPrefix)
@@ -1371,7 +1388,7 @@ abstract class test implements observable, \countable
 
 	public static function getMethodPrefix()
 	{
-		return self::$methodPrefix ?: self::defaultMethodPrefix;
+		return self::$methodPrefix ?: static::defaultMethodPrefix;
 	}
 
 	public static function setDefaultEngine($defaultEngine)
@@ -1703,6 +1720,55 @@ abstract class test implements observable, \countable
 		$this->callObservers(self::beforeTearDown);
 		$this->tearDown();
 		$this->callObservers(self::afterTearDown);
+
+		return $this;
+	}
+
+	public function getExtensions()
+	{
+		return iterator_to_array($this->extensions);
+	}
+
+	public function removeExtension(atoum\extension $extension)
+	{
+		$this->extensions->detach($extension);
+
+		return $this->removeObserver($extension);;
+	}
+
+	public function removeExtensions()
+	{
+		foreach ($this->extensions as $extension)
+		{
+			$this->removeObserver($extension);
+		}
+
+		$this->extensions = new \splObjectStorage();
+
+		return $this;
+	}
+
+
+	public function addExtension(atoum\extension $extension)
+	{
+		if ($this->extensions->contains($extension) === false)
+		{
+			$extension->setTest($this);
+
+			$this->extensions->attach($extension);
+
+			$this->addObserver($extension);
+		}
+
+		return $this;
+	}
+
+	public function addExtensions(\traversable $extensions)
+	{
+		foreach ($extensions as $extension)
+		{
+			$this->addExtension($extension);
+		}
 
 		return $this;
 	}

--- a/classes/test/engines/concurrent.php
+++ b/classes/test/engines/concurrent.php
@@ -127,6 +127,11 @@ class concurrent extends test\engine
 				$phpCode .= '$test->getMockGenerator()->disallowUndefinedMethodInInterface();';
 			}
 
+			foreach ($test->getExtensions() as $extension)
+			{
+				$phpCode .= '$test->addExtension(new ' . get_class($extension) . ');';
+			}
+
 			$phpCode .=
 				'ob_end_clean();' .
 				'mageekguy\atoum\scripts\runner::disableAutorun();' .

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -445,6 +445,76 @@ class runner extends atoum\test
 		;
 	}
 
+	public function testAddExtension()
+	{
+		$this
+			->if($runner = new testedClass())
+			->then
+				->object($runner->addExtension($extension = new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEqualTo(array($extension))
+				->array($runner->getObservers())->contains($extension)
+				->mock($extension)
+					->call('setRunner')->withArguments($runner)->once()
+			->if($this->resetMock($extension))
+			->then
+				->object($runner->addExtension($extension))->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEqualTo(array($extension))
+				->array($runner->getObservers())->contains($extension)
+				->mock($extension)
+					->call('setRunner')->never();
+		;
+	}
+
+	public function testRemoveExtension()
+	{
+		$this
+			->if($runner = new testedClass())
+			->then
+				->array($runner->getExtensions())->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+			->if($extension = new \mock\mageekguy\atoum\extension())
+			->and($otherExtension = new \mock\mageekguy\atoum\extension())
+			->and($runner->addExtension($extension)->addExtension($otherExtension))
+			->then
+				->array($runner->getExtensions())->isEqualTo(array($extension, $otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
+				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEqualTo(array($extension, $otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
+				->object($runner->removeExtension($extension))->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEqualTo(array($otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+				->object($runner->removeExtension($otherExtension))->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+		;
+	}
+
+	public function testRemoveExtensions()
+	{
+		$this
+			->if($runner = new testedClass())
+			->then
+				->array($runner->getExtensions())->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+				->object($runner->removeExtensions())->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+			->if($extension = new \mock\mageekguy\atoum\extension())
+			->and($otherExtension = new \mock\mageekguy\atoum\extension())
+			->and($runner->addExtension($extension)->addExtension($otherExtension))
+			->then
+				->array($runner->getExtensions())->isEqualTo(array($extension, $otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
+				->object($runner->removeExtensions())->isIdenticalTo($runner)
+				->array($runner->getExtensions())->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+		;
+	}
+
 	public function testEnableCodeCoverage()
 	{
 		$this

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -1014,5 +1014,75 @@ namespace mageekguy\atoum\tests\units
 					->string(atoum\test::getTestedClassNameFromTestClass('foo\bar\aaa\bbb\testedClass', '#(?:^|\\\)aaas?\\\bbbs?\\\#i'))->isEqualTo('foo\bar\testedClass')
 			;
 		}
+
+		public function testAddExtension()
+		{
+			$this
+				->if($test = new emptyTest())
+				->then
+					->object($test->addExtension($extension = new \mock\mageekguy\atoum\extension()))->isIdenticalTo($test)
+					->array($test->getExtensions())->isEqualTo(array($extension))
+					->array($test->getObservers())->contains($extension)
+					->mock($extension)
+						->call('setTest')->withArguments($test)->once()
+				->if($this->resetMock($extension))
+				->then
+					->object($test->addExtension($extension))->isIdenticalTo($test)
+					->array($test->getExtensions())->isEqualTo(array($extension))
+					->array($test->getObservers())->contains($extension)
+					->mock($extension)
+						->call('setTest')->never();
+			;
+		}
+
+		public function testRemoveExtension()
+		{
+			$this
+				->if($test = new emptyTest())
+				->then
+					->array($test->getExtensions())->isEmpty()
+					->array($test->getObservers())->isEmpty()
+					->object($test->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($test)
+					->array($test->getExtensions())->isEmpty()
+					->array($test->getObservers())->isEmpty()
+				->if($extension = new \mock\mageekguy\atoum\extension())
+				->and($otherExtension = new \mock\mageekguy\atoum\extension())
+				->and($test->addExtension($extension)->addExtension($otherExtension))
+				->then
+					->array($test->getExtensions())->isEqualTo(array($extension, $otherExtension))
+					->array($test->getObservers())->isEqualTo(array($extension, $otherExtension))
+					->object($test->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($test)
+					->array($test->getExtensions())->isEqualTo(array($extension, $otherExtension))
+					->array($test->getObservers())->isEqualTo(array($extension, $otherExtension))
+					->object($test->removeExtension($extension))->isIdenticalTo($test)
+					->array($test->getExtensions())->isEqualTo(array($otherExtension))
+					->array($test->getObservers())->isEqualTo(array($otherExtension))
+					->object($test->removeExtension($otherExtension))->isIdenticalTo($test)
+					->array($test->getExtensions())->isEmpty()
+					->array($test->getObservers())->isEmpty()
+			;
+		}
+
+		public function testRemoveExtensions()
+		{
+			$this
+				->if($test = new emptyTest())
+				->then
+					->array($test->getExtensions())->isEmpty()
+					->array($test->getObservers())->isEmpty()
+					->object($test->removeExtensions())->isIdenticalTo($test)
+					->array($test->getExtensions())->isEmpty()
+					->array($test->getObservers())->isEmpty()
+				->if($extension = new \mock\mageekguy\atoum\extension())
+				->and($otherExtension = new \mock\mageekguy\atoum\extension())
+				->and($test->addExtension($extension)->addExtension($otherExtension))
+				->then
+					->array($test->getExtensions())->isEqualTo(array($extension, $otherExtension))
+					->array($test->getObservers())->isEqualTo(array($extension, $otherExtension))
+					->object($test->removeExtensions())->isIdenticalTo($test)
+					->array($test->getExtensions())->isEmpty()
+					->array($test->getObservers())->isEmpty()
+			;
+		}
 	}
 }


### PR DESCRIPTION
Following https://github.com/atoum/atoum/pull/327 : relocated the source branch.
## atoum extensions

This branch provides an interface to allow users/contributors to write their own extensions, and add some awesome features to atoum dynamically. Here is the roadmap I propose to get this branch merged:
- [x] make it mergeable
- [x] review code and clean it
- [x] review extensions
- [x] move some of them to the org
- [x] write a blog post somewhere
## What we get now?

There already are some extensions ready:
### [atoum-visibility-extension](https://github.com/jubianchi/atoum-visibility-extension)

Allows user to test hidden (protected/private) methods.

``` php
<?php

namespace tests\units
{
    use mageekguy\atoum;
    class foo extends atoum\test
    {
        public function testBar()
        {
            $this
                ->if($sut = new \foo())
                ->then
                    ->object($this->invoke($sut)->bar())->isIdenticalTo($sut)
                    ->array($this->invoke($sut)->bar($a = uniqid(), $b = uniqid()))->isIdenticalTo(array($a, $b))
                                        //->string($this->invoke('bar')->foo())->isEqualTo('bar::foo')
                ->given(
                    $this->mockGenerator
                        ->makeVisible('bar')
                        ->generate('foo')
                )
                ->if($mockedSut = new \mock\foo)
                ->and($this->calling($mockedSut)->bar = 'foo')
                ->then
                    ->string($mockedSut->baz())->isEqualTo('foo')
                    ->mock($mockedSut)
                        ->call('bar')->once()
            ;
        }
    }
}
```
### [jubianchi/atoum-bdd-extension](https://github.com/jubianchi/atoum-bdd-extension)

Allows users to write their tests in a Spec/BDD style and produce formatted reports:

``` php
<?php
namespace jubianchi\example\specs;

use atoum;
use jubianchi\example\formatter as testedClass;

class formatter extends atoum\spec
{
    public function should_format_underscore_separated_method_name()
    {
        $this
            ->given($formatter = new testedClass())
            ->then
                ->invoking->format(__FUNCTION__)->on($formatter)
                    ->shouldReturn('should format underscore separated method name')
        ;
    }
}
```

![atoum_bdd](https://cloud.githubusercontent.com/assets/327237/4967400/28cfc6fc-680f-11e4-9446-ee67eda69622.png)
### [jubianchi/atoum-json-schema-extension](https://github.com/jubianchi/atoum-json-schema-extension)

Allows user to validate JSON against a schema
### [hoaproject/Contributions-Atoum-PraspelExtension](https://github.com/hoaproject/Contributions-Atoum-PraspelExtension)

Integrates Praspel in atoum
