### PR TITLE
Test if class is in excluded directories should be the first!

### DIFF
--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -192,23 +192,23 @@ class coverage implements \countable, \serializable
 		{
 			$reflectedClass = call_user_func($this->reflectionClassFactory, $class);
 
-			if (isset($this->classes[$class]) === false)
+			if ($this->isExcluded($reflectedClass) === false)
 			{
-				if ($this->isExcluded($reflectedClass) === false)
+				if (isset($this->classes[$class]) === false)
 				{
 					$this->classes[$class] = $classes[$class];
 				}
-			}
 
-			foreach ($methods as $method => $lines)
-			{
-				if (isset($this->methods[$class][$method]) === true || $this->isExcluded($this->getDeclaringClass($reflectedClass->getMethod($method))) === false)
+				foreach ($methods as $method => $lines)
 				{
-					foreach ($lines as $line => $call)
+					if (isset($this->methods[$class][$method]) === true || $this->isExcluded($this->getDeclaringClass($reflectedClass->getMethod($method))) === false)
 					{
-						if (isset($this->methods[$class][$method][$line]) === false || $this->methods[$class][$method][$line] < $call)
+						foreach ($lines as $line => $call)
 						{
-							$this->methods[$class][$method][$line] = $call;
+							if (isset($this->methods[$class][$method][$line]) === false || $this->methods[$class][$method][$line] < $call)
+							{
+								$this->methods[$class][$method][$line] = $call;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
It's possible to exclude classes from code coverage.
However, there is a bug in this feature : even if a class is excluded, its methods are used to compute code coverage.
This PR resolve this bug. 