### PR TITLE
Rename `match` to `matches` on the string asserter

### DIFF
--- a/classes/asserters/hash.php
+++ b/classes/asserters/hash.php
@@ -32,7 +32,7 @@ class hash extends asserters\string
 	{
 		if (strlen($this->valueIsSet()->value) === $length)
 		{
-			 $this->match('/^[a-fA-F0-9]+$/', $failMessage ?: $this->_('%s does not match given pattern', $this));
+			 $this->matches('/^[a-fA-F0-9]+$/', $failMessage ?: $this->_('%s does not match given pattern', $this));
 		}
 		else
 		{

--- a/classes/asserters/string.php
+++ b/classes/asserters/string.php
@@ -74,6 +74,11 @@ class string extends asserters\variable
 
 	public function match($pattern, $failMessage = null)
 	{
+		return $this->matches($pattern, $failMessage = null);
+	}
+
+	public function matches($pattern, $failMessage = null)
+	{
 		if (preg_match($pattern, $this->valueIsSet()->value) === 1)
 		{
 			$this->pass();

--- a/tests/units/classes/annotations/extractor.php
+++ b/tests/units/classes/annotations/extractor.php
@@ -14,18 +14,18 @@ class extractor extends atoum\test
 	public function testSpace()
 	{
 		$this
-			->string(self::space())->match('/ {1,10}/')
-			->string(self::space(5))->match('/ {1,5}/')
-			->string(self::space(5, 3))->match('/ {3,5}/')
+			->string(self::space())->matches('/ {1,10}/')
+			->string(self::space(5))->matches('/ {1,5}/')
+			->string(self::space(5, 3))->matches('/ {3,5}/')
 		;
 	}
 
 	public function testStar()
 	{
 		$this
-			->string(self::star())->match('/\*{2,10}/')
-			->string(self::star(5))->match('/\*{2,5}/')
-			->string(self::star(5, 3))->match('/\*{3,5}/')
+			->string(self::star())->matches('/\*{2,10}/')
+			->string(self::star(5))->matches('/\*{2,5}/')
+			->string(self::star(5, 3))->matches('/\*{3,5}/')
 		;
 	}
 

--- a/tests/units/classes/mock/stream.php
+++ b/tests/units/classes/mock/stream.php
@@ -44,7 +44,7 @@ class stream extends test
 			->if($adapter->stream_get_wrappers = array(testedClass::defaultProtocol))
 			->then
 				->object($streamController = testedClass::get())->isInstanceOf('mageekguy\atoum\mock\stream\controller')
-				->string($streamController->getPath())->match('#^' . testedClass::defaultProtocol . '://\w+$#')
+				->string($streamController->getPath())->matches('#^' . testedClass::defaultProtocol . '://\w+$#')
 				->adapter($adapter)
 					->call('stream_wrapper_register')->withArguments(testedClass::defaultProtocol, 'mageekguy\atoum\mock\stream')->once()
 				->object(testedClass::get($stream))->isIdenticalTo($streamController = testedClass::get($stream))
@@ -76,11 +76,11 @@ class stream extends test
 			->and($adapter->stream_wrapper_register = true)
 			->and($stream = testedClass::get())
 			->then
-				->string($stream . '\\' . uniqid())->match('#^' . $stream . preg_quote('\\') . '[^' . preg_quote('\\') . ']+$#')
+				->string($stream . '\\' . uniqid())->matches('#^' . $stream . preg_quote('\\') . '[^' . preg_quote('\\') . ']+$#')
 				->object($subStream = testedClass::getSubStream($stream))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
-				->castToString($subStream)->match('#^' . $stream . preg_quote(DIRECTORY_SEPARATOR) . '[^' . preg_quote(DIRECTORY_SEPARATOR) . ']+$#')
+				->castToString($subStream)->matches('#^' . $stream . preg_quote(DIRECTORY_SEPARATOR) . '[^' . preg_quote(DIRECTORY_SEPARATOR) . ']+$#')
 				->object($subStream = testedClass::getSubStream($stream, $basename = uniqid()))->isInstanceOf('mageekguy\atoum\mock\stream\controller')
-				->castToString($subStream)->match('#^' . $stream . preg_quote(DIRECTORY_SEPARATOR) . $basename . '$#')
+				->castToString($subStream)->matches('#^' . $stream . preg_quote(DIRECTORY_SEPARATOR) . $basename . '$#')
 		;
 	}
 


### PR DESCRIPTION
Hello :-),

All asserters is at the third-person: `contains`, `hasKey`, `isEqualTo`… but `match`, on the string asserter, does not follow this rule.

This PR adds the `matches` asserter, and redirects `match` to `matches` for the sake of backward compatibility.
All tests are consequently updated.
