### PR TITLE
Introduce the constant mocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#520](https://github.com/atoum/atoum/pull/520) Introduce the constant mocker ([@hywan])
 * [#518](https://github.com/atoum/atoum/pull/518) Update atoum's PHAR against Github releases with `--github-update` ([@jubianchi])
 * [#515](https://github.com/atoum/atoum/pull/515) Fix PHP7 support in the basic resolver ([@hywan])
 

--- a/classes/php/mocker.php
+++ b/classes/php/mocker.php
@@ -7,7 +7,7 @@ use
 	mageekguy\atoum\exceptions
 ;
 
-class mocker
+abstract class mocker
 {
 	protected $defaultNamespace = '';
 	protected $reflectedFunctionFactory = null;
@@ -16,33 +16,16 @@ class mocker
 
 	public function __construct($defaultNamespace = '')
 	{
-		$this
-			->setDefaultNamespace($defaultNamespace)
-			->setReflectedFunctionFactory()
-		;
+		$this->setDefaultNamespace($defaultNamespace);
 	}
 
-	public function __get($functionName)
-	{
-		return static::$adapter->{$this->generateIfNotExists($functionName)};
-	}
+	abstract public function __get($name);
 
-	public function __set($functionName, $mixed)
-	{
-		static::$adapter->{$this->generateIfNotExists($functionName)} = $mixed;
+	abstract public function __set($name, $mixed);
 
-		return $this;
-	}
+	abstract public function __isset($name);
 
-	public function __isset($functionName)
-	{
-		return $this->functionExists($this->getFqdn($functionName));
-	}
-
-	public function __unset($functionName)
-	{
-		$this->setDefaultBehavior($this->getFqdn($functionName));
-	}
+	abstract public function __unset($name);
 
 	public function setDefaultNamespace($namespace)
 	{
@@ -61,47 +44,6 @@ class mocker
 		return $this->defaultNamespace;
 	}
 
-	public function setReflectedFunctionFactory(\closure $factory = null)
-	{
-		$this->reflectedFunctionFactory = $factory ?: function($functionName) { return new \reflectionFunction($functionName); };
-
-		return $this;
-	}
-
-	public function useClassNamespace($className)
-	{
-		return $this->setDefaultNamespace(substr($className, 0, strrpos($className, '\\')));
-	}
-
-	public function generate($functionName)
-	{
-		$fqdn = $this->getFqdn($functionName);
-
-		if ($this->functionExists($fqdn) === false)
-		{
-			if (function_exists($fqdn) === true)
-			{
-				throw new exceptions\logic\invalidArgument('Function \'' . $fqdn . '\' already exists');
-			}
-
-			$lastAntislash = strrpos($fqdn, '\\');
-			$namespace = substr($fqdn, 0, $lastAntislash);
-			$function = substr($fqdn, $lastAntislash + 1);
-			$reflectedFunction = $this->buildReflectedFunction($function);
-
-			static::defineMockedFunction($namespace, get_class($this), $function, $reflectedFunction);
-		}
-
-		return $this->setDefaultBehavior($fqdn);
-	}
-
-	public function resetCalls($functionName = null)
-	{
-		static::$adapter->resetCalls($this->getFqdn($functionName));
-
-		return $this;
-	}
-
 	public static function setAdapter(atoum\test\adapter $adapter = null)
 	{
 		static::$adapter = $adapter ?: new atoum\php\mocker\adapter();
@@ -110,133 +52,6 @@ class mocker
 	public static function getAdapter()
 	{
 		return static::$adapter;
-	}
-
-	protected function getFqdn($functionName)
-	{
-		return $this->defaultNamespace . $functionName;
-	}
-
-	protected function generateIfNotExists($functionName)
-	{
-		if (isset($this->{$functionName}) === false)
-		{
-			$this->generate($functionName);
-		}
-
-		return $this->getFqdn($functionName);
-	}
-
-	protected function setDefaultBehavior($fqdn, \reflectionFunction $reflectedFunction = null)
-	{
-		$function = substr($fqdn, strrpos($fqdn, '\\') + 1);
-
-		if ($reflectedFunction === null)
-		{
-			$reflectedFunction = $this->buildReflectedFunction($function);
-		}
-
-		if ($reflectedFunction === null)
-		{
-			$closure = function() { return null; };
-		}
-		else
-		{
-			$closure = eval('return function(' . static::getParametersSignature($reflectedFunction) . ') { return call_user_func_array(\'\\' . $function . '\', ' . static::getParameters($reflectedFunction) . '); };');
-		}
-
-		static::$adapter->{$fqdn}->setClosure($closure);
-
-		return $this;
-	}
-
-	protected function functionExists($fqdn)
-	{
-		return (isset(static::$adapter->{$fqdn}) === true);
-	}
-
-	protected static function getParametersSignature(\reflectionFunction $function)
-	{
-		$parameters = array();
-
-		foreach (self::filterParameters($function) as $parameter)
-		{
-			$parameterCode = self::getParameterType($parameter) . ($parameter->isPassedByReference() == false ? '' : '& ') . '$' . $parameter->getName();
-
-			switch (true)
-			{
-				case $parameter->isDefaultValueAvailable():
-					$parameterCode .= ' = ' . var_export($parameter->getDefaultValue(), true);
-					break;
-
-				case $parameter->isOptional():
-					$parameterCode .= ' = null';
-			}
-
-			$parameters[] = $parameterCode;
-		}
-
-		return join(', ', $parameters);
-	}
-
-	protected static function getParameters(\reflectionFunction $function)
-	{
-		$parameters = array();
-
-		foreach (self::filterParameters($function) as $parameter)
-		{
-			$parameters[] = ($parameter->isPassedByReference() === false ? '' : '& ') . '$' . $parameter->getName();
-		}
-
-		return 'array(' . join(',', $parameters) . ')';
-	}
-
-	protected static function getParameterType(\reflectionParameter $parameter)
-	{
-		switch (true)
-		{
-			case $parameter->isArray():
-				return 'array ';
-
-			case method_exists($parameter, 'isCallable') && $parameter->isCallable():
-				return 'callable ';
-
-			case ($class = $parameter->getClass()):
-				return '\\' . $class->getName() . ' ';
-
-			default:
-				return '';
-		}
-	}
-
-	protected static function defineMockedFunction($namespace, $class, $function, \reflectionFunction $reflectedFunction = null)
-	{
-		eval(sprintf(
-			'namespace %s { function %s(%s) { return \\%s::getAdapter()->invoke(__FUNCTION__, %s); } }',
-			$namespace,
-			$function,
-			$reflectedFunction ? static::getParametersSignature($reflectedFunction) : '',
-			$class,
-			$reflectedFunction ? static::getParameters($reflectedFunction) : 'func_get_args()'
-		));
-	}
-
-	private function buildReflectedFunction($function)
-	{
-		$reflectedFunction = null;
-
-		try
-		{
-			$reflectedFunction = call_user_func_array($this->reflectedFunctionFactory, array($function));
-		}
-		catch (\exception $exception) {}
-
-		return $reflectedFunction;
-	}
-
-	private static function filterParameters(\reflectionFunction $function)
-	{
-		return array_filter($function->getParameters(), function($parameter) { return ($parameter->getName() != '...'); });
 	}
 }
 

--- a/classes/php/mocker.php
+++ b/classes/php/mocker.php
@@ -27,6 +27,8 @@ abstract class mocker
 
 	abstract public function __unset($name);
 
+	abstract function addToTest(atoum\test $test);
+
 	public function setDefaultNamespace($namespace)
 	{
 		$this->defaultNamespace = trim($namespace, '\\');

--- a/classes/php/mocker/constant.php
+++ b/classes/php/mocker/constant.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace mageekguy\atoum\php\mocker;
+
+use mageekguy\atoum;
+use mageekguy\atoum\php\mocker;
+
+class constant extends mocker
+{
+	public function __get($name)
+	{
+		if ($this->__isset($name) === false)
+		{
+			throw new exceptions\constant('Constant \'' . $name . '\' is not defined in namespace \'' . trim($this->getDefaultNamespace(), '\\') . '\'');
+		}
+
+		return $this->getAdapter()->constant($this->getDefaultNamespace() . $name);
+	}
+
+	public function __set($name, $value)
+	{
+		if (@$this->getAdapter()->define($this->getDefaultNamespace() . $name, $value) === false)
+		{
+			throw new exceptions\constant('Could not mock constant \'' . $name . '\' in namespace \'' . trim($this->getDefaultNamespace(), '\\') . '\'');
+		}
+
+		return $this;
+	}
+
+	public function __isset($name)
+	{
+		return $this->getAdapter()->defined($this->getDefaultNamespace() . $name);
+	}
+
+	public function __unset($name)
+	{
+		throw new exceptions\constant('Could not unset constant \'' . $name . '\' in namespace \'' . trim($this->getDefaultNamespace(), '\\') . '\'');
+	}
+
+	function addToTest(atoum\test $test)
+	{
+		$test->setPhpConstantMocker($this);
+
+		return $this;
+	}
+}

--- a/classes/php/mocker/exception.php
+++ b/classes/php/mocker/exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace mageekguy\atoum\php\mocker;
+
+use mageekguy\atoum;
+
+class exception extends \runtimeException implements atoum\exception {}

--- a/classes/php/mocker/exceptions/constant.php
+++ b/classes/php/mocker/exceptions/constant.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace mageekguy\atoum\php\mocker\exceptions;
+
+use mageekguy\atoum\php\mocker;
+
+class constant extends mocker\exception {}

--- a/classes/php/mocker/funktion.php
+++ b/classes/php/mocker/funktion.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace mageekguy\atoum\php\mocker;
+
+use
+	mageekguy\atoum\exceptions,
+	mageekguy\atoum\php\mocker
+;
+
+class funktion extends mocker
+{
+	public function __construct($defaultNamespace = '')
+	{
+		parent::__construct($defaultNamespace);
+		$this->setReflectedFunctionFactory();
+	}
+
+	public function __get($functionName)
+	{
+		return $this->getAdapter()->{$this->generateIfNotExists($functionName)};
+	}
+
+	public function __set($functionName, $mixed)
+	{
+		$this->getAdapter()->{$this->generateIfNotExists($functionName)} = $mixed;
+
+		return $this;
+	}
+
+	public function __isset($functionName)
+	{
+		return $this->functionExists($this->getFqdn($functionName));
+	}
+
+	public function __unset($functionName)
+	{
+		$this->setDefaultBehavior($this->getFqdn($functionName));
+	}
+
+	public function setReflectedFunctionFactory(\closure $factory = null)
+	{
+		$this->reflectedFunctionFactory = $factory ?: function($functionName) { return new \reflectionFunction($functionName); };
+		return $this;
+	}
+
+	public function useClassNamespace($className)
+	{
+		return $this->setDefaultNamespace(substr($className, 0, strrpos($className, '\\')));
+	}
+
+	public function generate($functionName)
+	{
+		$fqdn = $this->getFqdn($functionName);
+		if ($this->functionExists($fqdn) === false)
+		{
+			if (function_exists($fqdn) === true)
+			{
+				throw new exceptions\logic\invalidArgument('Function \'' . $fqdn . '\' already exists');
+			}
+			$lastAntislash = strrpos($fqdn, '\\');
+			$namespace = substr($fqdn, 0, $lastAntislash);
+			$function = substr($fqdn, $lastAntislash + 1);
+			$reflectedFunction = $this->buildReflectedFunction($function);
+			static::defineMockedFunction($namespace, get_class($this), $function, $reflectedFunction);
+		}
+		return $this->setDefaultBehavior($fqdn);
+	}
+
+	public function resetCalls($functionName = null)
+	{
+		static::$adapter->resetCalls($this->getFqdn($functionName));
+		return $this;
+	}
+
+	protected function getFqdn($functionName)
+	{
+		return $this->defaultNamespace . $functionName;
+	}
+
+	protected function generateIfNotExists($functionName)
+	{
+		if (isset($this->{$functionName}) === false)
+		{
+			$this->generate($functionName);
+		}
+		return $this->getFqdn($functionName);
+	}
+
+	protected function setDefaultBehavior($fqdn, \reflectionFunction $reflectedFunction = null)
+	{
+		$function = substr($fqdn, strrpos($fqdn, '\\') + 1);
+		if ($reflectedFunction === null)
+		{
+			$reflectedFunction = $this->buildReflectedFunction($function);
+		}
+		if ($reflectedFunction === null)
+		{
+			$closure = function() { return null; };
+		}
+		else
+		{
+			$closure = eval('return function(' . static::getParametersSignature($reflectedFunction) . ') { return call_user_func_array(\'\\' . $function . '\', ' . static::getParameters($reflectedFunction) . '); };');
+		}
+		static::$adapter->{$fqdn}->setClosure($closure);
+		return $this;
+	}
+
+	protected function functionExists($fqdn)
+	{
+		return (isset(static::$adapter->{$fqdn}) === true);
+	}
+
+	protected static function getParametersSignature(\reflectionFunction $function)
+	{
+		$parameters = array();
+		foreach (self::filterParameters($function) as $parameter)
+		{
+			$parameterCode = self::getParameterType($parameter) . ($parameter->isPassedByReference() == false ? '' : '& ') . '$' . $parameter->getName();
+			switch (true)
+			{
+				case $parameter->isDefaultValueAvailable():
+					$parameterCode .= ' = ' . var_export($parameter->getDefaultValue(), true);
+					break;
+				case $parameter->isOptional():
+					$parameterCode .= ' = null';
+			}
+			$parameters[] = $parameterCode;
+		}
+		return join(', ', $parameters);
+	}
+
+	protected static function getParameters(\reflectionFunction $function)
+	{
+		$parameters = array();
+		foreach (self::filterParameters($function) as $parameter)
+		{
+			$parameters[] = ($parameter->isPassedByReference() === false ? '' : '& ') . '$' . $parameter->getName();
+		}
+		return 'array(' . join(',', $parameters) . ')';
+	}
+
+	protected static function getParameterType(\reflectionParameter $parameter)
+	{
+		switch (true)
+		{
+			case $parameter->isArray():
+				return 'array ';
+			case method_exists($parameter, 'isCallable') && $parameter->isCallable():
+				return 'callable ';
+			case ($class = $parameter->getClass()):
+				return '\\' . $class->getName() . ' ';
+			default:
+				return '';
+		}
+	}
+
+	protected static function defineMockedFunction($namespace, $class, $function, \reflectionFunction $reflectedFunction = null)
+	{
+		eval(sprintf(
+			'namespace %s { function %s(%s) { return \\%s::getAdapter()->invoke(__FUNCTION__, %s); } }',
+			$namespace,
+			$function,
+			$reflectedFunction ? static::getParametersSignature($reflectedFunction) : '',
+			$class,
+			$reflectedFunction ? static::getParameters($reflectedFunction) : 'func_get_args()'
+		));
+	}
+
+	private function buildReflectedFunction($function)
+	{
+		$reflectedFunction = null;
+		try
+		{
+			$reflectedFunction = call_user_func_array($this->reflectedFunctionFactory, array($function));
+		}
+		catch (\exception $exception) {}
+		return $reflectedFunction;
+	}
+
+	private static function filterParameters(\reflectionFunction $function)
+	{
+		return array_filter($function->getParameters(), function($parameter) { return ($parameter->getName() != '...'); });
+	}
+}

--- a/classes/test.php
+++ b/classes/test.php
@@ -47,7 +47,7 @@ abstract class test implements observable, \countable
 	private $phpExtensionFactory;
 	private $asserterGenerator = null;
 	private $assertionManager = null;
-	private $phpMocker = null;
+	private $phpFunctionMocker = null;
 	private $testAdapterStorage = null;
 	private $asserterCallManager = null;
 	private $mockControllerLinker = null;
@@ -92,7 +92,7 @@ abstract class test implements observable, \countable
 	{
 		$this
 			->setAdapter($adapter)
-			->setPhpMocker()
+			->setPhpFunctionMocker()
 			->setMockGenerator()
 			->setMockAutoloader()
 			->setAsserterGenerator($asserterGenerator)
@@ -280,16 +280,16 @@ abstract class test implements observable, \countable
 		return $this->adapter;
 	}
 
-	public function setPhpMocker(php\mocker $phpMocker = null)
+	public function setPhpFunctionMocker(php\mocker\funktion $phpFunctionMocker = null)
 	{
-		$this->phpMocker = $phpMocker ?: new php\mocker();
+		$this->phpFunctionMocker = $phpFunctionMocker ?: new php\mocker\funktion();
 
 		return $this;
 	}
 
-	public function getPhpMocker()
+	public function getPhpFunctionMocker()
 	{
-		return $this->phpMocker;
+		return $this->phpFunctionMocker;
 	}
 
 	public function setMockGenerator(test\mock\generator $generator = null)
@@ -392,7 +392,7 @@ abstract class test implements observable, \countable
 			->setHandler('stop', function() use ($test) { if ($test->debugModeIsEnabled() === true) { throw new test\exceptions\stop(); } return $test; })
 			->setHandler('executeOnFailure', function($callback) use ($test) { if ($test->debugModeIsEnabled() === true) { $test->executeOnFailure($callback); } return $test; })
 			->setHandler('dumpOnFailure', function($variable) use ($test) { if ($test->debugModeIsEnabled() === true) { $test->executeOnFailure(function() use ($variable) { var_dump($variable); }); } return $test; })
-			->setPropertyHandler('function', function() use ($test) { return $test->getPhpMocker(); })
+            ->setPropertyHandler('function', function() use ($test) { return $this->getPhpFunctionMocker(); })
 			->setPropertyHandler('exception', function() { return asserters\exception::getLastValue(); })
 		;
 
@@ -426,9 +426,9 @@ abstract class test implements observable, \countable
 			->setHandler('resetAdapter', function(test\adapter $adapter) { return $adapter->resetCalls(); })
 		;
 
-		$phpMocker = $this->phpMocker;
+		$phpFunctionMocker = $this->phpFunctionMocker;
 
-		$this->assertionManager->setHandler('resetFunction', function(test\adapter\invoker $invoker) use ($phpMocker) { $phpMocker->resetCalls($invoker->getFunction()); return $invoker; });
+		$this->assertionManager->setHandler('resetFunction', function(test\adapter\invoker $invoker) use ($phpFunctionMocker) { $phpFunctionMocker->resetCalls($invoker->getFunction()); return $invoker; });
 
 		$assertionAliaser = $this->assertionManager->getAliaser();
 
@@ -1131,7 +1131,7 @@ abstract class test implements observable, \countable
 			$this->currentMethod = $testMethod;
 			$this->executeOnFailure = array();
 
-			$this->phpMocker->setDefaultNamespace($this->getTestedClassNamespace());
+			$this->phpFunctionMocker->setDefaultNamespace($this->getTestedClassNamespace());
 
 			try
 			{

--- a/tests/units/classes/php/mocker.php
+++ b/tests/units/classes/php/mocker.php
@@ -9,8 +9,6 @@ use
 	mageekguy\atoum\php
 ;
 
-function doesSomething() {}
-
 class mocker extends atoum\test
 {
 	public function test__construct()
@@ -19,67 +17,6 @@ class mocker extends atoum\test
 			->given($this->newTestedInstance)
 			->then
 				->string($this->testedInstance->getDefaultNamespace())->isEmpty()
-		;
-	}
-
-	public function test__set()
-	{
-		$this
-			->given($this->newTestedInstance)
-
-			->if($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'} = $returnValue = uniqid())
-			->then
-				->string(version_compare(uniqid(), uniqid()))->isEqualTo($returnValue)
-
-			->if($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'} = $otherReturnValue = uniqid())
-			->then
-				->string(version_compare(uniqid(), uniqid()))->isEqualTo($otherReturnValue)
-
-			->if($this->testedInstance->{$otherFunctionName = __NAMESPACE__ . '\file_get_contents'} = $fileContents = uniqid())
-			->then
-				->string(version_compare(uniqid(), uniqid()))->isEqualTo($otherReturnValue)
-				->string(file_get_contents(uniqid()))->isEqualTo($fileContents)
-		;
-	}
-
-	public function test__get()
-	{
-		$this
-			->given($this->newTestedInstance)
-			->then
-				->object($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
-				->boolean(function_exists($functionName))->isTrue()
-		;
-	}
-
-	public function test__isset()
-	{
-		$this
-			->given($this->newTestedInstance)
-			->then
-				->boolean(isset($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'}))->isFalse()
-
-			->if($this->testedInstance->generate($functionName))
-			->then
-				->boolean(isset($this->testedInstance->{$functionName}))->isTrue()
-		;
-	}
-
-	public function test__unset()
-	{
-		$this
-			->given($mocker = $this->newTestedInstance)
-
-			->if($functionName = __NAMESPACE__ . '\version_compare')
-			->when(function() use ($mocker, $functionName) { unset($mocker->{$functionName}); })
-			->then
-				->boolean(function_exists($functionName))->isFalse()
-
-			->if($this->testedInstance->{$functionName} = uniqid())
-			->when(function() use ($mocker, $functionName) { unset($mocker->{$functionName}); })
-			->then
-				->integer(version_compare('5.4.0', '5.3.0'))->isEqualTo(1)
-				->integer(version_compare('5.3.0', '5.4.0'))->isEqualTo(-1)
 		;
 	}
 
@@ -101,41 +38,6 @@ class mocker extends atoum\test
 		;
 	}
 
-	public function testUseClassNamespace()
-	{
-		$this
-			->given($this->newTestedInstance)
-			->then
-				->object($this->testedInstance->useClassNamespace(__CLASS__))->isTestedInstance
-				->string($this->testedInstance->getDefaultNamespace())->isEqualTo(__NAMESPACE__ . '\\')
-		;
-	}
-
-	public function testResetCalls()
-	{
-		$this
-			->given($this->newTestedInstance)
-
-			->if(
-				$this->mockGenerator
-					->orphanize('__construct')
-					->orphanize('resetCalls'),
-				php\mocker::setAdapter($adapter = new \mock\atoum\test\adapter())
-			)
-			->then
-				->object($this->testedInstance->resetCalls())->isTestedInstance
-				->mock($adapter)->call('resetCalls')->once
-
-				->object($this->testedInstance->resetCalls($functionName = uniqid()))->isTestedInstance
-				->mock($adapter)->call('resetCalls')->withArguments($functionName)->once
-
-			->if($this->testedInstance->setDefaultNamespace($defaultNamespace = uniqid()))
-			->then
-				->object($this->testedInstance->resetCalls($functionName = uniqid()))->isTestedInstance
-				->mock($adapter)->call('resetCalls')->withArguments($defaultNamespace . '\\' . $functionName)->once
-		;
-	}
-
 	public function testSetAdapter()
 	{
 		$this
@@ -145,46 +47,6 @@ class mocker extends atoum\test
 			->object(php\mocker::getAdapter())
 				->isNotIdenticalTo($adapter)
 				->isEqualTo(new atoum\php\mocker\adapter())
-		;
-	}
-
-	public function testGenerate()
-	{
-		$this
-			->given($mocker = $this->newTestedInstance)
-			->then
-				->object($this->testedInstance->generate($functionName = __NAMESPACE__ . '\version_compare'))->isIdenticalTo($this->testedInstance)
-				->boolean(function_exists($functionName))->isTrue()
-				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
-				->integer(\version_compare('5.4.0', '5.3.0'))->isEqualTo(1)
-				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
-				->integer(\version_compare('5.3.0', '5.4.0'))->isEqualTo(-1)
-				->exception(function() use ($mocker) { $mocker->generate(__NAMESPACE__ . '\doesSomething'); })
-					->isInstanceof('mageekguy\atoum\exceptions\logic\invalidArgument')
-					->hasMessage('Function \'' . __NAMESPACE__ . '\doesSomething\' already exists')
-
-			->if($this->testedInstance->{$functionName} = $returnValue = uniqid())
-			->then
-				->string(version_compare(uniqid(), uniqid()))->isEqualTo($returnValue)
-				->object($this->testedInstance->generate($functionName = __NAMESPACE__ . '\version_compare'))->isIdenticalTo($this->testedInstance)
-				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
-				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
-				->object($this->testedInstance->generate($unknownFunctionName = __NAMESPACE__ . '\\foo'))->isIdenticalTo($this->testedInstance)
-				->variable(foo())->isNull()
-
-			->if($this->testedInstance->{$unknownFunctionName} = $fooReturnValue = uniqid())
-			->then
-				->string(foo())->isEqualTo($fooReturnValue)
-
-			->if($this->testedInstance->{$functionName} = $returnValue = uniqid())
-			->when(function() use ($mocker, $functionName) { unset($mocker->{$functionName}); })
-			->then
-				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
-				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
-
-			->when(function() use ($mocker, $unknownFunctionName) { unset($mocker->{$unknownFunctionName}); })
-			->then
-				->variable(foo())->isNull()
 		;
 	}
 }

--- a/tests/units/classes/php/mocker/constant.php
+++ b/tests/units/classes/php/mocker/constant.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\php\mocker;
+
+require_once __DIR__ . '/../../../runner.php';
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php
+;
+
+class constant extends atoum\test
+{
+	public function test__set()
+	{
+		$this
+			->given(
+				$this->newTestedInstance,
+				$adapter = new atoum\test\adapter(),
+				php\mocker\constant::setAdapter($adapter)
+			)
+
+			->if(
+				$adapter->define = true,
+				$this->testedInstance->setDefaultNameSpace($namespace = uniqid())
+			)
+			->then
+				->string($this->testedInstance->{$constant = uniqid()} = $value = uniqid())->isEqualTo($value)
+				->adapter($adapter)
+					->call('define')->withArguments($namespace . '\\' . $constant, $value)->once
+
+			->if($adapter->define = false)
+			->then
+				->exception(function(atoum\test $test) use (& $constant, & $value) {
+						$test->testedInstance->{$constant = uniqid('a')} = $value = uniqid();
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\php\mocker\exceptions\constant')
+					->hasMessage('Could not mock constant \'' . $constant . '\' in namespace \'' . $namespace . '\'')
+				->adapter($adapter)
+					->call('define')->withArguments($namespace . '\\' . $constant, $value)->once
+		;
+	}
+
+	public function test__get()
+	{
+		$this
+			->given(
+				$this->newTestedInstance,
+				$adapter = new atoum\test\adapter(),
+				php\mocker\constant::setAdapter($adapter)
+			)
+
+			->if(
+				$adapter->defined = false,
+				$this->testedInstance->setDefaultNameSpace($namespace = uniqid())
+			)
+			->then
+				->exception(function(atoum\test $test) use (& $constant) {
+						$test->testedInstance->{$constant = uniqid()};
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\php\mocker\exceptions\constant')
+					->hasMessage('Constant \'' . $constant . '\' is not defined in namespace \'' . $namespace . '\'')
+				->adapter($adapter)
+					->call('defined')->withArguments($namespace . '\\' . $constant)->once
+
+			->if(
+				$adapter->defined = true,
+				$adapter->constant = $value = uniqid()
+			)
+			->then
+				->string($this->testedInstance->{$constant = uniqid()})->isEqualTo($value)
+				->adapter($adapter)
+					->call('defined')->withArguments($namespace . '\\' . $constant)->once
+					->call('constant')->withArguments($namespace . '\\' . $constant)->once
+		;
+	}
+
+	public function test__isset()
+	{
+		$this
+			->given(
+				$this->newTestedInstance,
+				$adapter = new atoum\test\adapter(),
+				php\mocker\constant::setAdapter($adapter)
+			)
+
+			->if(
+				$adapter->defined = false,
+				$this->testedInstance->setDefaultNameSpace($namespace = uniqid())
+			)
+			->then
+				->boolean(isset($this->testedInstance->{$constant = uniqid()}))->isFalse
+				->adapter($adapter)
+					->call('defined')->withArguments($namespace . '\\' . $constant)->once
+
+			->if($adapter->defined = true)
+			->then
+				->boolean(isset($this->testedInstance->{$constant = uniqid()}))->isTrue
+				->adapter($adapter)
+					->call('defined')->withArguments($namespace . '\\' . $constant)->once
+		;
+	}
+
+	public function test__unset()
+	{
+		$this
+			->given(
+				$this->newTestedInstance,
+				$adapter = new atoum\test\adapter()
+			)
+
+			->if($this->testedInstance->setDefaultNameSpace($namespace = uniqid()))
+			->then
+				->exception(function(atoum\test $test) use (& $constant, & $value) {
+						unset($test->testedInstance->{$constant = uniqid()});
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\php\mocker\exceptions\constant')
+					->hasMessage('Could not unset constant \'' . $constant . '\' in namespace \'' . $namespace . '\'')
+		;
+	}
+}

--- a/tests/units/classes/php/mocker/funktion.php
+++ b/tests/units/classes/php/mocker/funktion.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\php\mocker;
+
+require_once __DIR__ . '/../../runner.php';
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\php
+;
+
+function doesSomething() {}
+
+class funktion extends atoum\test
+{
+	public function test__set()
+	{
+		$this
+			->given($this->newTestedInstance)
+
+			->if($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'} = $returnValue = uniqid())
+			->then
+				->string(version_compare(uniqid(), uniqid()))->isEqualTo($returnValue)
+
+			->if($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'} = $otherReturnValue = uniqid())
+			->then
+				->string(version_compare(uniqid(), uniqid()))->isEqualTo($otherReturnValue)
+
+			->if($this->testedInstance->{$otherFunctionName = __NAMESPACE__ . '\file_get_contents'} = $fileContents = uniqid())
+			->then
+				->string(version_compare(uniqid(), uniqid()))->isEqualTo($otherReturnValue)
+				->string(file_get_contents(uniqid()))->isEqualTo($fileContents)
+		;
+	}
+
+	public function test__get()
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'})->isInstanceOf('mageekguy\atoum\test\adapter\invoker')
+				->boolean(function_exists($functionName))->isTrue()
+		;
+	}
+
+	public function test__isset()
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->boolean(isset($this->testedInstance->{$functionName = __NAMESPACE__ . '\version_compare'}))->isFalse()
+
+			->if($this->testedInstance->generate($functionName))
+			->then
+				->boolean(isset($this->testedInstance->{$functionName}))->isTrue()
+		;
+	}
+
+	public function test__unset()
+	{
+		$this
+			->given($mocker = $this->newTestedInstance)
+
+			->if($functionName = __NAMESPACE__ . '\version_compare')
+			->when(function() use ($mocker, $functionName) { unset($mocker->{$functionName}); })
+			->then
+				->boolean(function_exists($functionName))->isFalse()
+
+			->if($this->testedInstance->{$functionName} = uniqid())
+			->when(function() use ($mocker, $functionName) { unset($mocker->{$functionName}); })
+			->then
+				->integer(version_compare('5.4.0', '5.3.0'))->isEqualTo(1)
+				->integer(version_compare('5.3.0', '5.4.0'))->isEqualTo(-1)
+		;
+	}
+
+	public function testUseClassNamespace()
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->useClassNamespace(__CLASS__))->isTestedInstance
+				->string($this->testedInstance->getDefaultNamespace())->isEqualTo(__NAMESPACE__ . '\\')
+		;
+	}
+
+	public function testResetCalls()
+	{
+		$this
+			->given($this->newTestedInstance)
+
+			->if(
+				$this->mockGenerator
+					->orphanize('__construct')
+					->orphanize('resetCalls'),
+				php\mocker::setAdapter($adapter = new \mock\atoum\test\adapter())
+			)
+			->then
+				->object($this->testedInstance->resetCalls())->isTestedInstance
+				->mock($adapter)->call('resetCalls')->once
+
+				->object($this->testedInstance->resetCalls($functionName = uniqid()))->isTestedInstance
+				->mock($adapter)->call('resetCalls')->withArguments($functionName)->once
+
+			->if($this->testedInstance->setDefaultNamespace($defaultNamespace = uniqid()))
+			->then
+				->object($this->testedInstance->resetCalls($functionName = uniqid()))->isTestedInstance
+				->mock($adapter)->call('resetCalls')->withArguments($defaultNamespace . '\\' . $functionName)->once
+		;
+	}
+
+	public function testGenerate()
+	{
+		$this
+			->given($mocker = $this->newTestedInstance)
+			->then
+				->object($this->testedInstance->generate($functionName = __NAMESPACE__ . '\version_compare'))->isIdenticalTo($this->testedInstance)
+				->boolean(function_exists($functionName))->isTrue()
+				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
+				->integer(\version_compare('5.4.0', '5.3.0'))->isEqualTo(1)
+				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
+				->integer(\version_compare('5.3.0', '5.4.0'))->isEqualTo(-1)
+				->exception(function() use ($mocker) { $mocker->generate(__NAMESPACE__ . '\doesSomething'); })
+					->isInstanceof('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->hasMessage('Function \'' . __NAMESPACE__ . '\doesSomething\' already exists')
+
+			->if($this->testedInstance->{$functionName} = $returnValue = uniqid())
+			->then
+				->string(version_compare(uniqid(), uniqid()))->isEqualTo($returnValue)
+				->object($this->testedInstance->generate($functionName = __NAMESPACE__ . '\version_compare'))->isIdenticalTo($this->testedInstance)
+				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
+				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
+				->object($this->testedInstance->generate($unknownFunctionName = __NAMESPACE__ . '\\foo'))->isIdenticalTo($this->testedInstance)
+				->variable(foo())->isNull()
+
+			->if($this->testedInstance->{$unknownFunctionName} = $fooReturnValue = uniqid())
+			->then
+				->string(foo())->isEqualTo($fooReturnValue)
+
+			->if($this->testedInstance->{$functionName} = $returnValue = uniqid())
+			->when(function() use ($mocker, $functionName) { unset($mocker->{$functionName}); })
+			->then
+				->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
+				->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
+
+			->when(function() use ($mocker, $unknownFunctionName) { unset($mocker->{$unknownFunctionName}); })
+			->then
+				->variable(foo())->isNull()
+		;
+	}
+}

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -92,7 +92,8 @@ namespace mageekguy\atoum\tests\units
 					->object($test->getScore())->isInstanceOf('mageekguy\atoum\score')
 					->object($test->getLocale())->isEqualTo(new atoum\locale())
 					->object($test->getAdapter())->isEqualTo(new atoum\adapter())
-					->object($test->getPhpMocker())->isInstanceOf('mageekguy\atoum\php\mocker')
+					->object($test->getPhpFunctionMocker())->isInstanceOf('mageekguy\atoum\php\mocker\funktion')
+					->object($test->getPhpConstantMocker())->isInstanceOf('mageekguy\atoum\php\mocker\constant')
 					->object($test->getFactoryBuilder())->isInstanceOf('mageekguy\atoum\factory\builder\closure')
 					->boolean($test->isIgnored())->isTrue()
 					->boolean($test->debugModeIsEnabled())->isFalse()
@@ -314,17 +315,17 @@ namespace mageekguy\atoum\tests\units
 			;
 		}
 
-		public function testSetPhpMocker()
+		public function testSetPhpFunktionMocker()
 		{
 			$this
 				->if($test = new emptyTest())
 				->then
-					->object($test->setPhpMocker($phpMocker = new atoum\php\mocker()))->isIdenticalTo($test)
-					->object($test->getPhpMocker())->isIdenticalTo($phpMocker)
-					->object($test->setPhpMocker())->isIdenticalTo($test)
-					->object($test->getPhpMocker())
-						->isNotIdenticalTo($phpMocker)
-						->isInstanceOf('mageekguy\atoum\php\mocker')
+					->object($test->setPhpFunctionMocker($phpFunctionMocker = new atoum\php\mocker\funktion()))->isIdenticalTo($test)
+					->object($test->getPhpFunctionMocker())->isIdenticalTo($phpFunctionMocker)
+					->object($test->setPhpFunctionMocker())->isIdenticalTo($test)
+					->object($test->getPhpFunctionMocker())
+						->isNotIdenticalTo($phpFunctionMocker)
+						->isInstanceOf('mageekguy\atoum\php\mocker\funktion')
 			;
 		}
 


### PR DESCRIPTION
Fix #511.

In 2 steps

### Split PHP mocker

The PHP mocker is splitted into 2 layers:
  1. Abstract mocker, containing all namespace logic,
  2. Function mocker.

The goal is to be able to introduce another mocker. So we must decouple this part first.

**BC break**: All “phpMocker” references become “phpFunctionMocker” (like `setPhpMocker`, `getPhpMocker` etc.). This is not complicated to migrate but this is necessary, sorry.

### Introduce the constant mocker

We use it the same way we use the function mocker:
```php
$this->constant->PHP_VERSION_ID = '606060'; // troll \o/
```

Note: This is used to mock constants, not class constants.

Thoughts?