### PR TITLE
Hide classes and methods coverage details in CLI report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#452](https://github.com/atoum/atoum/issues/452) Hide classes and methods coverage details in CLI report ([@jubianchi])
 * [#474](https://github.com/atoum/atoum/pull/474) Add the method return type and parameter type in the mock generator ([@guillaumeDievart])
 * [#470](https://github.com/atoum/atoum/pull/470) Add `isNotEmpty` asserter on `array` ([@metalaka])
 

--- a/classes/report/fields/runner/tests/coverage/cli.php
+++ b/classes/report/fields/runner/tests/coverage/cli.php
@@ -17,6 +17,8 @@ class cli extends report\fields\runner\tests\coverage
 	protected $methodPrompt = null;
 	protected $titleColorizer = null;
 	protected $coverageColorizer = null;
+	protected $hideClassesCoverageDetails = false;
+	protected $hideMethodsCoverageDetails = false;
 
 	public function __construct()
 	{
@@ -71,43 +73,46 @@ class cli extends report\fields\runner\tests\coverage
 			}
 
 
-			foreach ($this->coverage->getMethods() as $class => $methods)
+			if ($this->hideClassesCoverageDetails === false)
 			{
-				$classCoverage = $this->coverage->getValueForClass($class);
-				$classPathsCoverage = $this->coverage->getPathsCoverageValueForClass($class);
-				$classBranchesCoverage = $this->coverage->getBranchesCoverageValueForClass($class);
-
-				if ($classCoverage < 1.0)
+				foreach ($this->coverage->getMethods() as $class => $methods)
 				{
-					$string .= $this->classPrompt .
-						sprintf(
-							$this->locale->_('%s: %s%s%s'),
-							$this->titleColorizer->colorize(sprintf($this->locale->_('Class %s'), $class)),
-							$this->coverageColorizer->colorize(sprintf('%s%3.2f%%', ($classPathsCoverage !== null || $classBranchesCoverage !== null ? 'Line: ' : ''), $classCoverage * 100.0)),
-							$classPathsCoverage !== null ? $this->coverageColorizer->colorize(sprintf(' Path: %3.2f%%', $classPathsCoverage * 100.0)) : '',
-							$classBranchesCoverage !== null ? $this->coverageColorizer->colorize(sprintf(' Branch: %3.2f%%', $classBranchesCoverage * 100.0)) : ''
-						) .
-						PHP_EOL
-					;
+					$classCoverage = $this->coverage->getValueForClass($class);
+					$classPathsCoverage = $this->coverage->getPathsCoverageValueForClass($class);
+					$classBranchesCoverage = $this->coverage->getBranchesCoverageValueForClass($class);
 
-					foreach (array_keys($methods) as $method)
+					if ($classCoverage < 1.0)
 					{
-						$methodCoverage = $this->coverage->getValueForMethod($class, $method);
-						$methodPathsCoverage = $this->coverage->getPathsCoverageValueForMethod($class, $method);
-						$methodBranchesCoverage = $this->coverage->getBranchesCoverageValueForMethod($class, $method);
+						$string .= $this->classPrompt .
+							sprintf(
+								$this->locale->_('%s: %s%s%s'),
+								$this->titleColorizer->colorize(sprintf($this->locale->_('Class %s'), $class)),
+								$this->coverageColorizer->colorize(sprintf('%s%3.2f%%', ($classPathsCoverage !== null || $classBranchesCoverage !== null ? 'Line: ' : ''), $classCoverage * 100.0)),
+								$classPathsCoverage !== null ? $this->coverageColorizer->colorize(sprintf(' Path: %3.2f%%', $classPathsCoverage * 100.0)) : '',
+								$classBranchesCoverage !== null ? $this->coverageColorizer->colorize(sprintf(' Branch: %3.2f%%', $classBranchesCoverage * 100.0)) : ''
+							) .
+							PHP_EOL
+						;
 
-						if ($methodCoverage < 1.0)
+						if ($this->hideMethodsCoverageDetails === false)
 						{
-							$string .= $this->methodPrompt .
-								sprintf(
-									$this->locale->_('%s: %s%s%s'),
-									$this->titleColorizer->colorize(sprintf($this->locale->_('%s::%s()'), $class, $method)),
-									$this->coverageColorizer->colorize(sprintf('%s%3.2f%%', ($methodPathsCoverage !== null || $methodBranchesCoverage !== null ? 'Line: ' : ''), $methodCoverage * 100.0)),
-									$methodPathsCoverage !== null ? $this->coverageColorizer->colorize(sprintf(', Path: %3.2f%%', $methodPathsCoverage * 100.0)) : '',
-									$methodBranchesCoverage !== null ? $this->coverageColorizer->colorize(sprintf(', Branch: %3.2f%%', $methodBranchesCoverage * 100.0)) : ''
-								) .
-								PHP_EOL
-							;
+							foreach (array_keys($methods) as $method) {
+								$methodCoverage = $this->coverage->getValueForMethod($class, $method);
+								$methodPathsCoverage = $this->coverage->getPathsCoverageValueForMethod($class, $method);
+								$methodBranchesCoverage = $this->coverage->getBranchesCoverageValueForMethod($class, $method);
+
+								if ($methodCoverage < 1.0) {
+									$string .= $this->methodPrompt .
+										sprintf(
+											$this->locale->_('%s: %s%s%s'),
+											$this->titleColorizer->colorize(sprintf($this->locale->_('%s::%s()'), $class, $method)),
+											$this->coverageColorizer->colorize(sprintf('%s%3.2f%%', ($methodPathsCoverage !== null || $methodBranchesCoverage !== null ? 'Line: ' : ''), $methodCoverage * 100.0)),
+											$methodPathsCoverage !== null ? $this->coverageColorizer->colorize(sprintf(', Path: %3.2f%%', $methodPathsCoverage * 100.0)) : '',
+											$methodBranchesCoverage !== null ? $this->coverageColorizer->colorize(sprintf(', Branch: %3.2f%%', $methodBranchesCoverage * 100.0)) : ''
+										) .
+										PHP_EOL;
+								}
+							}
 						}
 					}
 				}
@@ -175,5 +180,19 @@ class cli extends report\fields\runner\tests\coverage
 	public function getCoverageColorizer()
 	{
 		return $this->coverageColorizer;
+	}
+
+	public function hideClassesCoverageDetails()
+	{
+		$this->hideClassesCoverageDetails = true;
+
+		return $this;
+	}
+
+	public function hideMethodsCoverageDetails()
+	{
+		$this->hideMethodsCoverageDetails = true;
+
+		return $this;
 	}
 }

--- a/classes/reports/realtime/cli.php
+++ b/classes/reports/realtime/cli.php
@@ -13,6 +13,8 @@ use
 
 class cli extends realtime
 {
+	private $runnerTestsCoverageField = false;
+
 	public function __construct()
 	{
 		parent::__construct();
@@ -56,15 +58,15 @@ class cli extends realtime
 
 		$this->addField($runnerTestsMemoryField);
 
-		$runnerTestsCoverageField = new runner\tests\coverage\cli();
-		$runnerTestsCoverageField
+		$this->runnerTestsCoverageField = new runner\tests\coverage\cli();
+		$this->runnerTestsCoverageField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($defaultColorizer)
 			->setClassPrompt($secondLevelPrompt)
 			->setMethodPrompt(new prompt('==> ', $defaultColorizer))
 		;
 
-		$this->addField($runnerTestsCoverageField);
+		$this->addField($this->runnerTestsCoverageField);
 
 		$runnerDurationField = new runner\duration\cli();
 		$runnerDurationField
@@ -201,5 +203,19 @@ class cli extends realtime
 		;
 
 		$this->addField($testMemoryField);
+	}
+
+	public function hideClassesCoverageDetails()
+	{
+		$this->runnerTestsCoverageField->hideClassesCoverageDetails();
+
+		return $this;
+	}
+
+	public function hideMethodsCoverageDetails()
+	{
+		$this->runnerTestsCoverageField->hideMethodsCoverageDetails();
+
+		return $this;
 	}
 }

--- a/tests/units/classes/report/fields/runner/tests/coverage/cli.php
+++ b/tests/units/classes/report/fields/runner/tests/coverage/cli.php
@@ -119,6 +119,24 @@ class cli extends atoum\test
 		;
 	}
 
+	public function testHideClassesCoverageDetails()
+	{
+		$this
+			->if($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->hideClassesCoverageDetails())->isTestedInstance
+		;
+	}
+
+	public function testHideMethodsCoverageDetails()
+	{
+		$this
+			->if($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->hideMethodsCoverageDetails())->isTestedInstance
+		;
+	}
+
 	public function test__toString()
 	{
 		$this
@@ -236,6 +254,21 @@ class cli extends atoum\test
 						) .
 						PHP_EOL
 					)
