### PR TITLE
test::beforeTestMethod() should be called before tested class was loaded

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -1091,6 +1091,8 @@ abstract class test implements observable, \countable
 				{
 					ob_start();
 
+					$this->beforeTestMethod($this->currentMethod);
+
 					try
 					{
 						$testedClass = new \reflectionClass($testedClassName = $this->getTestedClassName());
@@ -1133,8 +1135,6 @@ abstract class test implements observable, \countable
 					mock\controller::setLinker($this->mockControllerLinker);
 
 					$this->testAdapterStorage->add(php\mocker::getAdapter());
-
-					$this->beforeTestMethod($this->currentMethod);
 
 					if ($this->codeCoverageIsEnabled() === true)
 					{


### PR DESCRIPTION
It must be interesting to use static mock in a test.
A static mock is a mock which is not created automatically by atoum but made by the developer because atoum can't mock a class (because it is final, for example).
So, the developer define the mock manually and require its file manually before test execution.
He can do that at top level but in this case, class name collision can happen.
To avoid that, the require can be done in the `test::beforeTestMethod()` method.
However, currently, the tested class is defined using reflection before the call to `test::beforeTestMethod()`.
So, the tested class and any class used as argument is loaded automatically by autoloader, and if a static mock is used as argument, require its file generate a class name collision.
To avoid that, `test::beforeTestMethod()` should be called BEFORE the tested class was defined.
