### PR TITLE
Add isNotEmpty property to array asserter

### DIFF
--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -28,6 +28,9 @@ class phpArray extends asserters\variable implements \arrayAccess
 			case 'isempty':
 				return $this->isEmpty();
 
+			case 'isnotempty':
+				return $this->isNotEmpty();
+
 			default:
 				$asserter = parent::__get($asserter);
 

--- a/tests/units/classes/asserters/phpArray.php
+++ b/tests/units/classes/asserters/phpArray.php
@@ -384,6 +384,11 @@ class phpArray extends atoum\test
 					->hasMessage($isEmpty)
 				->mock($locale)->call('_')->withArguments('%s is empty', $asserter)->once
 
+				->exception(function() use ($asserter) { $asserter->isNotEmpty; })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($isEmpty)
+				->mock($locale)->call('_')->withArguments('%s is empty', $asserter)->twice
+
 				->exception(function() use ($asserter, & $failMessage) { $asserter->isNotEmpty($failMessage = uniqid()); })
 						->isInstanceOf('mageekguy\atoum\asserter\exception')
 						->hasMessage($failMessage)


### PR DESCRIPTION
Hi,

This PR add  the missing `isNotEmpty` "property" of array asserter.

So, it's improve atoum consistency, all asserters methods without arguments can be called as properties.