### PR TITLE
Fix PHP7 support in the basic resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 # 2.3.0
 
 * [#501](https://github.com/atoum/atoum/pull/501) Add atoum path and version to default CLI report ([@jubianchi])
-* [#502](https://github.com/atoum/atoum/pull/502) Improve setTestNamespace() parameters validation ([@remicollet])
+* [#502](https://github.com/atoum/atoum/pull/502) Improve `setTestNamespace` parameters validation ([@remicollet])
 
 ## Bugfix
 * [f28a6ee](https://github.com/atoum/atoum/commit/f28a6eeb6de80ccea3619e228b7a16ddd03637fc) "DOMElement::setIdAttribute(): ID otherMethod already defined" error ([@jubianchi])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#515](https://github.com/atoum/atoum/pull/515) Fix PHP7 support in the basic resolver ([@hywan])
+
 # 2.3.0
 
 * [#501](https://github.com/atoum/atoum/pull/501) Add atoum path and version to default CLI report ([@jubianchi])

--- a/classes/asserter/resolver.php
+++ b/classes/asserter/resolver.php
@@ -2,6 +2,8 @@
 
 namespace mageekguy\atoum\asserter;
 
+use mageekguy\atoum\test;
+
 class resolver
 {
 	const defaultBaseClass = 'mageekguy\atoum\asserter';
@@ -50,13 +52,28 @@ class resolver
 		{
 			$class = $this->checkClass($asserter);
 		}
-		else foreach ($this->namespaces as $namespace)
+		else
 		{
-			$class = $this->checkClass($namespace . '\\' . $asserter);
-
-			if ($class !== null)
+			if (false === test::isValidIdentifier($asserter))
 			{
-				break;
+				return null;
+			}
+
+			foreach ($this->namespaces as $namespace)
+			{
+				$class = $this->checkClass($namespace . '\\' . $asserter);
+
+				if ($class !== null)
+				{
+					break;
+				}
+
+				$class = $this->checkClass($namespace . '\\php' . ucfirst($asserter));
+
+				if ($class !== null)
+				{
+					break;
+				}
 			}
 		}
 

--- a/classes/asserter/resolver.php
+++ b/classes/asserter/resolver.php
@@ -49,6 +49,11 @@ class resolver
 
 	public function resolve($asserter)
 	{
+		if (false === analyzer::isValidNamespace($asserter))
+		{
+			return null;
+		}
+
 		$class = null;
 
 		if (strpos($asserter, '\\') !== false)
@@ -57,11 +62,6 @@ class resolver
 		}
 		else
 		{
-			if (false === analyzer::isValidIdentifier($asserter))
-			{
-				return null;
-			}
-
 			foreach ($this->namespaces as $namespace)
 			{
 				$class = $this->checkClass($namespace . '\\' . $asserter);

--- a/classes/asserter/resolver.php
+++ b/classes/asserter/resolver.php
@@ -2,7 +2,10 @@
 
 namespace mageekguy\atoum\asserter;
 
-use mageekguy\atoum\test;
+use
+	mageekguy\atoum\test,
+	mageekguy\atoum\tools\variable\analyzer
+;
 
 class resolver
 {
@@ -54,7 +57,7 @@ class resolver
 		}
 		else
 		{
-			if (false === test::isValidIdentifier($asserter))
+			if (false === analyzer::isValidIdentifier($asserter))
 			{
 				return null;
 			}

--- a/classes/test.php
+++ b/classes/test.php
@@ -749,7 +749,7 @@ abstract class test implements observable, \countable
 			throw new exceptions\logic\invalidArgument('Test namespace must not be empty');
 		}
 
-		if (!analyzer::isRegex($testNamespace) && !analyzer::isValidNamespace($testNamespace, true))
+		if (!analyzer::isRegex($testNamespace) && !analyzer::isValidNamespace($testNamespace))
 		{
 			throw new exceptions\logic\invalidArgument('Test namespace must be a valid regex or identifier');
 		}

--- a/classes/test.php
+++ b/classes/test.php
@@ -1841,7 +1841,7 @@ abstract class test implements observable, \countable
 		return false !== @preg_match($namespace, null);
 	}
 
-	private static function isValidIdentifier($identifier)
+	public static function isValidIdentifier($identifier)
 	{
 		return 0 !== preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $identifier);
 	}

--- a/classes/test.php
+++ b/classes/test.php
@@ -9,7 +9,8 @@ use
 	mageekguy\atoum\asserter,
 	mageekguy\atoum\asserters,
 	mageekguy\atoum\exceptions,
-	mageekguy\atoum\annotations
+	mageekguy\atoum\annotations,
+	mageekguy\atoum\tools\variable\analyzer
 ;
 
 abstract class test implements observable, \countable
@@ -154,7 +155,7 @@ abstract class test implements observable, \countable
 
 		$testMethodPrefix = $this->getTestMethodPrefix();
 
-		if (self::isRegex($testMethodPrefix) === false)
+		if (analyzer::isRegex($testMethodPrefix) === false)
 		{
 			$testMethodFilter = function($methodName) use ($testMethodPrefix) { return (stripos($methodName, $testMethodPrefix) === 0); };
 		}
@@ -748,7 +749,7 @@ abstract class test implements observable, \countable
 			throw new exceptions\logic\invalidArgument('Test namespace must not be empty');
 		}
 
-		if (!self::isRegex($testNamespace) && !self::isValidNamespace($testNamespace, true))
+		if (!analyzer::isRegex($testNamespace) && !analyzer::isValidNamespace($testNamespace, true))
 		{
 			throw new exceptions\logic\invalidArgument('Test namespace must be a valid regex or identifier');
 		}
@@ -772,7 +773,7 @@ abstract class test implements observable, \countable
 			throw new exceptions\logic\invalidArgument('Test method prefix must not be empty');
 		}
 
-		if (!self::isRegex($methodPrefix) && !self::isValidIdentifier($methodPrefix))
+		if (!analyzer::isRegex($methodPrefix) && !analyzer::isValidIdentifier($methodPrefix))
 		{
 			throw new exceptions\logic\invalidArgument('Test method prefix must a valid regex or identifier');
 		}
@@ -1466,7 +1467,7 @@ abstract class test implements observable, \countable
 			$testNamespace = self::getNamespace();
 		}
 
-		if (self::isRegex($testNamespace) === true)
+		if (analyzer::isRegex($testNamespace) === true)
 		{
 			if (preg_match($testNamespace, $fullyQualifiedClassName) === 0)
 			{
@@ -1834,26 +1835,5 @@ abstract class test implements observable, \countable
 	private static function cleanNamespace($namespace)
 	{
 		return trim((string) $namespace, '\\');
-	}
-
-	private static function isRegex($namespace)
-	{
-		return false !== @preg_match($namespace, null);
-	}
-
-	public static function isValidIdentifier($identifier)
-	{
-		return 0 !== preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $identifier);
-	}
-
-	private static function isValidNamespace($namespace)
-	{
-		foreach(explode('\\', $namespace) as $sub) {
-			if (!self::isValidIdentifier($sub)) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 }

--- a/classes/tools/variable/analyzer.php
+++ b/classes/tools/variable/analyzer.php
@@ -82,4 +82,25 @@ class analyzer
 	{
 		return (is_array($mixed) === true);
 	}
+
+	public static function isRegex($namespace)
+	{
+		return false !== @preg_match($namespace, null);
+	}
+
+	public static function isValidIdentifier($identifier)
+	{
+		return 0 !== preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $identifier);
+	}
+
+	public static function isValidNamespace($namespace)
+	{
+		foreach(explode('\\', $namespace) as $sub) {
+			if (!self::isValidIdentifier($sub)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 }

--- a/classes/tools/variable/analyzer.php
+++ b/classes/tools/variable/analyzer.php
@@ -95,8 +95,10 @@ class analyzer
 
 	public static function isValidNamespace($namespace)
 	{
-		foreach(explode('\\', trim($namespace, '\\')) as $sub) {
-			if (!self::isValidIdentifier($sub)) {
+		foreach(explode('\\', trim($namespace, '\\')) as $sub)
+		{
+			if (!self::isValidIdentifier($sub))
+			{
 				return false;
 			}
 		}

--- a/classes/tools/variable/analyzer.php
+++ b/classes/tools/variable/analyzer.php
@@ -95,7 +95,7 @@ class analyzer
 
 	public static function isValidNamespace($namespace)
 	{
-		foreach(explode('\\', $namespace) as $sub) {
+		foreach(explode('\\', trim($namespace, '\\')) as $sub) {
 			if (!self::isValidIdentifier($sub)) {
 				return false;
 			}

--- a/classes/tools/variable/analyzer.php
+++ b/classes/tools/variable/analyzer.php
@@ -90,7 +90,7 @@ class analyzer
 
 	public static function isValidIdentifier($identifier)
 	{
-		return 0 !== preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $identifier);
+		return 0 !== \preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $identifier);
 	}
 
 	public static function isValidNamespace($namespace)

--- a/tests/units/classes/asserter/resolver.php
+++ b/tests/units/classes/asserter/resolver.php
@@ -54,10 +54,10 @@ class resolver extends atoum
 					$this->function->is_subclass_of = true
 				)
 				->then
-					->string($this->testedInstance->resolve($asserter = uniqid()))->isEqualTo('mageekguy\atoum\asserters\\' . $asserter)
-					->string($this->testedInstance->resolve($asserter = '\\' . uniqid()))->isEqualTo($asserter)
-					->string($this->testedInstance->resolve($asserter = uniqid() . '\\' . uniqid()))->isEqualTo($asserter)
-					->string($this->testedInstance->resolve($asserter = '\\' . uniqid() . '\\' . uniqid()))->isEqualTo($asserter)
+					->string($this->testedInstance->resolve($asserter = uniqid('a')))->isEqualTo('mageekguy\atoum\asserters\\' . $asserter)
+					->string($this->testedInstance->resolve($asserter = '\\' . uniqid('a')))->isEqualTo($asserter)
+					->string($this->testedInstance->resolve($asserter = uniqid('a') . '\\' . uniqid('a')))->isEqualTo($asserter)
+					->string($this->testedInstance->resolve($asserter = '\\' . uniqid('a') . '\\' . uniqid('a')))->isEqualTo($asserter)
 
 				->if($this->function->class_exists = function($class) use (& $unknownClass) { return ($class !== 'mageekguy\atoum\asserters\\' . $unknownClass); })
 				->then


### PR DESCRIPTION
Since PHP7, some new keywords have been introduced, like `string` or `float` for instance. Consequently, `asserters/string.php` have been renamed to `asserters/phpString.php` etc.

However, it is like we forget to change the resolver too. This bug was not visible because asserter aliases exist in the famous `test` class. Nevertheless, if we use only the `asserter\generator`, the bug is present.

This patch fixes the bug by checking twice if the class exists in the resolver: First time with the canonical asserter name, second time prefixed by `php` and with the first letter uppercased.