### PR TITLE
add relative url root choice

### DIFF
--- a/resources/treemap/index.html
+++ b/resources/treemap/index.html
@@ -240,6 +240,12 @@
 			return zoom(node == d.parent ? root : d.parent);
 		} else if (codeUrl) {
 			return window.location.href = codeUrl + d.path;
+		} else if (codeUrl === '') {
+			var urlBase = window.location.href;
+			if (urlBase.substr(urlBase.length - 1) !== '/') {
+				urlBase = window.location.href.substring(0, window.location.href.lastIndexOf("/") + 1);
+			}
+			return window.location.href = urlBase + d.path;
 		}
 	};
 

--- a/resources/treemap/index.html
+++ b/resources/treemap/index.html
@@ -243,7 +243,7 @@
 		} else if (codeUrl === '') {
 			var urlBase = window.location.href;
 			if (urlBase.substr(urlBase.length - 1) !== '/') {
-				urlBase = window.location.href.substring(0, window.location.href.lastIndexOf("/") + 1);
+				urlBase = window.location.href.substring(0, window.location.href.lastIndexOf('/') + 1);
 			}
 			return window.location.href = urlBase + d.path;
 		}


### PR DESCRIPTION
This change allows Atoum users to use relative root URL for code coverage. Now, the `html::setRootUrl` method can take either a relative URL or an absolute URL as argument.