### PR TITLE
Compare nested objects with object::isEqualTo()

### DIFF
--- a/tests/units/classes/asserters/object.php
+++ b/tests/units/classes/asserters/object.php
@@ -361,4 +361,117 @@ class object extends atoum\test
 				->object($asserter->isNotInstanceOf(new \stdClass()))->isIdenticalTo($asserter)
 		;
 	}
+
+	public function testIsEqualTo()
+	{
+		$this
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+				$object->property = $object,
+				$otherObject->property = $otherObject,
+				$asserter = $this->newTestedInstance
+			)
+			->if($asserter->setWith($object))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($object)
+				->exception(function() use ($asserter) { $asserter->isEqualTo($asserter); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+
+			->if($asserter->setWith($asserter))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($asserter)
+				->exception(function() use ($asserter, $object) { $asserter->isEqualTo($object); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+				$object->property = $object,
+				$otherObject->property = $object
+			)
+			->if($asserter->setWith($object))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($object)
+				->object($asserter->isEqualTo($otherObject))->isTestedInstance
+				->object($asserter->getValue())->isIdenticalTo($object)
+
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+				$childObject = new \stdClass,
+				$otherChildObject = new \stdClass,
+
+				$childObject->property = $object,
+				$otherChildObject->property = $object,
+
+				$object->child = $childObject,
+				$otherObject->child = $childObject
+			)
+			->if($asserter->setWith($object))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($object)
+				->object($asserter->isEqualTo($otherObject))->isTestedInstance
+				->object($asserter->getValue())->isIdenticalTo($object)
+
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+				$childObject = new \stdClass,
+				$otherChildObject = new \stdClass,
+
+				$childObject->property = $object,
+				$otherChildObject->property = $object,
+
+				$object->child = $childObject,
+				$otherObject->child = $otherChildObject
+			)
+			->if($asserter->setWith($object))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($object)
+				->boolean($object == $otherObject)->isTrue
+				->object($asserter->isEqualTo($otherObject))->isTestedInstance
+				->object($asserter->getValue())->isIdenticalTo($object)
+
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+
+				$childObject->property = array('foo'),
+				$otherChildObject->property = array('foo')
+			)
+			->if($asserter->setWith($object))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($object)
+				->boolean($object == $otherObject)->isTrue
+				->object($asserter->isEqualTo($otherObject))->isTestedInstance
+				->object($asserter->getValue())->isIdenticalTo($object)
+
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+
+				$childObject->property = array(array('foo')),
+				$otherChildObject->property = array(array('foo'))
+			)
+			->if($asserter->setWith($object))
+			->then
+				->object($asserter->getValue())->isIdenticalTo($object)
+				->boolean($object == $otherObject)->isTrue
+				->object($asserter->isEqualTo($otherObject))->isTestedInstance
+				->object($asserter->getValue())->isIdenticalTo($object)
+
+			->given(
+				$object = new \stdClass,
+				$otherObject = new \stdClass,
+
+				$childObject->property = array(array(function() {})),
+				$otherChildObject->property = array(array(function() {}))
+			)
+			->if($asserter->setWith($object))
+			->then
+				->exception(function() use ($asserter) { $asserter->isEqualTo($asserter); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+		;
+	}
 }


### PR DESCRIPTION
Attempt to fix #333... I don't find this solution very clean but it's the easiest one I found... Feedbacks are welcome, especially on the unit test because I probably missed some cases event if the full atoum test suite is green.

This is a POC of a strategy to compare deeply nested objects. PHP throws
fatal errors when the nesting level is too high so we can't catch it and
fallback. We have to always apply this strategy.

Basically, how this works:
- we try to `json_encode` objects with a limited depth: if this works we can assume that their is no nesting and the `==` will work.
- if the `json_encode` fails and the value is an object, we cast it to an array containing all properties (public, protected and private) we then clean the array removing closures for further serialization (we replace each closure instance by its spl_hash)
- we then walk the array to remove recursion by replacing each nested by its identity

The identity we use here is a plain string we compute by:
- serializing the original object
- computing an md5sum on the result

When we walk the object tree, each time we find a nested object for
which we already computed the identity, we replace it by its identity
value.

Finally, if we do not find any recursion, we just return the original
value we received. If there is a recursion, we cast the unnested array
to an object and give it to the asserter.

NOTE:
- the `md5` on the identity is probably useless
- the `json_encode` thing can be remove and everything should still work, I just tried to limit to scope of this hacky strategy (i.e do not use it if PHP can handle the compare)
- this seems less complex than what has been done on phpunit for example
- we can probably improve it
- there probably are many edge-cases
- ...
