### PR TITLE
fix loop mode when argument contains single quotes

### DIFF
--- a/classes/cli/command.php
+++ b/classes/cli/command.php
@@ -65,7 +65,7 @@ class command
 		}
 		else
 		{
-			$command = escapeshellcmd($this->binaryPath . $command);
+			$command = escapeshellcmd($this->binaryPath) . $command;
 		}
 
 		return $command;

--- a/tests/units/classes/cli/command.php
+++ b/tests/units/classes/cli/command.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\cli;
+
+require_once __DIR__ . '/../../runner.php';
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\cli\command as testedClass
+;
+
+class command extends atoum
+{
+
+	public function test__construct()
+	{
+		$this
+			->if($command = new testedClass())
+			->then
+				->string($command->getBinaryPath())->isEmpty()
+				->object($command->getAdapter())->isEqualTo(new atoum\adapter())
+		;
+	}
+
+	public function test__toString()
+	{
+		$this
+			->if($command = new testedClass('/usr/bin/php5'))
+			->and($command->addOption('-f', './vendor/bin/atoum'))
+			->and($command->addArgument('--disable-loop-mode'))
+			->and($command->addArgument('--force-terminal'))
+			->and($command->addArgument('-f', 'toto_test.php'))
+			->and($command->addArgument('--tags', 'test'))
+			->and($command->addArgument('--score-file', '/tmp/atoum.score'))
+			->then
+				->string((string)$command)
+					->isEqualTo("/usr/bin/php5 -f ./vendor/bin/atoum -- --disable-loop-mode --force-terminal -f 'toto_test.php' --tags 'test' --score-file '/tmp/atoum.score'")
+		;
+
+		$this
+			->if($command = new testedClass('/usr/bin/php5'))
+			->and($command->addOption('-f', './vendor/bin/atoum'))
+			->and($command->addArgument('--disable-loop-mode'))
+			->and($command->addArgument('--force-terminal'))
+			->and($command->addArgument('-f', 'toto_test.php'))
+			->and($command->addArgument('--filter', "'test1' in tags"))
+			->and($command->addArgument('--score-file', '/tmp/atoum.score'))
+			->then
+				->string((string)$command)
+					->isEqualTo("/usr/bin/php5 -f ./vendor/bin/atoum -- --disable-loop-mode --force-terminal -f 'toto_test.php' --filter ''\''test1'\'' in tags' --score-file '/tmp/atoum.score'")
+		;
+
+	}
+}


### PR DESCRIPTION
When the ruler-extension with the loop mode was runned and the filter argument had a single quote, this error occurs :

```
Error: Context reference \test1\\ does not exists.
```

cf https://github.com/atoum/ruler-extension/issues/15

This occurs because there was too much escaping when running the loop mode :

```
/usr/bin/php5 -f ./vendor/bin/atoum -- --disable-loop-mode --force-terminal -f 'toto_test.php' --filter ''\\''test1'\\'' in tags' --score-file '/tmp/atoum.score'
```

Now the command launched by the loop mode is properly escaped :

```
/usr/bin/php5 -f ./vendor/bin/atoum -- --disable-loop-mode --force-terminal -f 'toto_test.php' --filter ''\''test1'\'' in tags' --score-file '/tmp/atoum.score'
```
