### PR TITLE
Add support for branch and path coverage

### DIFF
--- a/classes/report/fields/runner/coverage.php
+++ b/classes/report/fields/runner/coverage.php
@@ -129,7 +129,7 @@ abstract class coverage extends report\field
 				$phpCode .=
 					'$data = array(\'classes\' => get_declared_classes());' .
 					'ob_start();' .
-					'xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);' .
+					'xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE' . ($observable->branchCoverageIsEnabled() === true ? ' | XDEBUG_CC_BRANCH_CHECK' : '')  . ');' .
 					'require_once \'%s\';' .
 					'$data[\'coverage\'] = xdebug_get_code_coverage();' .
 					'xdebug_stop_code_coverage();' .

--- a/classes/report/fields/runner/tests/coverage/cli.php
+++ b/classes/report/fields/runner/tests/coverage/cli.php
@@ -46,6 +46,31 @@ class cli extends report\fields\runner\tests\coverage
 				PHP_EOL
 			;
 
+			if (sizeof($this->coverage->getPaths()) > 0)
+			{
+				$string .= $this->titlePrompt .
+					sprintf(
+						$this->locale->_('%s: %s'),
+						$this->titleColorizer->colorize($this->locale->_('Path coverage value')),
+						$this->coverageColorizer->colorize(sprintf('%3.2f%%', $this->coverage->getPathsCoverageValue() * 100.0))
+					) .
+					PHP_EOL
+				;
+			}
+
+			if (sizeof($this->coverage->getBranches()) > 0)
+			{
+				$string .= $this->titlePrompt .
+					sprintf(
+						$this->locale->_('%s: %s'),
+						$this->titleColorizer->colorize($this->locale->_('Branch coverage value')),
+						$this->coverageColorizer->colorize(sprintf('%3.2f%%', $this->coverage->getBranchesCoverageValue() * 100.0))
+					) .
+					PHP_EOL
+				;
+			}
+
+
 			foreach ($this->coverage->getMethods() as $class => $methods)
 			{
 				$classCoverage = $this->coverage->getValueForClass($class);

--- a/classes/reports/asynchronous/xunit.php
+++ b/classes/reports/asynchronous/xunit.php
@@ -132,7 +132,7 @@ class xunit extends atoum\reports\asynchronous
 				{
 					$time += $duration['value'];
 
-					static::getTestCase($document, $testSuite, $name, $duration['method'], $duration['value'], $duration['path'], isset($class['assertions'][$duration['method']]) ? $class['assertions'][$duration['method']] : 0);
+					self::getTestCase($document, $testSuite, $name, $duration['method'], $duration['value'], $duration['path'], isset($class['assertions'][$duration['method']]) ? $class['assertions'][$duration['method']] : 0);
 				}
 
 				$testSuite->setAttribute('time', $time);
@@ -194,7 +194,7 @@ class xunit extends atoum\reports\asynchronous
 
 	private static function getTestCase(\DOMDocument $document, \DOMElement $testSuite, $class, $method, $time, $path, $assertions)
 	{
-		if (($testCase = static::findTestCase($document, $class, $method)) === null)
+		if (($testCase = self::findTestCase($document, $class, $method)) === null)
 		{
 			$testCase = $document->createElement('testcase');
 			$testCase->setAttribute('name', $method);

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -31,6 +31,7 @@ class runner implements observable
 	protected $testNumber = 0;
 	protected $testMethodNumber = 0;
 	protected $codeCoverage = true;
+	protected $branchCoverage = false;
 	protected $php = null;
 	protected $defaultReportTitle = null;
 	protected $maxChildrenNumber = null;
@@ -371,6 +372,25 @@ class runner implements observable
 		return $this->codeCoverage;
 	}
 
+	public function enableBranchCoverage()
+	{
+		$this->branchCoverage = $this->codeCoverageIsEnabled();
+
+		return $this;
+	}
+
+	public function disableBranchCoverage()
+	{
+		$this->branchCoverage = false;
+
+		return $this;
+	}
+
+	public function branchCoverageIsEnabled()
+	{
+		return $this->branchCoverage;
+	}
+
 	public function doNotfailIfVoidMethods()
 	{
 		$this->failIfVoidMethods = false;
@@ -558,6 +578,11 @@ class runner implements observable
 					}
 					else
 					{
+						if ($this->branchCoverageIsEnabled())
+						{
+							$test->enableBranchCoverage();
+						}
+
 						$test->getScore()->setCoverage($this->getCoverage());
 					}
 
@@ -890,38 +915,5 @@ class runner implements observable
 		}
 
 		return $this;
-	}
-
-	private static function getMethods(test $test, array $runTestMethods, array $tags)
-	{
-		$methods = array();
-
-		if (isset($runTestMethods['*']) === true)
-		{
-			$methods = $runTestMethods['*'];
-		}
-
-		$testClass = $test->getClass();
-
-		if (isset($runTestMethods[$testClass]) === true)
-		{
-			$methods = $runTestMethods[$testClass];
-		}
-
-		if (in_array('*', $methods) === true)
-		{
-			$methods = array();
-		}
-
-		if (sizeof($methods) <= 0)
-		{
-			$methods = $test->getTestMethods($tags);
-		}
-		else
-		{
-			$methods = $test->getTaggedTestMethods($methods, $tags);
-		}
-
-		return $methods;
 	}
 }

