### PR TITLE
Short syntax for base assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#384](https://github.com/atoum/atoum/pull/384) Short syntax for base assertions ([@jubianchi])
+
 # 2.2.0 - 2015-07-31 
 
 * [#467](https://github.com/atoum/atoum/pull/467) Hide classes and methods coverage details in CLI report ([@jubianchi])

--- a/classes/asserters/integer.php
+++ b/classes/asserters/integer.php
@@ -13,13 +13,9 @@ class integer extends asserters\variable
 	{
 		$assertion = null;
 
-		if (is_numeric($method) === true)
+		switch ($method)
 		{
-			$assertion = 'isEqualTo';
-		}
-		else switch ($method)
-		{
-			case '=<':
+			case '<=':
 				$assertion = 'isLessThanOrEqualTo';
 				break;
 
@@ -44,11 +40,7 @@ class integer extends asserters\variable
 
 	public function __get($property)
 	{
-		if (is_numeric($property) === true)
-		{
-			return $this->isEqualTo($property);
-		}
-		else switch (strtolower($property))
+		switch (strtolower($property))
 		{
 			case 'iszero':
 				return $this->isZero();

--- a/classes/asserters/integer.php
+++ b/classes/asserters/integer.php
@@ -9,9 +9,46 @@ use
 
 class integer extends asserters\variable
 {
+	public function __call($method, $arguments)
+	{
+		$assertion = null;
+
+		if (is_numeric($method) === true)
+		{
+			$assertion = 'isEqualTo';
+		}
+		else switch ($method)
+		{
+			case '=<':
+				$assertion = 'isLessThanOrEqualTo';
+				break;
+
+			case '<':
+				$assertion = 'isLessThan';
+				break;
+
+			case '>=':
+				$assertion = 'isGreaterThanOrEqualTo';
+				break;
+
+			case '>':
+				$assertion = 'isGreaterThan';
+				break;
+
+			default:
+				return parent::__call($method, $arguments);
+		}
+
+		return call_user_func_array(array($this, $assertion), $arguments);
+	}
+
 	public function __get($property)
 	{
-		switch (strtolower($property))
+		if (is_numeric($property) === true)
+		{
+			return $this->isEqualTo($property);
+		}
+		else switch (strtolower($property))
 		{
 			case 'iszero':
 				return $this->isZero();

--- a/classes/asserters/variable.php
+++ b/classes/asserters/variable.php
@@ -46,6 +46,35 @@ class variable extends atoum\asserter
 		}
 	}
 
+	public function __call($method, $arguments)
+	{
+		$assertion = null;
+
+		switch ($method)
+		{
+			case '==':
+				$assertion = 'isEqualTo';
+				break;
+
+			case '===':
+				$assertion = 'isIdenticalTo';
+				break;
+
+			case '!=':
+				$assertion = 'isNotEqualTo';
+				break;
+
+			case '!==':
+				$assertion = 'isNotIdenticalTo';
+				break;
+
+			default:
+				return parent::__call($method, $arguments);
+		}
+
+		return call_user_func_array(array($this, $assertion), $arguments);
+	}
+
 	public function setDiff(diffs\variable $diff = null)
 	{
 		$this->diff = $diff ?: new diffs\variable();

--- a/tests/units/classes/asserters/integer.php
+++ b/tests/units/classes/asserters/integer.php
@@ -71,6 +71,7 @@ class integer extends atoum\test
 			->if($asserter->setWith($value = rand(1, PHP_INT_MAX)))
 			->then
 				->object($asserter->isEqualTo($value))->isIdenticalTo($asserter)
+				->object($asserter->{'=='}($value))->isIdenticalTo($asserter)
 
 			->if($this->testedInstance
 					->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
@@ -111,6 +112,7 @@ class integer extends atoum\test
 			->if($asserter->setWith(PHP_INT_MAX))
 			->then
 				->object($asserter->isGreaterThan(0))->isIdenticalTo($asserter)
+				->object($asserter->{'>'}(0))->isIdenticalTo($asserter)
 
 			->if($asserter
 					->setWith(- PHP_INT_MAX)
@@ -146,6 +148,7 @@ class integer extends atoum\test
 			->then
 				->object($asserter->isGreaterThanOrEqualTo(0))->isIdenticalTo($asserter)
 				->object($asserter->isGreaterThanOrEqualTo(PHP_INT_MAX))->isIdenticalTo($asserter)
+				->object($asserter->{'>='}(PHP_INT_MAX))->isIdenticalTo($asserter)
 
 			->if($asserter
 					->setWith(- PHP_INT_MAX)
@@ -180,6 +183,7 @@ class integer extends atoum\test
 			->if($asserter->setWith(0))
 			->then
 				->object($asserter->isLessThan(PHP_INT_MAX))->isIdenticalTo($asserter)
+				->object($asserter->{'<'}(PHP_INT_MAX))->isIdenticalTo($asserter)
 
 			->if($asserter
 					->setWith(PHP_INT_MAX)
@@ -216,6 +220,7 @@ class integer extends atoum\test
 			->then
 				->object($asserter->isLessThanOrEqualTo(PHP_INT_MAX))->isIdenticalTo($asserter)
 				->object($asserter->isLessThanOrEqualTo(0))->isIdenticalTo($asserter)
+				->object($asserter->{'<='}(0))->isIdenticalTo($asserter)
 
 			->if($asserter
 					->setWith(PHP_INT_MAX)

--- a/tests/units/classes/asserters/variable.php
+++ b/tests/units/classes/asserters/variable.php
@@ -155,6 +155,7 @@ class variable extends atoum\test
 			->then
 				->object($asserter->isEqualTo($value))->isIdenticalTo($asserter)
 				->object($asserter->isEqualTo((string) $value))->isIdenticalTo($asserter)
+				->object($asserter->{'=='}($value))->isIdenticalTo($asserter)
 
 			->if(
 				$this->calling($locale)->_ = $localizedMessage = uniqid(),
@@ -188,6 +189,7 @@ class variable extends atoum\test
 			->if($asserter->setWith($value = uniqid()))
 			->then
 				->object($asserter->isNotEqualTo(uniqid()))->isIdenticalTo($asserter)
+				->object($asserter->{'!='}(uniqid()))->isIdenticalTo($asserter)
 
 			->if(
 				$this->calling($locale)->_ = $localizedMessage = uniqid(),
@@ -218,6 +220,7 @@ class variable extends atoum\test
 			->if($asserter->setWith($value = rand(- PHP_INT_MAX, PHP_INT_MAX)))
 			->then
 				->object($asserter->isIdenticalTo($value))->isIdenticalTo($asserter)
+				->object($asserter->{'==='}($value))->isIdenticalTo($asserter)
 
 			->if(
 				$this->calling($locale)->_ = $localizedMessage = uniqid(),
@@ -260,6 +263,7 @@ class variable extends atoum\test
 			->then
 				->object($asserter->isNotIdenticalTo((string) $value))->isIdenticalTo($asserter)
 				->object($asserter->isNotIdenticalTo(uniqid()))->isIdenticalTo($asserter)
+				->object($asserter->{'!=='}(uniqid()))->isIdenticalTo($asserter)
 
 			->if(
 				$this->calling($locale)->_ = $localizedMessage = uniqid(),


### PR DESCRIPTION
Introducing new short syntax for base assertions:

```php
<?php

namespace tests\units;

use atoum;

class stdClass extends atoum
{
    public function testFoo()
    {
        $this
            ->variable('foo')->{'=='}('foo')
            ->variable('foo')->{'!='}('bar')

            ->object($this->newInstance)->{'=='}($this->newInstance)
            ->object($this->newInstance)->{'!='}(new \exception)
            ->object($this->newTestedInstance)->{'==='}($this->testedInstance)
            ->object($this->newTestedInstance)->{'!=='}($this->newTestedInstance)

            ->integer(42)->{42} // isEqualTo
            ->integer(42)->{'42'} // isEqualTo
            ->integer(rand(0, 10))->{'<'}(11)
            ->integer(rand(0, 10))->{'=<'}(10)
            ->integer(rand(0, 10))->{'>'}(-1)
            ->integer(rand(0, 10))->{'>='}(0)
        ;
    }
}

```

I was reviewing some code and remembered what we did with @mageekguy on mock call asserter to allow things like `$this->mock($foo)->call('bar')->{3}` to test if the `bar` method was called exactly three times on `$foo`. I asked myself if we could apply similar things to some other asserters, basically `variable` and `integer` to cover assertions that have a native operator counterpart (i.e `isEqualTo`, `isIdenticalTo`, ...).

As you have seen in the previous example, this is doable and works fine (I tested it from PHP 5.4 to 5.6). Let me know if you think it's useful ;)