### PR TITLE
use composer autoloader in atoum if present

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -263,7 +263,9 @@ class autoloader
 	public static function registerComposerAutoloader()
 	{
 		$composerAutoloaderPath = __DIR__ . '/../../../autoload.php';
-		if (is_file($composerAutoloaderPath)) {
+
+		if (is_file($composerAutoloaderPath))
+		{
 			require_once $composerAutoloaderPath;
 		}
 	}

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -254,9 +254,18 @@ class autoloader
 		{
 			static::$autoloader = new static();
 			static::$autoloader->register();
+			static::registerComposerAutoloader();
 		}
 
 		return static::$autoloader;
+	}
+
+	public static function registerComposerAutoloader()
+	{
+		$composerAutoloaderPath = __DIR__ . '/../../../autoload.php';
+		if (is_file($composerAutoloaderPath)) {
+			require_once $composerAutoloaderPath;
+		}
 	}
 
 	public static function get()


### PR DESCRIPTION
If we detect that atoum is in a composer environnement,
we load the composer autoloader within the atoum autoloaded.

This will be usefull for extensions :
having to require manually the composer autoloader, in both
bootstrap and .atoum files will not be needed anymore.

We can see this in the extension documentations. 
For example : https://github.com/atoum/ruler-extension

We have to add two lines in the .atoum.php file : 
```php
<?php

// .atoum.php

require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';

$runner->addExtension(new \mageekguy\atoum\ruler\extension($script));
```