### PR TITLE
Add a coverge script to run tests and produce coverage reports

### DIFF
--- a/classes/scripts/coverage.php
+++ b/classes/scripts/coverage.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace mageekguy\atoum\scripts;
+
+require_once __DIR__ . '/../../constants.php';
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\cli,
+	mageekguy\atoum\php,
+	mageekguy\atoum\writers,
+	mageekguy\atoum\exceptions
+;
+
+class coverage extends runner
+{
+	const defaultReportFormat = 'xml';
+
+	protected $reportOutputPath;
+	protected $reportFormat;
+
+	public function __construct($name, atoum\adapter $adapter = null)
+	{
+		parent::__construct($name, $adapter);
+
+		$this->setReportFormat();
+	}
+
+	protected function doRun()
+	{
+		if (sizeof($this->getReports()) === 0)
+		{
+			$this->addDefaultReport();
+		}
+
+		switch ($this->reportFormat)
+		{
+			case 'xml':
+			case 'clover':
+				$writer = new atoum\writers\file($this->reportOutputPathIsSet()->reportOutputPath);
+				$report = new atoum\reports\asynchronous\clover();
+				$this->addReport($report->addWriter($writer));
+				break;
+
+			case 'html':
+				$field = new atoum\report\fields\runner\coverage\html('Code coverage', $this->reportOutputPathIsSet()->reportOutputPath);
+				$field->setRootUrl('file://' . realpath(rtrim($this->reportOutputPathIsSet()->reportOutputPath, DIRECTORY_SEPARATOR)) . '/index.html');
+				current($this->getReports())->addField($field);
+				break;
+
+			case 'treemap':
+				$field = new atoum\report\fields\runner\coverage\treemap('Code coverage treemap', $this->reportOutputPathIsSet()->reportOutputPath);
+				$field->setTreemapUrl('file://' . realpath(rtrim($this->reportOutputPathIsSet()->reportOutputPath, DIRECTORY_SEPARATOR)) . '/index.html');
+				current($this->getReports())->addField($field);
+				break;
+
+			default:
+				throw new exceptions\logic\invalidArgument('Invalid format for coverage report');
+		}
+
+		return parent::doRun();
+	}
+
+	public function setReportFormat($format = null)
+	{
+		$this->reportFormat = $format ?: self::defaultReportFormat;
+
+		return $this;
+	}
+
+	public function getReportFormat()
+	{
+		return $this->reportFormat;
+	}
+
+	public function setReportOutputPath($path)
+	{
+		$this->reportOutputPath = $path;
+
+		return $this;
+	}
+
+	protected function reportOutputPathIsSet()
+	{
+		if ($this->reportOutputPath === null)
+		{
+			throw new exceptions\runtime('Coverage report output path is not set');
+		}
+
+		return $this;
+	}
+
+	protected function setArgumentHandlers()
+	{
+		return parent::setArgumentHandlers()
+			->addArgumentHandler(
+					function($script, $argument, $values) {
+						if (sizeof($values) === 0)
+						{
+							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
+						}
+
+						$script->setReportFormat(current($values));
+					},
+					array('-fmt', '--format'),
+					'<xml|clover|html|treemap>',
+					$this->locale->_('Coverage report format')
+				)
+			->addArgumentHandler(
+					function($script, $argument, $values) {
+						if (sizeof($values) === 0)
+						{
+							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
+						}
+
+						$script->setReportOutputPath(current($values));
+					},
+					array('-o', '--output'),
+					'<path/to/file/or/directory>',
+					$this->locale->_('Coverage report output path')
+				)
+		;
+	}
+}

--- a/scripts/coverage.php
+++ b/scripts/coverage.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace mageekguy\atoum;
+
+use mageekguy\atoum\scripts;
+
+require_once __DIR__ . '/../classes/autoloader.php';
+
+if (defined(__NAMESPACE__ . '\scripts\coverage') === false)
+{
+	define(__NAMESPACE__ . '\scripts\coverage', defined('atoum\scripts\coverage') === false ? __FILE__ : \atoum\scripts\coverage);
+}
+
+if (scripts\coverage::autorunMustBeEnabled() === true)
+{
+	scripts\coverage::enableAutorun(constant(__NAMESPACE__ . '\scripts\coverage'));
+}

