### PR TITLE
Removed usage of die in deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#457](https://github.com/atoum/atoum/pull/457) Removed usage of die in deprecated methods ([@jubianchi][jubianchi])
 * [#442](https://github.com/atoum/atoum/issues/442) [#444](https://github.com/atoum/atoum/pull/444) Properly report skipped method due to a missing extension ([@jubianchi][jubianchi])
 * [#441](https://github.com/atoum/atoum/pull/441) Add PHP 7.0 in the build matrix ([@jubianchi][jubianchi])
 * [#399](https://github.com/atoum/atoum/pull/399) Add the `let` assertion handler ([@hywan][hywan])

--- a/classes/asserters/dateTime.php
+++ b/classes/asserters/dateTime.php
@@ -58,7 +58,7 @@ class dateTime extends asserters\object
 
 	public function isInYear()
 	{
-		die('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasYear instead');
+		throw new exceptions\runtime('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasYear instead');
 	}
 
 	public function hasMonth($month, $failMessage = null)
@@ -77,7 +77,7 @@ class dateTime extends asserters\object
 
 	public function isInMonth()
 	{
-		die('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasMonth instead');
+		throw new exceptions\runtime('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasMonth instead');
 	}
 
 	public function hasDay($day, $failMessage = null)
@@ -96,7 +96,7 @@ class dateTime extends asserters\object
 
 	public function isInDay()
 	{
-		die('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasDay instead');
+		throw new exceptions\runtime('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasDay instead');
 	}
 
 	public function hasDate($year, $month, $day, $failMessage = null)

--- a/tests/units/classes/asserters/dateTime.php
+++ b/tests/units/classes/asserters/dateTime.php
@@ -357,4 +357,46 @@ class dateTime extends atoum\test
 					->hasmessage($failMessage)
 		;
 	}
+
+	public function testIsInYear()
+	{
+		$this
+			->if($this->newTestedInstance)
+			->then
+				->exception(function($test) {
+						$test->testedInstance->isInYear(rand(0, PHP_INT_MAX));
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->hasMessage('The method ' . $this->getTestedClassName() . '::isInYear is deprecated, please use ' . $this->getTestedClassName() . '::hasYear instead')
+		;
+	}
+
+	public function testIsInMonth()
+	{
+		$this
+			->if($this->newTestedInstance)
+			->then
+				->exception(function($test) {
+						$test->testedInstance->isInMonth(rand(0, PHP_INT_MAX));
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->hasMessage('The method ' . $this->getTestedClassName() . '::isInMonth is deprecated, please use ' . $this->getTestedClassName() . '::hasMonth instead')
+		;
+	}
+
+	public function testIsInDay()
+	{
+		$this
+			->if($this->newTestedInstance)
+			->then
+				->exception(function($test) {
+						$test->testedInstance->isInDay(rand(0, PHP_INT_MAX));
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
+					->hasMessage('The method ' . $this->getTestedClassName() . '::isInDay is deprecated, please use ' . $this->getTestedClassName() . '::hasDay instead')
+		;
+	}
 }


### PR DESCRIPTION
This is a tiny fix in an asserter using `die` to emit deprecation message.

`die` will work in most cases but for those using the `inline` engine, it will make it stop right away. So if a method uses one of the deprecated assertions, the following test method will never run until the user fixes the deprecations.

atoum will now throw runtime exceptions which will get reported as `E_USER_ERROR` which I think is more appropriate. Also the test suite won't stop when the error is thrown.