### PR TITLE
Add --fail-if-*-methods options (Closes #347)

### DIFF
--- a/classes/report/fields/runner/result.php
+++ b/classes/report/fields/runner/result.php
@@ -10,6 +10,7 @@ use
 
 abstract class result extends report\field
 {
+	protected $success = false;
 	protected $testNumber = null;
 	protected $testMethodNumber = null;
 	protected $assertionNumber = null;
@@ -89,6 +90,17 @@ abstract class result extends report\field
 			$this->voidMethodNumber = $score->getVoidMethodNumber();
 			$this->uncompletedMethodNumber = $score->getUncompletedMethodNumber();
 			$this->skippedMethodNumber = $score->getSkippedMethodNumber();
+			$this->success = ($this->failNumber === 0 && $this->errorNumber === 0 && $this->exceptionNumber === 0 && $this->uncompletedMethodNumber === 0);
+
+			if ($observable->shouldFailIfVoidMethods() && $this->voidMethodNumber > 0)
+			{
+				$this->success = false;
+			}
+
+			if ($observable->shouldFailIfSkippedMethods() && $this->skippedMethodNumber > 0)
+			{
+				$this->success = false;
+			}
 
 			return true;
 		}

--- a/classes/report/fields/runner/result/cli.php
+++ b/classes/report/fields/runner/result/cli.php
@@ -4,14 +4,15 @@ namespace mageekguy\atoum\report\fields\runner\result;
 
 use
 	mageekguy\atoum,
-	mageekguy\atoum\locale,
 	mageekguy\atoum\cli\prompt,
 	mageekguy\atoum\cli\colorizer,
-	mageekguy\atoum\report\fields
+	mageekguy\atoum\report\fields,
+	mageekguy\atoum\observable
 ;
 
 class cli extends fields\runner\result
 {
+	protected $observable = null;
 	protected $prompt = null;
 	protected $successColorizer = null;
 	protected $failureColorizer = null;
@@ -35,7 +36,7 @@ class cli extends fields\runner\result
 		{
 			$string .= $this->locale->_('No test running.');
 		}
-		else if ($this->failNumber === 0 && $this->errorNumber === 0 && $this->exceptionNumber === 0 && $this->uncompletedMethodNumber === 0)
+		else if ($this->success)
 		{
 			$string .= $this->successColorizer->colorize(
 					sprintf(
@@ -104,5 +105,17 @@ class cli extends fields\runner\result
 	public function getFailureColorizer()
 	{
 		return $this->failureColorizer;
+	}
+
+	public function handleEvent($event, observable $observable)
+	{
+		if (parent::handleEvent($event, $observable) === false)
+		{
+			return false;
+		}
+
+		$this->observable = $observable;
+
+		return true;
 	}
 }

--- a/classes/report/fields/runner/result/logo.php
+++ b/classes/report/fields/runner/result/logo.php
@@ -13,7 +13,7 @@ class logo extends cli
 {
 	public function __toString()
 	{
-		if ($this->failNumber === 0 && $this->errorNumber === 0 && $this->exceptionNumber === 0 && $this->uncompletedMethodNumber === 0)
+		if ($this->success)
 		{
 			return "
               \033[48;5;16m  \033[0m                                 \033[48;5;16m  \033[0m

--- a/classes/report/fields/runner/result/notifier.php
+++ b/classes/report/fields/runner/result/notifier.php
@@ -21,14 +21,13 @@ abstract class notifier extends result
 	public function __toString()
 	{
 		$string = $this->notify();
+
 		return $string == '' ? '' : trim($string) . PHP_EOL;
 	}
 
 	public function notify()
 	{
-		$success = ($this->failNumber === 0 && $this->errorNumber === 0 && $this->exceptionNumber === 0 && $this->uncompletedMethodNumber === 0);
-
-		if ($success === true)
+		if ($this->success === true)
 		{
 			$title = 'Success!';
 			$message = sprintf(
@@ -56,7 +55,7 @@ abstract class notifier extends result
 			);
 		}
 
-		return $this->send($title, $message, $success);
+		return $this->send($title, $message, $this->success);
 	}
 
 	public function setAdapter(atoum\adapter $adapter = null)

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -38,6 +38,8 @@ class runner implements observable
 	protected $testDirectoryIterator = null;
 	protected $debugMode = false;
 	protected $xdebugConfig = null;
+	protected $failIfVoidMethods = false;
+	protected $failIfSkippedMethods = false;
 
 	private $start = null;
 	private $stop = null;
@@ -330,6 +332,44 @@ class runner implements observable
 	public function codeCoverageIsEnabled()
 	{
 		return $this->codeCoverage;
+	}
+
+	public function doNotfailIfVoidMethods()
+	{
+		$this->failIfVoidMethods = false;
+
+		return $this;
+	}
+
+	public function failIfVoidMethods()
+	{
+		$this->failIfVoidMethods = true;
+
+		return $this;
+	}
+
+	public function shouldFailIfVoidMethods()
+	{
+		return $this->failIfVoidMethods;
+	}
+
+	public function doNotfailIfSkippedMethods()
+	{
+		$this->failIfSkippedMethods = false;
+
+		return $this;
+	}
+
+	public function failIfSkippedMethods()
+	{
+		$this->failIfSkippedMethods = true;
+
+		return $this;
+	}
+
+	public function shouldFailIfSkippedMethods()
+	{
+		return $this->failIfSkippedMethods;
 	}
 
 	public function addObserver(atoum\observer $observer)

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -51,7 +51,6 @@ class runner extends atoum\script\configurable
 			$this->infoWriter->addDecorator(new cli\colorizer('0;32'));
 		}
 
-
 		return $this;
 	}
 
@@ -455,6 +454,44 @@ class runner extends atoum\script\configurable
 		return $this;
 	}
 
+	public function doNotfailIfVoidMethods()
+	{
+		$this->runner->doNotfailIfVoidMethods();
+
+		return $this;
+	}
+
+	public function failIfVoidMethods()
+	{
+		$this->runner->failIfVoidMethods();
+
+		return $this;
+	}
+
+	public function shouldFailIfVoidMethods()
+	{
+		return $this->runner->shouldFailIfVoidMethods();
+	}
+
+	public function doNotfailIfSkippedMethods()
+	{
+		$this->runner->doNotfailIfSkippedMethods();
+
+		return $this;
+	}
+
+	public function failIfSkippedMethods()
+	{
+		$this->runner->failIfSkippedMethods();
+
+		return $this;
+	}
+
+	public function shouldFailIfSkippedMethods()
+	{
+		return $this->runner->shouldFailIfSkippedMethods();
+	}
+
 	public function init($directory = null)
 	{
 		$resourceDirectory = static::getResourcesDirectory();
@@ -541,7 +578,19 @@ class runner extends atoum\script\configurable
 						{
 							$score = $autorunner->run()->getRunner()->getScore();
 
-							exit($score->getFailNumber() <= 0 && $score->getErrorNumber() <= 0 && $score->getExceptionNumber() <= 0 ? 0 : 1);
+							$isSuccess = $score->getFailNumber() <= 0 && $score->getErrorNumber() <= 0 && $score->getExceptionNumber() <= 0;
+
+							if ($autorunner->shouldFailIfVoidMethods() && $score->getVoidMethodNumber() > 0)
+							{
+								$isSuccess = false;
+							}
+
+							if ($autorunner->shouldFailIfSkippedMethods() && $score->getSkippedMethodNumber() > 0)
+							{
+								$isSuccess = false;
+							}
+
+							exit($isSuccess ? 0 : 1);
 						}
 						catch (\exception $exception)
 						{
@@ -954,6 +1003,22 @@ class runner extends atoum\script\configurable
 					array('-xc', '--xdebug-config'),
 					null,
 					$this->locale->_('Set XDEBUG_CONFIG variable')
+				)
+			->addArgumentHandler(
+					function($script, $argument, $values) {
+						$script->failIfVoidMethods();
+					},
+					array('-fivm', '--fail-if-void-methods'),
+					null,
+					$this->locale->_('Make the test suite fail if there is at least one void test method')
+				)
+			->addArgumentHandler(
+					function($script, $argument, $values) {
+						$script->failIfSkippedMethods();
+					},
+					array('-fism', '--fail-if-skipped-methods'),
+					null,
+					$this->locale->_('Make the test suite fail if there is at least one skipped test method')
 				)
 		;
 

--- a/tests/units/classes/scripts/coverage.php
+++ b/tests/units/classes/scripts/coverage.php
@@ -180,6 +180,16 @@ class coverage extends atoum\test
 							'Set XDEBUG_CONFIG variable'
 						),
 						array(
+							array('-fivm', '--fail-if-void-methods'),
+							null,
+							'Make the test suite fail if there is at least one void test method'
+						),
+						array(
+							array('-fism', '--fail-if-skipped-methods'),
+							null,
+							'Make the test suite fail if there is at least one skipped test method'
+						),
+						array(
 							array('-fmt', '--format'),
 							'<xml|clover|html|treemap>',
 							'Coverage report format'
@@ -346,6 +356,16 @@ class coverage extends atoum\test
 							array('-xc', '--xdebug-config'),
 							null,
 							'Set XDEBUG_CONFIG variable'
+						),
+						array(
+							array('-fivm', '--fail-if-void-methods'),
+							null,
+							'Make the test suite fail if there is at least one void test method'
+						),
+						array(
+							array('-fism', '--fail-if-skipped-methods'),
+							null,
+							'Make the test suite fail if there is at least one skipped test method'
 						),
 						array(
 							array('-fmt', '--format'),

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -188,6 +188,16 @@ class runner extends atoum\test
 							array('-xc', '--xdebug-config'),
 							null,
 							'Set XDEBUG_CONFIG variable'
+						),
+						array(
+							array('-fivm', '--fail-if-void-methods'),
+							null,
+							'Make the test suite fail if there is at least one void test method'
+						),
+						array(
+							array('-fism', '--fail-if-skipped-methods'),
+							null,
+							'Make the test suite fail if there is at least one skipped test method'
 						)
 					)
 				)
@@ -345,6 +355,16 @@ class runner extends atoum\test
 							array('-xc', '--xdebug-config'),
 							null,
 							'Set XDEBUG_CONFIG variable'
+						),
+						array(
+							array('-fivm', '--fail-if-void-methods'),
+							null,
+							'Make the test suite fail if there is at least one void test method'
+						),
+						array(
+							array('-fism', '--fail-if-skipped-methods'),
+							null,
+							'Make the test suite fail if there is at least one skipped test method'
 						)
 					)
 				)
@@ -646,6 +666,84 @@ class runner extends atoum\test
 			->then
 				->object($script->setXdebugConfig($xdebugConfig = uniqid()))->isIdenticalTo($script)
 				->mock($runner)->call('setXdebugConfig')->withArguments($xdebugConfig)->once()
+		;
+	}
+
+	public function testFailIfVoidMethods()
+	{
+		$this
+			->if($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($script->setRunner($runner = new \mock\mageekguy\atoum\runner()))
+			->then
+				->object($script->failIfVoidMethods())->isIdenticalTo($script)
+				->mock($runner)->call('failIfVoidMethods')->once()
+		;
+	}
+
+	public function testDoNotFailIfVoidMethods()
+	{
+		$this
+			->if($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($script->setRunner($runner = new \mock\mageekguy\atoum\runner()))
+			->then
+				->object($script->doNotFailIfVoidMethods())->isIdenticalTo($script)
+				->mock($runner)->call('doNotFailIfVoidMethods')->once()
+		;
+	}
+
+	public function testShouldFailIfVoidMethods()
+	{
+		$this
+			->if($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($script->setRunner($runner = new \mock\mageekguy\atoum\runner()))
+			->then
+				->boolean($script->shouldFailIfVoidMethods())->isFalse()
+				->mock($runner)->call('shouldFailIfVoidMethods')->once()
+			->if($this->calling($runner)->shouldFailIfVoidMethods = true)
+			->then
+				->boolean($script->shouldFailIfVoidMethods())->isTrue()
+			->if($this->calling($runner)->shouldFailIfVoidMethods = false)
+			->then
+				->boolean($script->shouldFailIfVoidMethods())->isFalse()
+		;
+	}
+
+	public function testFailIfSkippedMethods()
+	{
+		$this
+			->if($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($script->setRunner($runner = new \mock\mageekguy\atoum\runner()))
+			->then
+				->object($script->failIfSkippedMethods())->isIdenticalTo($script)
+				->mock($runner)->call('failIfSkippedMethods')->once()
+		;
+	}
+
+	public function testDoNotFailIfSkippedMethods()
+	{
+		$this
+			->if($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($script->setRunner($runner = new \mock\mageekguy\atoum\runner()))
+			->then
+				->object($script->doNotFailIfSkippedMethods())->isIdenticalTo($script)
+				->mock($runner)->call('doNotFailIfSkippedMethods')->once()
+		;
+	}
+
+	public function testShouldFailIfSkippedMethods()
+	{
+		$this
+			->if($script = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
+			->and($script->setRunner($runner = new \mock\mageekguy\atoum\runner()))
+			->then
+				->boolean($script->shouldFailIfSkippedMethods())->isFalse()
+				->mock($runner)->call('shouldFailIfSkippedMethods')->once()
+			->if($this->calling($runner)->shouldFailIfSkippedMethods = true)
+			->then
+				->boolean($script->shouldFailIfSkippedMethods())->isTrue()
+			->if($this->calling($runner)->shouldFailIfSkippedMethods = false)
+			->then
+				->boolean($script->shouldFailIfSkippedMethods())->isFalse()
 		;
 	}
 


### PR DESCRIPTION
We now have two more flags on the CLI:

``` sh
bin/atoum --fail-if-void-methods
# Short version: -fivm

bin/atoum --fail-if-skipped-methods
# Short version: -fism
```

Using either of those options will turn the result ribbon red if void
and/or skipped methods are found. atoum will also exit with an error
status (1) just like when it normally fails.
