### PR TITLE
improve setTestMethodPrefix

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -1830,7 +1830,7 @@ abstract class test implements observable, \countable
 
 	private static function isRegex($namespace)
 	{
-		return is_numeric(@preg_match($namespace, 'foo'));
+		return false !== @preg_match($namespace, NULL);
 	}
 
 	private static function isValidIdentifier($id)

--- a/classes/test.php
+++ b/classes/test.php
@@ -764,6 +764,10 @@ abstract class test implements observable, \countable
 		{
 			throw new exceptions\logic\invalidArgument('Test method prefix must not be empty');
 		}
+		if (!(self::isRegex($methodPrefix) || self::isValidIdentifier($methodPrefix)))
+		{
+			throw new exceptions\logic\invalidArgument('Test method prefix must a valid regex or identifier');
+		}
 
 		$this->testMethodPrefix = $methodPrefix;
 
@@ -1826,6 +1830,14 @@ abstract class test implements observable, \countable
 
 	private static function isRegex($namespace)
 	{
-		return preg_match('/^([^\\\[:alnum:][:space:]]).*\1.*$/', $namespace) === 1;
+		return is_numeric(@preg_match($namespace, 'foo'));
+	}
+
+	private static function isValidIdentifier($id)
+	{
+		return 0 !== preg_match(
+			'#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#',
+			$id
+		);
 	}
 }

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -369,11 +369,13 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new self())
 				->then
-					->object($test->setTestMethodPrefix($testMethodPrefix = uniqid()))->isIdenticalTo($test)
+					->object($test->setTestMethodPrefix($testMethodPrefix = uniqid('_')))->isIdenticalTo($test)
 					->string($test->getTestMethodPrefix())->isEqualTo($testMethodPrefix)
-					->object($test->setTestMethodPrefix($testMethodPrefix = rand(- PHP_INT_MAX, PHP_INT_MAX)))->isIdenticalTo($test)
+					->object($test->setTestMethodPrefix($testMethodPrefix = '/^test/i'))->isIdenticalTo($test)
+					->string($test->getTestMethodPrefix())->isEqualTo($testMethodPrefix)
+					->object($test->setTestMethodPrefix($testMethodPrefix = ('_'.rand(0, PHP_INT_MAX))))->isIdenticalTo($test)
 					->string($test->getTestMethodPrefix())->isEqualTo((string) $testMethodPrefix)
-					->object($test->setTestMethodPrefix($testMethodPrefix = "0"))->isIdenticalTo($test)
+					->object($test->setTestMethodPrefix($testMethodPrefix = "_0"))->isIdenticalTo($test)
 					->string($test->getTestMethodPrefix())->isEqualTo((string) $testMethodPrefix)
 					->exception(function() use ($test) {
 								$test->setTestMethodPrefix('');
@@ -381,6 +383,18 @@ namespace mageekguy\atoum\tests\units
 						)
 						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
 						->hasMessage('Test method prefix must not be empty')
+					->exception(function() use ($test) {
+								$test->setTestMethodPrefix('0');
+							}
+						)
+						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->hasMessage('Test method prefix must a valid regex or identifier')
+					->exception(function() use ($test) {
+								$test->setTestMethodPrefix('/:(/');
+							}
+						)
+						->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+						->hasMessage('Test method prefix must a valid regex or identifier')
 			;
 		}
 
@@ -390,7 +404,7 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new self())
 				->then
 					->string($test->getTestMethodPrefix())->isEqualTo(atoum\test::defaultMethodPrefix)
-				->if($test->setTestMethodPrefix($testMethodPrefix = uniqid()))
+				->if($test->setTestMethodPrefix($testMethodPrefix = uniqid('_')))
 				->then
 					->string($test->getTestMethodPrefix())->isEqualTo($testMethodPrefix)
 			;


### PR DESCRIPTION
As discussed in pr #491 , this is a try to improve setTestMethodPrefix by checking if arg is aither a valid PHP identifier or a valid regex.

Notice: I slightly improve isRegex method to really check if input is a valid regex (not seems to be a regex)

But don't know if this change really worth the work...