### PR TITLE
Fix exit code when there is something wrong in the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#477](https://github.com/atoum/atoum/pull/477) Fix exit code when there is something wrong in the configuration file ([@jubianchi])
+
 # 2.2.1 - 2015-08-27
 
 * [#491](https://github.com/atoum/atoum/pull/491) Fix `getTestMethodPrefix` when the prefix is `"0"` ([@remicollet])

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -205,6 +205,8 @@ class runner extends atoum\script\configurable
 		catch (atoum\exception $exception)
 		{
 			$this->writeError($exception->getMessage());
+
+			exit(2);
 		}
 
 		return $this;


### PR DESCRIPTION
This fixes a wrong status code when there an exception is thrown from a  call in the configuration file, see #472.

@mageekguy if you have some time to review it, it could be great : I just reverted a line you removed [here](https://github.com/atoum/atoum/commit/a13bf32e60091033a7a5db7d2d335a0b4a0a7a6d#diff-9a3727c7c25609d53b1b645a9db30c43L209) but I don't remember why you removed it and I'm afraid I'm missing a use-case or something.