### PR TITLE
Improve dataset key reporting in case of failure.

### DIFF
--- a/classes/report/fields/runner/failures/cli.php
+++ b/classes/report/fields/runner/failures/cli.php
@@ -68,7 +68,7 @@ class cli extends runner\failures
 							break;
 
 						case $fail['case'] === null && $fail['dataSetKey'] !== null:
-							$string .= sprintf($this->locale->_('In file %s on line %d, %s failed for data set #%s of data provider %s: %s'), $fail['file'], $fail['line'], $fail['asserter'], $fail['dataSetKey'], $fail['dataSetProvider'], $fail['fail']);
+							$string .= sprintf($this->locale->_('In file %s on line %d, %s failed for data set [%s] of data provider %s: %s'), $fail['file'], $fail['line'], $fail['asserter'], $fail['dataSetKey'], $fail['dataSetProvider'], $fail['fail']);
 							break;
 
 						case $fail['case'] !== null && $fail['dataSetKey'] === null:
@@ -76,7 +76,7 @@ class cli extends runner\failures
 							break;
 
 						case $fail['case'] !== null && $fail['dataSetKey'] !== null:
-							$string .= sprintf($this->locale->_('In file %s on line %d in case \'%s\', %s failed for data set #%s of data provider %s: %s'), $fail['file'], $fail['line'], $fail['case'],  $fail['asserter'], $fail['dataSetKey'], $fail['dataSetProvider'], $fail['fail']);
+							$string .= sprintf($this->locale->_('In file %s on line %d in case \'%s\', %s failed for data set [%s] of data provider %s: %s'), $fail['file'], $fail['line'], $fail['case'],  $fail['asserter'], $fail['dataSetKey'], $fail['dataSetProvider'], $fail['fail']);
 							break;
 					}
 

--- a/tests/units/classes/report/fields/runner/failures/cli.php
+++ b/tests/units/classes/report/fields/runner/failures/cli.php
@@ -302,9 +302,9 @@ class cli extends atoum\test
 			->then
 				->castToString($defaultField)->isEqualTo(sprintf('There are %d failures:', sizeof($fails)) . PHP_EOL .
 					$class . '::' . $method . '():' . PHP_EOL .
-					sprintf('In file %s on line %d in case \'%s\', %s failed for data set #%s of data provider %s: %s', $file, $line, $case, $asserter, $dataSetKey, $dataSetProvider, $fail) . PHP_EOL .
+					sprintf('In file %s on line %d in case \'%s\', %s failed for data set [%s] of data provider %s: %s', $file, $line, $case, $asserter, $dataSetKey, $dataSetProvider, $fail) . PHP_EOL .
 					$otherClass . '::' . $otherMethod . '():' . PHP_EOL .
-					sprintf('In file %s on line %d in case \'%s\', %s failed for data set #%s of data provider %s: %s', $otherFile, $otherLine, $otherCase, $otherAsserter, $otherDataSetKey, $otherDataSetProvider, $otherFail) . PHP_EOL
+					sprintf('In file %s on line %d in case \'%s\', %s failed for data set [%s] of data provider %s: %s', $otherFile, $otherLine, $otherCase, $otherAsserter, $otherDataSetKey, $otherDataSetProvider, $otherFail) . PHP_EOL
 				)
 				->castToString($customField)->isEqualTo(
 					$titlePrompt .
@@ -319,7 +319,7 @@ class cli extends atoum\test
 						$methodColorizer->colorize($class . '::' . $method . '()')
 					) .
 					PHP_EOL .
-					sprintf($locale->_('In file %s on line %d in case \'%s\', %s failed for data set #%s of data provider %s: %s'), $file, $line, $case, $asserter, $dataSetKey, $dataSetProvider, $fail) .
+					sprintf($locale->_('In file %s on line %d in case \'%s\', %s failed for data set [%s] of data provider %s: %s'), $file, $line, $case, $asserter, $dataSetKey, $dataSetProvider, $fail) .
 					PHP_EOL .
 					$methodPrompt .
 					sprintf(
@@ -327,7 +327,7 @@ class cli extends atoum\test
 						$methodColorizer->colorize($otherClass . '::' . $otherMethod . '()')
 					) .
 					PHP_EOL .
-					sprintf($locale->_('In file %s on line %d in case \'%s\', %s failed for data set #%s of data provider %s: %s'), $otherFile, $otherLine, $otherCase, $otherAsserter, $otherDataSetKey, $otherDataSetProvider, $otherFail) .
+					sprintf($locale->_('In file %s on line %d in case \'%s\', %s failed for data set [%s] of data provider %s: %s'), $otherFile, $otherLine, $otherCase, $otherAsserter, $otherDataSetKey, $otherDataSetProvider, $otherFail) .
 					PHP_EOL
 				)
 		;


### PR DESCRIPTION
Currently, if a test using a dataset provider fail, atoum display in cli
the following message ($ is the CLI prompt):

``` sh
$ In file 547c9209a296c on line 547 in case '547c9209a276c', 547c9209a29d7 failed for data set #3404808712286633985 of data provider 547c9209a27e1: 547c9209a2a00
```

To be clear, it display the key of the dataset which fail as # following by a string if a named key is used, by a number if the key is not named.
And if it's easily readable if key are not named, it's not the case if
the key is named:

``` sh
$ In file 547c9209a296c on line 547 in case '547c9209a276c', 547c9209a29d7 failed for data set #integer should be greater than 0 of data provider 547c9209a27e1: 547c9209a2a00
```

So, to improve readability, this commit use the [] notation for the two kind of key:

``` sh
$ In file 547c9209a296c on line 547 in case '547c9209a276c', 547c9209a29d7 failed for data set [integer should be greater than 0] of data provider 547c9209a27e1: 547c9209a2a00
```
