### PR TITLE
Add mock::receive() which is an alias of mock::call().

### DIFF
--- a/classes/asserters/mock.php
+++ b/classes/asserters/mock.php
@@ -27,6 +27,11 @@ class mock extends adapter
 		return $this;
 	}
 
+	public function receive($function)
+	{
+		return $this->call($function);
+	}
+
 	public function wasCalled($failMessage = null)
 	{
 		if ($this->adapterIsSet()->adapter->getCallsNumber() > 0)

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -207,6 +207,40 @@ class mock extends atoum\test
 		;
 	}
 
+	public function testReceive()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance)
+			->then
+				->exception(function() use ($asserter) { $asserter->receive(uniqid()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Mock is undefined')
+
+			->given(
+				$asserter->setManager($manager = new \mock\atoum\asserters\adapter\call\manager()),
+				$mock = new \mock\foo($mockController = new \mock\atoum\mock\controller()),
+				$this->calling($mockController)->getMockClass = $mockClass = uniqid()
+			)
+			->if($asserter->setWith($mock))
+			->then
+				->object($asserter->receive($function = uniqid()))->isIdenticalTo($asserter)
+				->string($asserter->getLastAssertionFile())->isEqualTo(__FILE__)
+				->integer($asserter->getLastAssertionLine())->isEqualTo(__LINE__ - 2)
+				->object($asserter->getCall())->isEqualTo(new test\adapter\call($function, null, new decorators\addClass($mockClass)))
+				->array($asserter->getBefore())->isEmpty
+				->array($asserter->getAfter())->isEmpty
+				->mock($manager)->receive('add')->withArguments($asserter)->once
+
+				->object($asserter->receive($otherFunction = uniqid()))->isIdenticalTo($asserter)
+				->string($asserter->getLastAssertionFile())->isEqualTo(__FILE__)
+				->integer($asserter->getLastAssertionLine())->isEqualTo(__LINE__ - 2)
+				->object($asserter->getCall())->isEqualTo(new test\adapter\call($otherFunction, null, new decorators\addClass($mockClass)))
+				->array($asserter->getBefore())->isEmpty
+				->array($asserter->getAfter())->isEmpty
+				->mock($manager)->receive('add')->withArguments($asserter)->twice
+		;
+	}
+
 	public function testWithArguments()
 	{
 		$this


### PR DESCRIPTION
In OOP, a method is not call agains on object (or invoked), the object receive a message.
So, this PR add the method `asserters\mock::receive()` which is basically a wrapper around `asserters\mock::call()`.
We can now write:
```
$this
	->given(
		$connection = new mock\connection,
	)
	->if(
		$this->newTestedInstance($connection)
	)
	->then
		->object($this->testedInstance->noMoreValue())->isTestedInstance
		->mock($connection)->receive('newPacket')->withArguments(new packet)->once
```
This PR introduce no regression.