### PR TITLE
Fix git pusher to correctly tag master (as dev-master) after a successful release

### DIFF
--- a/classes/scripts/git/pusher.php
+++ b/classes/scripts/git/pusher.php
@@ -14,6 +14,7 @@ class pusher extends script\configurable
 {
 	const defaultRemote = 'origin';
 	const defaultTagFile = '.tag';
+	const defaultMasterTag = 'dev-master';
 	const versionPattern = '$Rev: %s $';
 	const majorVersion = 1;
 	const minorVersion = 2;
@@ -210,7 +211,7 @@ class pusher extends script\configurable
 			{
 				if ($this->createGitTag($tag) === true)
 				{
-					if ($this->tagDevelopmentVersion('DEVELOPMENT-' . $tag) === true)
+					if ($this->tagDevelopmentVersion(self::defaultMasterTag) === true)
 					{
 						if ($this->pushToRemote($tag) === true)
 						{


### PR DESCRIPTION
cc @Hywan @mikaelrandy 

I chose `dev-master` to replace `DEVELOPMENT-master` as this is more consistent with what we use in the changelog and in composer.