### PR TITLE
Autoloader should resolve classes step by step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#443](https://github.com/atoum/atoum/pull/443) Autoloader should resolve classes step by step ([@jubianchi][jubianchi])
+
 # 2.0.1 - 2015-02-27
 
 * [#440](https://github.com/atoum/atoum/pull/440) `--configurations` option should be handled first ([@jubianchi][jubianchi])

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -203,11 +203,20 @@ class autoloader
 		}
 		else
 		{
-			$realClass = $this->resolveNamespaceAlias($this->resolveClassAlias($class));
+			$realClass = $this->resolveClassAlias($class);
 
 			if (static::exists($realClass) === false && ($path = $this->getPath($realClass)) !== null)
 			{
 				require $path;
+			}
+			else
+			{
+				$realClass = $this->resolveNamespaceAlias($realClass);
+
+				if (static::exists($realClass) === false && ($path = $this->getPath($realClass)) !== null)
+				{
+					require $path;
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a follow-up for #437.

With the #437, atoum's autoloader now tries to include a class as requested by the user without resolving aliases. When the class does not exists, atoum will try to resolve namespaces and classes aliases.

Those two resolutions are done in a single step: atoum resolves classes aliases, namespaces aliases and then atoum tries to find the class.

If resolving only classes aliases is enough to find the actual class, the autoloader will probably fail loading it if it resolves namespaces aliases on it.