### PR TITLE
Stylesheet path of HTML coverage report when tested class is in the root namespace

### DIFF
--- a/classes/report/fields/runner/coverage/html.php
+++ b/classes/report/fields/runner/coverage/html.php
@@ -118,7 +118,11 @@ class html extends report\fields\runner\coverage\cli
 				foreach ($this->coverage->getMethods() as $className => $methods)
 				{
 					$classTemplate->className = $className;
-					$classTemplate->relativeRootUrl = rtrim(str_repeat('../', substr_count($className, '\\')), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+					if (substr_count($className, '\\') >= 1)
+					{
+						$classTemplate->relativeRootUrl = rtrim(str_repeat('../', substr_count($className, '\\')), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+					}
 
 					$classCoverageValue = $this->coverage->getValueForClass($className);
 


### PR DESCRIPTION
**Given** a class:

```php
<?php

namespace
{
    class foo
    {
        //...
    }
}
```

**And** a test:

```php
<?php

namespace tests\units
{
    use atoum;

    class foo extends atoum
    {
    	//...
    }
}
```

**When** the user enables the HTML coverage report
**And** he runs the previous test
**Then** he gets a broken coverage report:

The directory containing the HTML report looks like this:
```
.
├── foo.html
├── index.html
└── screen.css
```

In the `foo.html` the stylesheet is linked using `<link rel="stylesheet" media="screen" type="text/css" href="/screen.css" title="Screen" />` which is not good: the stylesheet path is absolute from the root (leading `/`) when it should be relative to the `foo.html` file. Thisbreaks the class report when the report is served from a the filesystem (`file://`) from a non-root directory. Same thing apply if the report is served with a HTTP server from an alias/subdirectory.

I fixed this by using a simple `if` checking if the tested class is in the root namespace or not. If it's in the root namespace, leading `/` is not added.