--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -14,6 +14,8 @@ class coverage implements \countable, \serializable
 	protected $reflectionClassFactory = null;
 	protected $classes = array();
 	protected $methods = array();
+	protected $paths = array();
+	protected $branches = array();
 	protected $excludedMethods = array();
 	protected $excludedClasses = array();
 	protected $excludedNamespaces = array();
@@ -56,6 +58,8 @@ class coverage implements \countable, \serializable
 		return serialize(array(
 				$this->classes,
 				$this->methods,
+				$this->paths,
+				$this->branches,
 				$this->excludedClasses,
 				$this->excludedNamespaces,
 				$this->excludedDirectories
@@ -70,6 +74,8 @@ class coverage implements \countable, \serializable
 		list(
 			$this->classes,
 			$this->methods,
+			$this->paths,
+			$this->branches,
 			$this->excludedClasses,
 			$this->excludedNamespaces,
 			$this->excludedDirectories
@@ -88,10 +94,22 @@ class coverage implements \countable, \serializable
 		return $this->methods;
 	}
 
+	public function getPaths()
+	{
+		return $this->paths;
+	}
+
+	public function getBranches()
+	{
+		return $this->branches;
+	}
+
 	public function reset()
 	{
 		$this->classes = array();
 		$this->methods = array();
+		$this->paths = array();
+		$this->branches = array();
 
 		return $this;
 	}
@@ -155,6 +173,12 @@ class coverage implements \countable, \serializable
 								$declaringClassName = $declaringClass->getName();
 								$declaringClassFile = $declaringClass->getFilename();
 
+								if (isset($data[$declaringClassFile]['functions'][$declaringClassName . '->' . $method->getName()]))
+								{
+									$this->paths[$declaringClassName][$method->getName()] = $data[$declaringClassFile]['functions'][$declaringClassName . '->' . $method->getName()]['paths'];
+									$this->branches[$declaringClassName][$method->getName()] = $data[$declaringClassFile]['functions'][$declaringClassName . '->' . $method->getName()]['branches'];
+								}
+
 								if (isset($this->classes[$declaringClassName]) === false)
 								{
 									$this->classes[$declaringClassName] = $declaringClassFile;
@@ -165,6 +189,11 @@ class coverage implements \countable, \serializable
 								{
 									for ($line = $method->getStartLine(), $endLine = $method->getEndLine(); $line <= $endLine; $line++)
 									{
+										if (isset($data[$declaringClassFile]['lines'][$line]) === true && (isset($this->methods[$declaringClassName][$method->getName()][$line]) === false || $this->methods[$declaringClassName][$method->getName()][$line] < $data[$declaringClassFile][$line]))
+										{
+											$this->methods[$declaringClassName][$method->getName()][$line] = $data[$declaringClassFile]['lines'][$line];
+										}
+
 										if (isset($data[$declaringClassFile][$line]) === true && (isset($this->methods[$declaringClassName][$method->getName()][$line]) === false || $this->methods[$declaringClassName][$method->getName()][$line] < $data[$declaringClassFile][$line]))
 										{
 											$this->methods[$declaringClassName][$method->getName()][$line] = $data[$declaringClassFile][$line];
@@ -184,6 +213,8 @@ class coverage implements \countable, \serializable
 
 	public function merge(score\coverage $coverage)
 	{
+		$paths = $coverage->getPaths();
+		$branches = $coverage->getBranches();
 		$classes = $coverage->getClasses();
 		$methods = $coverage->getMethods();
 
@@ -198,8 +229,50 @@ class coverage implements \countable, \serializable
 					$this->classes[$class] = $classes[$class];
 				}
 
+				if (isset($paths[$class]) && isset($this->paths[$class]) === false)
+				{
+					$this->paths[$class] = $paths[$class];
+				}
+
+				if (isset($branches[$class]) && isset($this->branches[$class]) === false)
+				{
+					$this->branches[$class] = $branches[$class];
+				}
+
 				foreach ($methods as $method => $lines)
 				{
+					if (isset($paths[$class]) === true)
+					{
+						if (isset($this->paths[$class][$method]) === false)
+						{
+							$this->paths[$class][$method] = $paths[$class][$method];
+						}
+
+						foreach ($paths[$class][$method] as $index => $path)
+						{
+							if ($this->paths[$class][$method][$index]['hit'] < $path['hit'])
+							{
+								$this->paths[$class][$method][$index]['hit'] = $path['hit'];
+							}
+						}
+					}
+
+					if (isset($branches[$class]) === true)
+					{
+						if (isset($this->branches[$class][$method]) === false)
+						{
+							$this->branches[$class][$method] = $branches[$class][$method];
+						}
+
+						foreach ($branches[$class][$method] as $index => $branch)
+						{
+							if ($this->branches[$class][$method][$index]['hit'] < $branch['hit'])
+							{
+								$this->branches[$class][$method][$index]['hit'] = $branch['hit'];
+							}
+						}
+					}
+
 					if (isset($this->methods[$class][$method]) === true || $this->isExcluded($this->getDeclaringClass($reflectedClass->getMethod($method))) === false)
 					{
 						foreach ($lines as $line => $call)
@@ -248,6 +321,74 @@ class coverage implements \countable, \serializable
 			if ($totalLines > 0)
 			{
 				$value = (float) $coveredLines / $totalLines;
+			}
+		}
+
+		return $value;
+	}
+
+	public function getPathsCoverageValue()
+	{
+		$value = null;
+
+		if (sizeof($this->getPaths()) > 0)
+		{
+			$totalPaths = 0;
+			$coveredPaths = 0;
+
+			foreach ($this->paths as $methods)
+			{
+				foreach ($methods as $method)
+				{
+					foreach ($method as $path)
+					{
+						$totalPaths++;
+
+						if ($path['hit'] === 1)
+						{
+							$coveredPaths++;
+						}
+					}
+				}
+			}
+
+			if ($totalPaths > 0)
+			{
+				$value = (float) $coveredPaths / $totalPaths;
+			}
+		}
+
+		return $value;
+	}
+
+	public function getBranchesCoverageValue()
+	{
+		$value = null;
+
+		if (sizeof($this->getBranches()) > 0)
+		{
+			$totalBranches = 0;
+			$coveredBranches = 0;
+
+			foreach ($this->branches as $methods)
+			{
+				foreach ($methods as $method)
+				{
+					foreach ($method as $branch)
+					{
+						$totalBranches++;
+
+						if ($branch['hit'] === 1)
+						{
+							$coveredBranches++;
+						}
+					}
+				}
+			}
+
+			if ($totalBranches > 0)
+			{
+				$value = (float) $coveredBranches / $totalBranches;
 			}
 		}
 

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -337,6 +337,13 @@ class runner extends atoum\script\configurable
 		return $this;
 	}
 
+	public function enableBranchCoverage()
+	{
+		$this->runner->enableBranchCoverage();
+
+		return $this;
+	}
+
 	public function excludeNamespacesFromCoverage(array $namespaces)
 	{
 		$coverage = $this->runner->getCoverage();
@@ -790,6 +797,19 @@ class runner extends atoum\script\configurable
 					array('-nccfm', '--no-code-coverage-for-methods'),
 					'<method>...',
 					$this->locale->_('Disable code coverage for methods <method>')
+				)
+			->addArgumentHandler(
+					function($script, $argument, $empty) {
+						if ($empty)
+						{
+							throw new exceptions\logic\invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));
+						}
+
+						$script->enableBranchCoverage();
+					},
+					array('-ebpc', '--enable-branch-and-path-coverage'),
+					null,
+					$this->locale->_('Enable branch and path coverage')
 				)
 			->addArgumentHandler(
 					function($script, $argument, $files) {

--- a/classes/test.php
+++ b/classes/test.php
@@ -78,6 +78,7 @@ abstract class test implements observable, \countable
 	private $debugMode = false;
 	private $xdebugConfig = null;
 	private $codeCoverage = false;
+	private $branchCoverage = false;
 	private $classHasNotVoidMethods = false;
 	private $extensions = null;
 
@@ -693,6 +694,25 @@ abstract class test implements observable, \countable
 		return $this;
 	}
 
+	public function branchCoverageIsEnabled()
+	{
+		return $this->branchCoverage;
+	}
+
+	public function enableBranchCoverage()
+	{
+		$this->branchCoverage = $this->codeCoverageIsEnabled() && defined('XDEBUG_CC_BRANCH_CHECK');
+
+		return $this;
+	}
+
+	public function disableBranchCoverage()
+	{
+		$this->branchCoverage = false;
+
+		return $this;
+	}
+
 	public function setMaxChildrenNumber($number)
 	{
 		$number = (int) $number;
@@ -1161,7 +1181,14 @@ abstract class test implements observable, \countable
 
 					if ($this->codeCoverageIsEnabled() === true)
 					{
-						xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+						$options = XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE;
+
+						if ($this->branchCoverageIsEnabled() === true)
+						{
+							$options |= XDEBUG_CC_BRANCH_CHECK;
+						}
+
+						xdebug_start_code_coverage($options);
 					}
 
 					$assertionNumber = $this->score->getAssertionNumber();

--- a/classes/test/engines/concurrent.php
+++ b/classes/test/engines/concurrent.php
@@ -99,6 +99,11 @@ class concurrent extends test\engine
 			}
 			else
 			{
+				if ($this->test->branchCoverageIsEnabled() === true)
+				{
+					$phpCode .= '$test->enableBranchCoverage();';
+				}
+
 				$phpCode .= '$coverage = $test->getCoverage();';
 
 				foreach ($this->test->getCoverage()->getExcludedMethods() as $excludedMethod)

--- a/tests/units/classes/scripts/coverage.php
+++ b/tests/units/classes/scripts/coverage.php
@@ -105,6 +105,11 @@ class coverage extends atoum\test
 							'Disable code coverage for methods <method>'
 						),
 						array(
+							array('-ebpc', '--enable-branch-and-path-coverage'),
+							null,
+							'Enable branch and path coverage'
+						),
+						array(
 							array('-f', '--files'),
 							'<file>...',
 							'Execute all unit test files <file>'
@@ -286,6 +291,11 @@ class coverage extends atoum\test
 							array('-nccfm', '--no-code-coverage-for-methods'),
 							'<method>...',
 							'Disable code coverage for methods <method>'
+						),
+						array(
+							array('-ebpc', '--enable-branch-and-path-coverage'),
+							null,
+							'Enable branch and path coverage'
 						),
 						array(
 							array('-f', '--files'),

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -115,6 +115,11 @@ class runner extends atoum\test
 							'Disable code coverage for methods <method>'
 						),
 						array(
+							array('-ebpc', '--enable-branch-and-path-coverage'),
+							null,
+							'Enable branch and path coverage'
+						),
+						array(
 							array('-f', '--files'),
 							'<file>...',
 							'Execute all unit test files <file>'
@@ -285,6 +290,11 @@ class runner extends atoum\test
 							array('-nccfm', '--no-code-coverage-for-methods'),
 							'<method>...',
 							'Disable code coverage for methods <method>'
+						),
+						array(
+							array('-ebpc', '--enable-branch-and-path-coverage'),
+							null,
+							'Enable branch and path coverage'
 						),
 						array(
 							array('-f', '--files'),


### PR DESCRIPTION
Here comes branch and path coverage for all of you coverage lovers!

## Requirements:

To test this new feature you will need xDebug `>= 2.3`. To install it, use [pickle](https://github.com/FriendsOfPHP/pickle)

```
$ pickle install xdebug
```

## Testing this branch:

The patch is actually in its own branch since it's not finished. If you want to play with it you'll have to tweak your `composer.json`:

```json
{
	"require": {
		"atoum/atoum": "dev-branch-path-coverage as 2.1.0"	
	}	
}
```

## Use it:

Enabling branch and path coverage is as simple as appending an extra command line argument when you run your tests:

```
vendor/bin/atoum -d tests/units --enable-branch-and-path-coverage # or -ebpc
```

You test suite will run as usual but you will get extra informations on the command line output:

![atoum_coverage](https://cloud.githubusercontent.com/assets/327237/7139022/389df178-e2c4-11e4-85f3-5b0ab6022b11.png)

## Todo:

* [ ] Display branch coverage in the HTML report
* [ ] Display path coverage in the HTML report