### PR TITLE
Allow extension to define configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#529](https://github.com/atoum/atoum/pull/529) Allow extensions to define configuration ([@jubianchi])
 * [#496](https://github.com/atoum/atoum/pull/496) Mock generator supports variadic arguments passed by reference ([@jubianchi])
 * [#496](https://github.com/atoum/atoum/pull/496) Auto generate and inject mocks in test methods ([@jubianchi])
 

--- a/classes/extension/configuration.php
+++ b/classes/extension/configuration.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace mageekguy\atoum\extension;
+
+
+interface configuration
+{
+	public function serialize();
+
+	public static function unserialize(array $configuration);
+}

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -795,7 +795,7 @@ class runner implements observable
 
 	public function getExtensions()
 	{
-		return iterator_to_array($this->extensions);
+		return $this->extensions;
 	}
 
 	public function removeExtension(atoum\extension $extension)
@@ -818,13 +818,13 @@ class runner implements observable
 	}
 
 
-	public function addExtension(atoum\extension $extension)
+	public function addExtension(atoum\extension $extension, atoum\extension\configuration $configuration = null)
 	{
 		if ($this->extensions->contains($extension) === false)
 		{
 			$extension->setRunner($this);
 
-			$this->extensions->attach($extension);
+			$this->extensions->attach($extension, $configuration);
 
 			$this->addObserver($extension);
 		}

--- a/classes/test.php
+++ b/classes/test.php
@@ -1871,14 +1871,14 @@ abstract class test implements observable, \countable
 
 	public function getExtensions()
 	{
-		return iterator_to_array($this->extensions);
+		return $this->extensions;
 	}
 
 	public function removeExtension(atoum\extension $extension)
 	{
 		$this->extensions->detach($extension);
 
-		return $this->removeObserver($extension);;
+		return $this->removeObserver($extension);
 	}
 
 	public function removeExtensions()
@@ -1893,29 +1893,43 @@ abstract class test implements observable, \countable
 		return $this;
 	}
 
-
-	public function addExtension(atoum\extension $extension)
+	public function addExtension(atoum\extension $extension, atoum\extension\configuration $configuration = null)
 	{
 		if ($this->extensions->contains($extension) === false)
 		{
-			$extension->setTest($this);
+			$this->extensions->detach($extension);
+			$this->removeObserver($extension);
+		}
 
-			$this->extensions->attach($extension);
+		$this->extensions->attach($extension, $configuration);
 
-			$this->addObserver($extension);
+		$extension->setTest($this);
+
+		$this->addObserver($extension);
+
+		return $this;
+	}
+
+	public function addExtensions(\splObjectStorage $extensions)
+	{
+		foreach ($extensions as $extension)
+		{
+			$this->addExtension($extension, $extensions[$extension]);
 		}
 
 		return $this;
 	}
 
-	public function addExtensions(\traversable $extensions)
+	public function getExtensionConfiguration(atoum\extension $extension)
 	{
-		foreach ($extensions as $extension)
+		try
 		{
-			$this->addExtension($extension);
+			return $this->extensions[$extension];
 		}
-
-		return $this;
+		catch (\unexpectedValueException $e)
+		{
+			return null;
+		}
 	}
 
 	private static function cleanNamespace($namespace)

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -451,14 +451,14 @@ class runner extends atoum\test
 			->if($runner = new testedClass())
 			->then
 				->object($runner->addExtension($extension = new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEqualTo(array($extension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension))
 				->array($runner->getObservers())->contains($extension)
 				->mock($extension)
 					->call('setRunner')->withArguments($runner)->once()
 			->if($this->resetMock($extension))
 			->then
 				->object($runner->addExtension($extension))->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEqualTo(array($extension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension))
 				->array($runner->getObservers())->contains($extension)
 				->mock($extension)
 					->call('setRunner')->never();
@@ -470,25 +470,25 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->array($runner->getExtensions())->isEmpty()
+				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
 				->array($runner->getObservers())->isEmpty()
 				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEmpty()
+				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
 				->array($runner->getObservers())->isEmpty()
 			->if($extension = new \mock\mageekguy\atoum\extension())
 			->and($otherExtension = new \mock\mageekguy\atoum\extension())
 			->and($runner->addExtension($extension)->addExtension($otherExtension))
 			->then
-				->array($runner->getExtensions())->isEqualTo(array($extension, $otherExtension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
 				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEqualTo(array($extension, $otherExtension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
 				->object($runner->removeExtension($extension))->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEqualTo(array($otherExtension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($otherExtension))
 				->object($runner->removeExtension($otherExtension))->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEmpty()
+				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
 				->array($runner->getObservers())->isEmpty()
 		;
 	}
@@ -498,19 +498,19 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->array($runner->getExtensions())->isEmpty()
+				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
 				->array($runner->getObservers())->isEmpty()
 				->object($runner->removeExtensions())->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEmpty()
+				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
 				->array($runner->getObservers())->isEmpty()
 			->if($extension = new \mock\mageekguy\atoum\extension())
 			->and($otherExtension = new \mock\mageekguy\atoum\extension())
 			->and($runner->addExtension($extension)->addExtension($otherExtension))
 			->then
-				->array($runner->getExtensions())->isEqualTo(array($extension, $otherExtension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
 				->object($runner->removeExtensions())->isIdenticalTo($runner)
-				->array($runner->getExtensions())->isEmpty()
+				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
 				->array($runner->getObservers())->isEmpty()
 		;
 	}

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -1145,17 +1145,17 @@ namespace mageekguy\atoum\tests\units
 				->if($test = new emptyTest())
 				->then
 					->object($test->addExtension($extension = new \mock\mageekguy\atoum\extension()))->isIdenticalTo($test)
-					->array($test->getExtensions())->isEqualTo(array($extension))
-					->array($test->getObservers())->contains($extension)
+					->array(iterator_to_array($test->getExtensions()))->isEqualTo(array($extension))
+					->array($test->getObservers())->isEqualTo(array($extension))
 					->mock($extension)
 						->call('setTest')->withArguments($test)->once()
 				->if($this->resetMock($extension))
 				->then
 					->object($test->addExtension($extension))->isIdenticalTo($test)
-					->array($test->getExtensions())->isEqualTo(array($extension))
-					->array($test->getObservers())->contains($extension)
+					->array(iterator_to_array($test->getExtensions()))->isEqualTo(array($extension))
+					->array($test->getObservers())->isEqualTo(array($extension))
 					->mock($extension)
-						->call('setTest')->never();
+						->call('setTest')->once();
 			;
 		}
 
@@ -1164,25 +1164,25 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->array($test->getExtensions())->isEmpty()
+					->object($test->getExtensions())->isEqualTo(new \splObjectStorage())
 					->array($test->getObservers())->isEmpty()
 					->object($test->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($test)
-					->array($test->getExtensions())->isEmpty()
+					->object($test->getExtensions())->isEqualTo(new \splObjectStorage())
 					->array($test->getObservers())->isEmpty()
 				->if($extension = new \mock\mageekguy\atoum\extension())
 				->and($otherExtension = new \mock\mageekguy\atoum\extension())
 				->and($test->addExtension($extension)->addExtension($otherExtension))
 				->then
-					->array($test->getExtensions())->isEqualTo(array($extension, $otherExtension))
+					->array(iterator_to_array($test->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 					->array($test->getObservers())->isEqualTo(array($extension, $otherExtension))
 					->object($test->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($test)
-					->array($test->getExtensions())->isEqualTo(array($extension, $otherExtension))
+					->array(iterator_to_array($test->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 					->array($test->getObservers())->isEqualTo(array($extension, $otherExtension))
 					->object($test->removeExtension($extension))->isIdenticalTo($test)
-					->array($test->getExtensions())->isEqualTo(array($otherExtension))
+					->array(iterator_to_array($test->getExtensions()))->isEqualTo(array($otherExtension))
 					->array($test->getObservers())->isEqualTo(array($otherExtension))
 					->object($test->removeExtension($otherExtension))->isIdenticalTo($test)
-					->array($test->getExtensions())->isEmpty()
+					->object($test->getExtensions())->isEqualTo(new \splObjectStorage())
 					->array($test->getObservers())->isEmpty()
 			;
 		}
@@ -1192,20 +1192,39 @@ namespace mageekguy\atoum\tests\units
 			$this
 				->if($test = new emptyTest())
 				->then
-					->array($test->getExtensions())->isEmpty()
+					->object($test->getExtensions())->isEqualTo(new \splObjectStorage())
 					->array($test->getObservers())->isEmpty()
 					->object($test->removeExtensions())->isIdenticalTo($test)
-					->array($test->getExtensions())->isEmpty()
+					->object($test->getExtensions())->isEqualTo(new \splObjectStorage())
 					->array($test->getObservers())->isEmpty()
 				->if($extension = new \mock\mageekguy\atoum\extension())
 				->and($otherExtension = new \mock\mageekguy\atoum\extension())
 				->and($test->addExtension($extension)->addExtension($otherExtension))
 				->then
-					->array($test->getExtensions())->isEqualTo(array($extension, $otherExtension))
+					->array(iterator_to_array($test->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 					->array($test->getObservers())->isEqualTo(array($extension, $otherExtension))
 					->object($test->removeExtensions())->isIdenticalTo($test)
-					->array($test->getExtensions())->isEmpty()
+					->object($test->getExtensions())->isEqualTo(new \splObjectStorage())
 					->array($test->getObservers())->isEmpty()
+			;
+		}
+
+		public function testGetExtensionConfiguration()
+		{
+			$this
+				->if(
+					$test = new emptyTest(),
+					$extension = new \mock\mageekguy\atoum\extension()
+				)
+				->then
+					->variable($test->getExtensionConfiguration($extension))->isNull
+				->if($test->addExtension($extension))
+				->then
+					->variable($test->getExtensionConfiguration($extension))->isNull
+				->given($configuration = new \mock\mageekguy\atoum\extension\configuration())
+				->if($test->addExtension($extension, $configuration))
+				->then
+					->object($test->getExtensionConfiguration($extension))->isIdenticalTo($configuration)
 			;
 		}
 


### PR DESCRIPTION
atoum will use this configuration and pass it to child processes.

@agallou noticed there was something missing around extension configuration while writing the `blackfire-extension`: we can't properly configure the blackfire client as atoum won't forward anything to the child processes actually using the client.

With this patch, extension are free to expose a configuration class and inject an instance of it in atoum when adding the extension so that atoum will forward the configuration to child processes.

For extension developpers, this means they will have to expose a configuration class implementing the provided `mageekguy\atoum\extension\configuration` interface:

```php
<?php

namespace atoum\my\ext
{

    use mageekguy\atoum\observable;
    use mageekguy\atoum\runner;
    use mageekguy\atoum\test;

    class configuration
    {
        private $foo;
        private $bar;

        public function serialize()
        {
            return array(
                'foo' => $this->foo,
                'bar' => $this->bar,
            );
        }

        public function setFoo($v)
        {
            $this->foo = $v;

            return $this;
        }

        public function setBar($v)
        {
            $this->bar = $v;

            return $this;
        }

        public static function unserialize(array $config)
        {
            $configuration = new static;

            $configuration->setFoo($config['foo']);
            $configuration->setBar($config['bar']);

            return $configuration;
        }
    }
}
```

The `configuration` is a bit special: it has to be serialisable as an array representation and should be able to deserialize instance of itself (from the `array` representation).

The extension class will then use this configuration class:

```php
<?php

namespace atoum\my\ext
{

    use mageekguy\atoum\observable;
    use mageekguy\atoum\runner;
    use mageekguy\atoum\test;

    class extension implements \mageekguy\atoum\extension {
        private $configuration;
        private $runner;
        private $test;

        public function __construct()
        {
            $this->configuration = new configuration();
        }

        public function setFoo($v)
        {
            $this->configuration->setFoo($v);

            return $this;
        }

        public function setBar($v)
        {
            $this->configuration->setBar($v);

            return $this;
        }

        public function addToRunner(\mageekguy\atoum\runner $runner)
        {
            $runner->addExtension($this, $this->configuration);

            return $this;
        }

        public function setRunner(runner $runner)
        {
            $this->runner = $runner;

            return $this;
        }

        public function setTest(test $test)
        {
            $this->test = $test;
            $configuration = $test->getExtensionConfiguration($this);

            if ($configuration === null)
            {
                $this->configuration = $configuration;
            }

            return $this;
        }

        public function handleEvent($event, observable $observable)
        {
            return $this;
        }
    }
}
```

When the `setTest` method is called, the extension will be able to fetch its configuration from the `$test` (especially usefull with `concurrent`/`isolate` engines).

For atoum users, this does not change much. Here is an example `.atoum.php` configuration file:

```
<?php

use atoum\my\ext\extension;

$extension = nex extension();

$extension
    ->setFoo('blabla')
    ->setBar('blibli')
    ->addToRunner($runner)
;
```