### PR TITLE
fix setTestMethodPrefix/getTestMethodPrefix inconsistency

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -772,7 +772,7 @@ abstract class test implements observable, \countable
 
 	public function getTestMethodPrefix()
 	{
-		return $this->testMethodPrefix ?: self::getMethodPrefix();
+		return $this->testMethodPrefix !== NULL ? $this->testMethodPrefix : self::getMethodPrefix();
 	}
 
 	public function setPhpPath($path)

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -373,6 +373,8 @@ namespace mageekguy\atoum\tests\units
 					->string($test->getTestMethodPrefix())->isEqualTo($testMethodPrefix)
 					->object($test->setTestMethodPrefix($testMethodPrefix = rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($test)
 					->string($test->getTestMethodPrefix())->isEqualTo((string) $testMethodPrefix)
+					->object($test->setTestMethodPrefix($testMethodPrefix = "0"))->isIdenticalTo($test)
+					->string($test->getTestMethodPrefix())->isEqualTo((string) $testMethodPrefix)
 					->exception(function() use ($test) {
 								$test->setTestMethodPrefix('');
 							}


### PR DESCRIPTION
In Fedora we encounter a erratic result on the test suite.
https://apps.fedoraproject.org/koschei/package/atoum

Digging on this, this seems related to uniqid somtime returning 0... strange :(

But I think there is a small inconsistency in the code:
* setTestMethodPrefix only accept not empty string, so accept "0"
* getTestMethodPrefix check if the prefix is ~true~, so refuse "0"

This trivial fix solves this, and add an additional test for the "0" case.