--- a/tests/units/classes/scripts/coverage.php
+++ b/tests/units/classes/scripts/coverage.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\scripts;
+
+use
+	mageekguy\atoum
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class coverage extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass
+				->extends('mageekguy\atoum\scripts\runner');
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($this->newTestedInstance($name = uniqid()))
+			->then
+				->boolean($this->testedInstance->hasDefaultArguments())->isFalse()
+				->array($this->testedInstance->getDefaultArguments())->isEmpty()
+				->string($this->testedInstance->getName())->isEqualTo($name)
+				->string($this->testedInstance->getReportFormat())->isEqualTo('xml')
+				->object($this->testedInstance->getAdapter())->isInstanceOf('mageekguy\atoum\adapter')
+				->object($this->testedInstance->getLocale())->isInstanceOf('mageekguy\atoum\locale')
+				->object($this->testedInstance->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
+				->object($this->testedInstance->getRunner())->isInstanceOf('mageekguy\atoum\runner')
+				->variable($this->testedInstance->getScoreFile())->isNull()
+				->array($this->testedInstance->getReports())->isEmpty()
+				->array($this->testedInstance->getArguments())->isEmpty()
+				->array($this->testedInstance->getHelp())->isEqualTo(array(
+						array(
+							array('-h', '--help'),
+							null,
+							'Display this help'
+						),
+						array(
+							array('-c', '--configurations'),
+							'<file>...',
+							'Use all configuration files <file>'
+						),
+						array(
+							array('-v', '--version'),
+							null,
+							'Display version'
+						),
+						array(
+							array('+verbose', '++verbose'),
+							null,
+							'Enable verbose mode'
+						),
+						array(
+							array('--init'),
+							null,
+							'Create configuration and bootstrap files in the current directory'
+						),
+						array(
+							array('-p', '--php'),
+							'<path/to/php/binary>',
+							'Path to PHP binary which must be used to run tests'
+						),
+						array(
+							array('-drt', '--default-report-title'),
+							'<string>',
+							'Define default report title with <string>'
+						),
+						array(
+							array('-sf', '--score-file'),
+							'<file>',
+							'Save score in file <file>'
+						),
+						array(
+							array('-mcn', '--max-children-number'),
+							'<integer>',
+							'Maximum number of sub-processus which will be run simultaneously'
+						),
+						array(
+							array('-ncc', '--no-code-coverage'),
+							null,
+							'Disable code coverage'
+						),
+						array(
+							array('-nccid', '--no-code-coverage-in-directories'),
+							'<directory>...',
+							'Disable code coverage in directories <directory>'
+						),
+						array(
+							array('-nccfns', '--no-code-coverage-for-namespaces'),
+							'<namespace>...',
+							'Disable code coverage for namespaces <namespace>'
+						),
+						array(
+							array('-nccfc', '--no-code-coverage-for-classes'),
+							'<class>...',
+							'Disable code coverage for classes <class>'
+						),
+						array(
+							array('-f', '--files'),
+							'<file>...',
+							'Execute all unit test files <file>'
+						),
+						array(
+							array('-d', '--directories'),
+							'<directory>...',
+							'Execute unit test files in all <directory>'
+						),
+						array(
+							array('-tfe', '--test-file-extensions'),
+							'<extension>...',
+							'Execute unit test files with one of extensions <extension>'
+						),
+						array(
+							array('-g', '--glob'),
+							'<pattern>...',
+							'Execute unit test files which match <pattern>'
+						),
+						array(
+							array('-t', '--tags'),
+							'<tag>...',
+							'Execute only unit test with tags <tag>'
+						),
+						array(
+							array('-m', '--methods'),
+							'<class::method>...',
+							'Execute all <class::method>, * may be used as wildcard for class name or method name'
+						),
+						array(
+							array('-ns', '--namespaces'),
+							'<namespace>...',
+							'Execute all classes in all namespaces <namespace>'
+						),
+						array(
+							array('-l', '--loop'),
+							null,
+							'Execute tests in an infinite loop'
+						),
+						array(
+							array('--test-it'),
+							null,
+							'Execute atoum unit tests'
+						),
+						array(
+							array('--test-all'),
+							null,
+							'DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead'
+						),
+						array(
+							array('-ft', '--force-terminal'),
+							null,
+							'Force output as in terminal'
+						),
+						array(
+							array('-bf', '--bootstrap-file'),
+							'<file>',
+							'Include <file> before executing each test method'
+						),
+						array(
+							array('-ulr', '--use-light-report'),
+							null,
+							'Use "light" CLI report'
+						),
+						array(
+							array('-utr', '--use-tap-report'),
+							null,
+							'Use TAP report'
+						),
+						array(
+							array('--debug'),
+							null,
+							'Enable debug mode'
+						),
+						array(
+							array('-xc', '--xdebug-config'),
+							null,
+							'Set XDEBUG_CONFIG variable'
+						),
+						array(
+							array('-fmt', '--format'),
+							'<xml|clover|html|treemap>',
+							'Coverage report format'
+						),
+						array(
+							array('-o', '--output'),
+							'<path/to/file/or/directory>',
+							'Coverage report output path'
+						)
+					)
+				)
+			->if($this->newTestedInstance($name = uniqid(), $adapter = new atoum\adapter()))
+			->then
+				->string($this->testedInstance->getName())->isEqualTo($name)
+				->string($this->testedInstance->getReportFormat())->isEqualTo('xml')
+				->object($this->testedInstance->getAdapter())->isIdenticalTo($adapter)
+				->object($this->testedInstance->getLocale())->isInstanceOf('mageekguy\atoum\locale')
+				->object($this->testedInstance->getIncluder())->isInstanceOf('mageekguy\atoum\includer')
+				->object($this->testedInstance->getRunner())->isInstanceOf('mageekguy\atoum\runner')
+				->variable($this->testedInstance->getScoreFile())->isNull()
+				->array($this->testedInstance->getArguments())->isEmpty()
+				->array($this->testedInstance->getHelp())->isEqualTo(array(
+						array(
+							array('-h', '--help'),
+							null,
+							'Display this help'
+						),
+						array(
+							array('-c', '--configurations'),
+							'<file>...',
+							'Use all configuration files <file>'
+						),
+						array(
+							array('-v', '--version'),
+							null,
+							'Display version'
+						),
+						array(
+							array('+verbose', '++verbose'),
+							null,
+							'Enable verbose mode'
+						),
+						array(
+							array('--init'),
+							null,
+							'Create configuration and bootstrap files in the current directory'
+						),
+						array(
+							array('-p', '--php'),
+							'<path/to/php/binary>',
+							'Path to PHP binary which must be used to run tests'
+						),
+						array(
+							array('-drt', '--default-report-title'),
+							'<string>',
+							'Define default report title with <string>'
+						),
+						array(
+							array('-sf', '--score-file'),
+							'<file>',
+							'Save score in file <file>'
+						),
+						array(
+							array('-mcn', '--max-children-number'),
+							'<integer>',
+							'Maximum number of sub-processus which will be run simultaneously'
+						),
+						array(
+							array('-ncc', '--no-code-coverage'),
+							null,
+							'Disable code coverage'
+						),
+						array(
+							array('-nccid', '--no-code-coverage-in-directories'),
+							'<directory>...',
+							'Disable code coverage in directories <directory>'
+						),
+						array(
+							array('-nccfns', '--no-code-coverage-for-namespaces'),
+							'<namespace>...',
+							'Disable code coverage for namespaces <namespace>'
+						),
+						array(
+							array('-nccfc', '--no-code-coverage-for-classes'),
+							'<class>...',
+							'Disable code coverage for classes <class>'
+						),
+						array(
+							array('-f', '--files'),
+							'<file>...',
+							'Execute all unit test files <file>'
+						),
+						array(
+							array('-d', '--directories'),
+							'<directory>...',
+							'Execute unit test files in all <directory>'
+						),
+						array(
+							array('-tfe', '--test-file-extensions'),
+							'<extension>...',
+							'Execute unit test files with one of extensions <extension>'
+						),
+						array(
+							array('-g', '--glob'),
+							'<pattern>...',
+							'Execute unit test files which match <pattern>'
+						),
+						array(
+							array('-t', '--tags'),
+							'<tag>...',
+							'Execute only unit test with tags <tag>'
+						),
+						array(
+							array('-m', '--methods'),
+							'<class::method>...',
+							'Execute all <class::method>, * may be used as wildcard for class name or method name'
+						),
+						array(
+							array('-ns', '--namespaces'),
+							'<namespace>...',
+							'Execute all classes in all namespaces <namespace>'
+						),
+						array(
+							array('-l', '--loop'),
+							null,
+							'Execute tests in an infinite loop'
+						),
+						array(
+							array('--test-it'),
+							null,
+							'Execute atoum unit tests'
+						),
+						array(
+							array('--test-all'),
+							null,
+							'DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead'
+						),
+						array(
+							array('-ft', '--force-terminal'),
+							null,
+							'Force output as in terminal'
+						),
+						array(
+							array('-bf', '--bootstrap-file'),
+							'<file>',
+							'Include <file> before executing each test method'
+						),
+						array(
+							array('-ulr', '--use-light-report'),
+							null,
+							'Use "light" CLI report'
+						),
+						array(
+							array('-utr', '--use-tap-report'),
+							null,
+							'Use TAP report'
+						),
+						array(
+							array('--debug'),
+							null,
+							'Enable debug mode'
+						),
+						array(
+							array('-xc', '--xdebug-config'),
+							null,
+							'Set XDEBUG_CONFIG variable'
+						),
+						array(
+							array('-fmt', '--format'),
+							'<xml|clover|html|treemap>',
+							'Coverage report format'
+						),
+						array(
+							array('-o', '--output'),
+							'<path/to/file/or/directory>',
+							'Coverage report output path'
+						)
+					)
+				)
+		;
+	}
+}


### PR DESCRIPTION
This PR adds a `coverage` script to run tests and produce coverage reports.
## How to use

``` sh
$ atoum/scripts/coverage.php -h
# ...
-fmt <xml|clover|html|treemap>, --format <xml|clover|html|treemap>: Coverage report format
-o <path/to/file/or/directory>, --output <path/to/file/or/directory>: Coverage report output path

# Default format is XML (Clover)
$ atoum/scripts/coverage.php -f my/test.php --output coverage.xml
# HTML report
$ atoum/scripts/coverage.php -f my/test.php --output coverage/ --format html
# Treemap report
$ atoum/scripts/coverage.php -f my/test.php --output treemap/ --format treemap
```

This could be useful to ease integration with external tools (#245, Jenkins, ...). 
