### PR TITLE
Add link to @n-couet in the `CHANGELOG.md` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,4 @@
 [@hywan]: https://github.com/hywan
 [@metalaka]: https://github.com/metalaka
 [@GuillaumeDievart]: https://github.com/GuillaumeDievart
+[@n-couet]: https://github.com/n-couet


### PR DESCRIPTION
The link to @n-couet was missing. This patch adds this link.