### PR TITLE
Remove bug in exit code management.

### DIFF
--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -205,8 +205,6 @@ class runner extends atoum\script\configurable
 		catch (atoum\exception $exception)
 		{
 			$this->writeError($exception->getMessage());
-
-			exit(2);
 		}
 
 		return $this;
@@ -581,7 +579,7 @@ class runner extends atoum\script\configurable
 								{
 									$autorunner->writeError($message . ' in ' . $file . ' at line ' . $line, $error);
 
-									exit($error);
+									exit(3);
 								}
 							}
 						);
@@ -608,7 +606,7 @@ class runner extends atoum\script\configurable
 						{
 							$autorunner->writeError($exception->getMessage());
 
-							exit($exception->getCode());
+							exit(2);
 						}
 					}
 				}


### PR DESCRIPTION
Atoum use exception code to set php's exit status.
However, most of exception does not define exit code, so exit code could be 0, which is success, instead of failure.
With with PR, exit code can be 0 (success), 1 (failure), 2 (exception) or 3 (error).