### PR TITLE
Assert on child arrays using the `phpArray` asserter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#540](https://github.com/atoum/atoum/pull/540) Assert on child arrays using the `phpArray` asserter ([@jubianchi])
 * [#541](https://github.com/atoum/atoum/pull/541) New `toArray` (along with `toArray` method on `phpString` and `object` asserters) and `iterator` asserters ([@jubianchi])
 * [#535](https://github.com/atoum/atoum/pull/535) New `resource` asserter group (with `isOfType` or `is*` wildcard like `isStream`) ([@hywan])
 * [#529](https://github.com/atoum/atoum/pull/529) Allow extensions to define configuration ([@jubianchi])

--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -31,6 +31,13 @@ class phpArray extends asserters\variable implements \arrayAccess
 			case 'isnotempty':
 				return $this->isNotEmpty();
 
+			case 'child':
+				$asserter = new phpArray\child($this);
+
+				$this->resetInnerAsserter();
+
+				return $asserter->setWith($this->value);
+
 			default:
 				$asserter = parent::__get($asserter);
 

--- a/classes/asserters/phpArray/child.php
+++ b/classes/asserters/phpArray/child.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace mageekguy\atoum\asserters\phpArray;
+
+use
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\exceptions
+;
+
+class child extends asserters\phpArray {
+	private $parent;
+
+	public function __construct(asserters\phpArray $parent = null)
+	{
+		parent::__construct($parent->getGenerator(), $parent->getAnalyzer(), $parent->getLocale());
+
+		$this->setWithParent($parent);
+	}
+
+	public function __get($property)
+	{
+		return $this->parentIsSet()->parent->__get($property);
+	}
+
+	public function __call($method, $arguments)
+	{
+		return $this->parentIsSet()->parent->__call($method, $arguments);
+	}
+
+	public function __invoke(\closure $assertions)
+	{
+		$assertions($this->parent->phpArray($this->value));
+
+		return $this;
+	}
+
+	public function setWithParent(asserters\phpArray $parent)
+	{
+		$this->parent = $parent;
+
+		return $this;
+	}
+
+	public function hasSize($size, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->hasSize($size, $failMessage);
+	}
+
+	public function isEmpty($failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isEmpty($failMessage);
+	}
+
+	public function isNotEmpty($failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isNotEmpty($failMessage);
+	}
+
+	public function strictlyContains($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->strictlyContains($value, $failMessage);
+	}
+
+	public function contains($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->contains($value, $failMessage);
+	}
+
+	public function strictlyNotContains($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->strictlyNotContains($value, $failMessage);
+	}
+
+	public function notContains($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->notContains($value, $failMessage);
+	}
+
+	public function hasKeys(array $keys, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->hasKeys($keys, $failMessage);
+	}
+
+	public function notHasKeys(array $keys, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->notHasKeys($keys, $failMessage);
+	}
+
+	public function hasKey($key, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->hasKey($key, $failMessage);
+	}
+
+	public function notHasKey($key, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->notHasKey($key, $failMessage);
+	}
+
+	public function containsValues(array $values, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->containsValues($values, $failMessage);
+	}
+
+	public function strictlyContainsValues(array $values, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->strictlyContainsValues($values, $failMessage);
+	}
+
+	public function notContainsValues(array $values, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->notContainsValues($values, $failMessage);
+	}
+
+	public function strictlyNotContainsValues(array $values, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->strictlyNotContainsValues($values, $failMessage);
+	}
+
+	public function isEqualTo($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isEqualTo($value, $failMessage);
+	}
+
+	public function isNotEqualTo($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isNotEqualTo($value, $failMessage);
+	}
+
+	public function isIdenticalTo($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isIdenticalTo($value, $failMessage);
+	}
+
+	public function isNotIdenticalTo($value, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isNotIdenticalTo($value, $failMessage);
+	}
+
+	public function isReferenceTo(& $reference, $failMessage = null)
+	{
+		return $this->parentIsSet()->parent->isReferenceTo($reference, $failMessage);
+	}
+
+	protected function containsValue($value, $failMessage, $strict)
+	{
+		return $this->parentIsSet()->parent->containsValue($value, $failMessage, $strict);
+	}
+
+	public function offsetGet($key)
+	{
+		$asserter = new child($this);
+
+		return $asserter->setWith($this->valueIsSet()->value[$key]);
+	}
+
+	protected function parentIsSet()
+	{
+		if ($this->parent === null)
+		{
+			throw new exceptions\logic('Parent array asserter is undefined');
+		}
+
+		return $this;
+	}
+}
+

--- a/tests/units/classes/asserters/phpArray.php
+++ b/tests/units/classes/asserters/phpArray.php
@@ -324,6 +324,27 @@ class phpArray extends atoum\test
 		;
 	}
 
+	public function testHasSizeOnInnerAsserter()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance)
+			->then
+				->exception(function() use ($asserter) { $asserter->isEmpty(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Array is undefined')
+			->if($asserter->setWith(array(range(1, 5))))
+			->then
+				->object($childAsserter = $asserter->child[0](function($child) { $child->hasSize(5); }))->isInstanceOf('mageekguy\atoum\asserters\phpArray\child')
+				->object($childAsserter->hasSize(1))->isIdenticalTo($asserter)
+
+			->given($asserter = $this->newTestedInstance)
+			->if($asserter->setWith(array(array(range(1, 5), range(1, 3)))))
+			->then
+				->object($childAsserter = $asserter->child[0][1](function($child) { $child->hasSize(3); }))->isInstanceOf('mageekguy\atoum\asserters\phpArray\child')
+				->object($childAsserter->hasSize(1))->isIdenticalTo($asserter)
+		;
+	}
+
 	public function testIsEmpty()
 	{
 		$this


### PR DESCRIPTION
Here is an example test:

```php
<?php

namespace tests\units;

class stdClass extends \mageekguy\atoum
{
    public function testExempleSugar()
    {
        $array = array(
            'string'    => $string = 'foo',
            'integer'   => $integer = rand(1, 1000),
            'object'    => $object = new \StdClass,
            'array'     => array(
                'key1' => $arrayVal1 = uniqid(),
                'key2' => $arrayVal2 = uniqid(),
                'key3' => array()
            ),
        );

        $this
            ->array($array)->hasSize(4)
                ->string['string']->isEqualTo($string)
                ->integer['integer']->isEqualTo($integer)
                ->child['array'](function($child) use ($arrayVal1,
$arrayVal2) {
                        $child->hasSize(3)
                            ->hasKeys(array('key1', 'key2'))
                            ->contains($arrayVal1)
                            ->string['key2']->isEqualTo($arrayVal2)
                            ->child['key3'](function($child) {
$child->isEmpty; })
                        ;
                    }
                )
                ->string['array']['key1']->isEqualTo($arrayVal1)
                ->object['object']
                    ->isIdenticalTo($object)
        ;
    }
}

```

Closes #506, #507