### PR TITLE
Fix a bug when a method returns a reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* #418 Fix a bug when a method returns a reference (@hywan)
+
 # 1.2.1 - 2015-01-09
 
 * #413 Fix a bug in the exit code management (@mageekguy)

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -361,13 +361,15 @@ class generator
 					$mockedMethods .= "\t\t" . '{' . PHP_EOL;
 					$mockedMethods .= "\t\t\t" . '$this->getMockController()->' . $methodName . ' = function() {};' . PHP_EOL;
 					$mockedMethods .= "\t\t" . '}' . PHP_EOL;
-					$mockedMethods .=	"\t\t" . 'return $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+					$mockedMethods .= "\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+					$mockedMethods .= "\t\t" . 'return $return;' . PHP_EOL;
 				}
 				else
 				{
 					$mockedMethods .= "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL;
 					$mockedMethods .= "\t\t" . '{' . PHP_EOL;
-					$mockedMethods .= "\t\t\t" . 'return $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+					$mockedMethods .= "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+					$mockedMethods .= "\t\t\t" . 'return $return;' . PHP_EOL;
 					$mockedMethods .= "\t\t" . '}' . PHP_EOL;
 					$mockedMethods .= "\t\t" . 'else' . PHP_EOL;
 					$mockedMethods .= "\t\t" . '{' . PHP_EOL;
@@ -381,7 +383,8 @@ class generator
 
 					if ($this->shuntParentClassCalls === false)
 					{
-						$mockedMethods .= "\t\t\t" . 'return call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL;
+						$mockedMethods .= "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL;
+						$mockedMethods .= "\t\t\t" . 'return $return;' . PHP_EOL;
 					}
 
 					$mockedMethods .= "\t\t" . '}' . PHP_EOL;
@@ -481,7 +484,15 @@ class generator
 					$methodCode .= "\t\t" . '{' . PHP_EOL;
 					$methodCode .= "\t\t\t" . '$this->getMockController()->' . $methodName . ' = function() {};' . PHP_EOL;
 					$methodCode .= "\t\t" . '}' . PHP_EOL;
-					$methodCode .= "\t\t" . ($isConstructor === true ? '' : 'return ') . '$this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+					if ($isConstructor === true)
+					{
+						$methodCode .= "\t\t" . '$this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+					}
+					else
+					{
+						$methodCode .= "\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL;
+						$methodCode .= "\t\t" . 'return $return;' . PHP_EOL;
+					}
 					$methodCode .= "\t" . '}' . PHP_EOL;
 					break;
 
@@ -712,7 +723,8 @@ class generator
 			"\t" . '{' . PHP_EOL .
 			"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
-			"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+			"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+			"\t\t\t" . 'return $return;' . PHP_EOL .
 			"\t\t" . '}' . PHP_EOL .
 			"\t\t" . 'else' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -193,7 +193,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -433,7 +434,8 @@ class generator extends atoum\test
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->' . $otherMethod . ') === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke(\'' . $otherMethod . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $otherMethod . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -828,7 +830,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -874,13 +877,15 @@ class generator extends atoum\test
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->getIterator = function() {};' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
-					"\t\t" . 'return $this->getMockController()->invoke(\'getIterator\', $arguments);' . PHP_EOL .
+					"\t\t" . '$return = $this->getMockController()->invoke(\'getIterator\', $arguments);' . PHP_EOL .
+					"\t\t" . 'return $return;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public function __call($methodName, $arguments)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1013,7 +1018,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1093,7 +1099,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1166,7 +1173,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1200,7 +1208,8 @@ class generator extends atoum\test
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->getIterator = function() {};' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
-					"\t\t" . 'return $this->getMockController()->invoke(\'getIterator\', $arguments);' . PHP_EOL .
+					"\t\t" . '$return = $this->getMockController()->invoke(\'getIterator\', $arguments);' . PHP_EOL .
+					"\t\t" . 'return $return;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
@@ -1221,7 +1230,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1294,12 +1304,14 @@ class generator extends atoum\test
 					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-					"\t\t\t" . 'return call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public static function getMockedMethods()' . PHP_EOL .
@@ -1369,7 +1381,8 @@ class generator extends atoum\test
 					"\t" . '{' . PHP_EOL .
 					"\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
-					"\t\t\t" . 'return $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
@@ -1807,7 +1820,8 @@ class generator extends atoum\test
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->' . $publicMethodName . ' = function() {};' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
-					"\t\t" . 'return $this->getMockController()->invoke(\'' . $publicMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . '$return = $this->getMockController()->invoke(\'' . $publicMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . 'return $return;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'protected function ' . $protectedMethodName . '()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
@@ -1816,7 +1830,8 @@ class generator extends atoum\test
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->' . $protectedMethodName . ' = function() {};' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
-					"\t\t" . 'return $this->getMockController()->invoke(\'' . $protectedMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . '$return = $this->getMockController()->invoke(\'' . $protectedMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . 'return $return;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public static function getMockedMethods()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
@@ -1922,7 +1937,8 @@ class generator extends atoum\test
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->' . $publicMethodName . ' = function() {};' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
-					"\t\t" . 'return $this->getMockController()->invoke(\'' . $publicMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . '$return = $this->getMockController()->invoke(\'' . $publicMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . 'return $return;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'protected function ' . $protectedMethodName . '()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
@@ -1931,7 +1947,8 @@ class generator extends atoum\test
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->' . $protectedMethodName . ' = function() {};' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
-					"\t\t" . 'return $this->getMockController()->invoke(\'' . $protectedMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . '$return = $this->getMockController()->invoke(\'' . $protectedMethodName . '\', $arguments);' . PHP_EOL .
+					"\t\t" . 'return $return;' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public static function getMockedMethods()' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
@@ -2245,12 +2262,14 @@ class generator extends atoum\test
 						"\t\t" . '$arguments = func_get_args();' . PHP_EOL .
 						"\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
 						"\t\t" . '{' . PHP_EOL .
-						"\t\t\t" . 'return $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+						"\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+						"\t\t\t" . 'return $return;' . PHP_EOL .
 						"\t\t" . '}' . PHP_EOL .
 						"\t\t" . 'else' . PHP_EOL .
 						"\t\t" . '{' . PHP_EOL .
 						"\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-						"\t\t\t" . 'return call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+						"\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+						"\t\t\t" . 'return $return;' . PHP_EOL .
 						"\t\t" . '}' . PHP_EOL .
 						"\t" . '}' . PHP_EOL .
 						"\t" . 'public static function getMockedMethods()' . PHP_EOL .


### PR DESCRIPTION
If a method returns a reference (`function &f`), then the returned value must be a variable. However, `return $return = …;` does not solve the issue. We have to `$return = …; return $return;`. This is what this patch does.