+			->if($defaultField->hideMethodsCoverageDetails())
+			->and($defaultField->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->castToString($defaultField)->isEqualTo(
+						$defaultField->getTitlePrompt() . sprintf($defaultField->getLocale()->_('Code coverage value: %3.2f%%'), $scoreCoverage->getValue() * 100) . PHP_EOL .
+						$defaultField->getClassPrompt() . sprintf($defaultField->getLocale()->_('Class %s: %3.2f%%'), $className, $scoreCoverage->getValueForClass($className) * 100.0) . PHP_EOL
+					)
+			->if($defaultField->hideClassesCoverageDetails())
+			->and($defaultField->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->castToString($defaultField)->isEqualTo($defaultField->getTitlePrompt() . sprintf($defaultField->getLocale()->_('Code coverage value: %3.2f%%'), $scoreCoverage->getValue() * 100) . PHP_EOL)
+			->if($customField->hideClassesCoverageDetails())
+			->and($customField->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->castToString($customField)->isEqualTo($customField->getTitlePrompt() . sprintf($customField->getLocale()->_('Code coverage value: %3.2f%%'), $scoreCoverage->getValue() * 100) . PHP_EOL)
 		;
 	}
 }


### PR DESCRIPTION
Using `hideClassesCoverageDetails` and `hideMethodsCoverageDetails`
on `mageekguy\atoum\reports\realtime\cli` report the user can choose to
disable classes and methods coverage details.

Here is an example configuration file:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

$script->addDefaultReport()
    ->hideClassesCoverageDetails()
    ->hideMethodsCoverageDetails()
;

```

ping @mageekguy 