### PR TITLE
Allow failure on PHP7 builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - hhvm-nightly
 matrix:
   allow_failures:
+    - php: 7.0
     - php: hhvm
     - php: hhvm-nightly
 notifications:


### PR DESCRIPTION
As long as PHP7 is not stable, builds on PHP7 should be allowed to failed without set entire build to failed