### PR TITLE
Add the `isFinal` assertion on the `phpClass`/`class`/`testedClass` asserters

### DIFF
--- a/classes/asserters/phpClass.php
+++ b/classes/asserters/phpClass.php
@@ -17,6 +17,7 @@ class phpClass extends atoum\asserter
 		switch (strtolower($property))
 		{
 			case 'isabstract':
+			case 'isfinal':
 			case 'hasnoparent':
 				return $this->{$property}();
 
@@ -170,6 +171,20 @@ class phpClass extends atoum\asserter
 		else
 		{
 			$this->fail($failMessage ?: $this->_('%s is not abstract', $this));
+		}
+
+		return $this;
+	}
+
+	public function isFinal($failMessage = null)
+	{
+		if ($this->classIsSet()->class->isFinal() === true)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage ?: $this->_('%s is not final', $this));
 		}
 
 		return $this;

--- a/tests/units/classes/asserters/phpClass.php
+++ b/tests/units/classes/asserters/phpClass.php
@@ -411,6 +411,52 @@ class phpClass extends atoum\test
 		;
 	}
 
+	public function testIsFinal()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance)
+			->then
+				->exception(function() use ($asserter) { $asserter->isFinal(); })
+					->isInstanceOf('logicException')
+					->hasMessage('Class is undefined')
+
+			->given(
+				$this->testedInstance
+					->setReflectionClassInjector(function($class) use (& $reflectionClass) {
+							$mockController = new atoum\mock\controller();
+							$mockController->__construct = function() {};
+							$mockController->getName = $class;
+
+							return $reflectionClass = new \mock\reflectionClass($class, $mockController);
+						}
+					)
+					->setWith(uniqid())
+					->setLocale($locale = new \mock\atoum\locale()),
+				$this->calling($locale)->_ = $notFinal = uniqid()
+			)
+
+			->if($this->calling($reflectionClass)->isFinal = false)
+			->then
+				->exception(function() use ($asserter) { $asserter->isFinal(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notFinal)
+				->mock($locale)->call('_')->withArguments('%s is not final', $asserter)->once
+
+				->exception(function() use ($asserter, & $failMessage) { $asserter->isFinal($failMessage = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($failMessage)
+
+				->exception(function() use ($asserter) { $asserter->isFinal; })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notFinal)
+				->mock($locale)->call('_')->withArguments('%s is not final', $asserter)->twice
+
+			->if($this->calling($reflectionClass)->isFinal = true)
+				->object($this->testedInstance->isFinal())->isTestedInstance
+				->object($this->testedInstance->isFinal)->isTestedInstance
+		;
+	}
+
 	public function testHasMethod()
 	{
 		$this


### PR DESCRIPTION
Currently, atoum does not provide any assertion about final status of a
class.
And even if using final on a class seems to be a bad practice, it's not
always the case, so having an assertion about that is interesting.
To use `phpClass::isFinal()` and the short version `phpClass:isFinal` (aka
syntaxic sugar), just do:

``` php
<?php

$this->testedClass->isFinal(); // or
$this->testedClass->isFinal; // strictly equivalent to the line above.
```
