### PR TITLE
New asserters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#541](https://github.com/atoum/atoum/pull/541) New `toArray` method on the `phpString` and `object` asserters to cast value to an array ([@jubianchi])
 * [#541](https://github.com/atoum/atoum/pull/541) New `iterator` asserter ([@jubianchi])
 * [#541](https://github.com/atoum/atoum/pull/541) New `castToArray` asserter ([@jubianchi])
 * [#535](https://github.com/atoum/atoum/pull/535) New `resource` asserter group (with `isOfType` or `is*` wildcard like `isStream`) ([@hywan])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # `dev-master`
 
-* [#541](https://github.com/atoum/atoum/pull/541) New `toArray` method on the `phpString` and `object` asserters to cast value to an array ([@jubianchi])
-* [#541](https://github.com/atoum/atoum/pull/541) New `iterator` asserter ([@jubianchi])
-* [#541](https://github.com/atoum/atoum/pull/541) New `castToArray` asserter ([@jubianchi])
+* [#541](https://github.com/atoum/atoum/pull/541) New `toArray` (along with `toArray` method on `phpString` and `object` asserters) and `iterator` asserters ([@jubianchi])
 * [#535](https://github.com/atoum/atoum/pull/535) New `resource` asserter group (with `isOfType` or `is*` wildcard like `isStream`) ([@hywan])
 * [#529](https://github.com/atoum/atoum/pull/529) Allow extensions to define configuration ([@jubianchi])
 * [#496](https://github.com/atoum/atoum/pull/496) Mock generator supports variadic arguments passed by reference ([@jubianchi])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#541](https://github.com/atoum/atoum/pull/541) New `iterator` asserter ([@jubianchi])
 * [#541](https://github.com/atoum/atoum/pull/541) New `castToArray` asserter ([@jubianchi])
 * [#535](https://github.com/atoum/atoum/pull/535) New `resource` asserter group (with `isOfType` or `is*` wildcard like `isStream`) ([@hywan])
 * [#529](https://github.com/atoum/atoum/pull/529) Allow extensions to define configuration ([@jubianchi])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#541](https://github.com/atoum/atoum/pull/541) New `castToArray` asserter ([@jubianchi])
 * [#535](https://github.com/atoum/atoum/pull/535) New `resource` asserter group (with `isOfType` or `is*` wildcard like `isStream`) ([@hywan])
 * [#529](https://github.com/atoum/atoum/pull/529) Allow extensions to define configuration ([@jubianchi])
 * [#496](https://github.com/atoum/atoum/pull/496) Mock generator supports variadic arguments passed by reference ([@jubianchi])

--- a/classes/asserters/castToArray.php
+++ b/classes/asserters/castToArray.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace mageekguy\atoum\asserters;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\tools,
+	mageekguy\atoum\asserters
+;
+
+class castToArray extends asserters\phpArray
+{
+	protected $adapter = null;
+
+	public function __construct(asserter\generator $generator = null, tools\variable\analyzer $analyzer = null, atoum\locale $locale = null, atoum\adapter $adapter = null)
+	{
+		parent::__construct($generator, $analyzer, $locale);
+
+		$this->setAdapter($adapter);
+	}
+
+	public function setAdapter(atoum\adapter $adapter = null)
+	{
+		$this->adapter = $adapter ?: new atoum\adapter();
+
+		return $this;
+	}
+
+	public function getAdapter()
+	{
+		return $this->adapter;
+	}
+
+	public function setWith($value)
+	{
+		parent::setWith($value, false);
+
+		$fail = false;
+		$this->adapter->set_error_handler(function() use (& $fail) { $fail = true; });
+
+		switch (true)
+		{
+			case $this->value instanceof \Iterator:
+				$value = iterator_to_array($this->value);
+				break;
+
+			case $this->getAnalyzer()->isString($value):
+				$value = $this->adapter->str_split($value);
+				$fail = $value === false;
+				break;
+
+			default:
+				$value = (array) $value;
+		}
+
+		$this->adapter->restore_error_handler();
+
+		if ($fail)
+		{
+			$this->fail($this->getLocale()->_('%s could not be converted to array', $this->getTypeOf($this->value)));
+		}
+
+		$this->value = $value;
+
+		return $this->pass();
+	}
+}

--- a/classes/asserters/iterator.php
+++ b/classes/asserters/iterator.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace mageekguy\atoum\asserters;
+
+use
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\exceptions
+	;
+
+class iterator extends asserters\object
+{
+	public function __get($asserter)
+	{
+		switch (strtolower($asserter))
+		{
+			case 'size':
+				return $this->size();
+
+			case 'isempty':
+				return $this->isEmpty();
+
+			case 'isnotempty':
+				return $this->isNotEmpty();
+
+			default:
+				return parent::__get($asserter);
+		}
+	}
+
+	public function setWith($value, $checkType = true)
+	{
+		parent::setWith($value, $checkType);
+
+		if ($checkType === true)
+		{
+			if (self::isIterator($this->value) === false)
+			{
+				$this->fail($this->getLocale()->_('%s is not an iterator', $this));
+			}
+			else
+			{
+				$this->pass();
+			}
+		}
+
+		return $this;
+	}
+
+	public function hasSize($size, $failMessage = null)
+	{
+		if (($actual = iterator_count($this->valueIsSet()->value)) == $size)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage ?: $this->getLocale()->_('%s has size %d, expected size %d', $this, $actual, $size));
+		}
+
+		return $this;
+	}
+
+	public function isEmpty($failMessage = null)
+	{
+		if (($actual = iterator_count($this->valueIsSet()->value)) === 0)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage ?: $this->getLocale()->_('%s is not empty', $this, $actual));
+		}
+
+		return $this;
+	}
+
+	public function isNotEmpty($failMessage = null)
+	{
+		if (iterator_count($this->valueIsSet()->value) > 0)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($failMessage ?: $this->_('%s is empty', $this));
+		}
+
+		return $this;
+	}
+
+	protected function size()
+	{
+		return $this->generator->__call('integer', array(iterator_count($this->valueIsSet()->value)));
+	}
+
+	protected static function isIterator($value)
+	{
+		return ($value instanceof \iterator);
+	}
+}

--- a/classes/asserters/iterator.php
+++ b/classes/asserters/iterator.php
@@ -5,7 +5,7 @@ namespace mageekguy\atoum\asserters;
 use
 	mageekguy\atoum\asserters,
 	mageekguy\atoum\exceptions
-	;
+;
 
 class iterator extends asserters\object
 {

--- a/classes/asserters/object.php
+++ b/classes/asserters/object.php
@@ -14,6 +14,7 @@ class object extends asserters\variable
 		switch (strtolower($property))
 		{
 			case 'tostring':
+			case 'toarray':
 			case 'isempty':
 			case 'istestedinstance':
 			case 'isnottestedinstance':
@@ -138,6 +139,11 @@ class object extends asserters\variable
 	public function toString()
 	{
 		return $this->generator->castToString($this->valueIsSet()->value);
+	}
+
+	public function toArray()
+	{
+		return $this->generator->castToArray($this->valueIsSet()->value);
 	}
 
 	protected function valueIsSet($message = 'Object is undefined')

--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -135,7 +135,7 @@ class phpArray extends asserters\variable implements \arrayAccess
 		return ($value !== null && array_key_exists($key, $value) === true);
 	}
 
-	public function setWith($value)
+	public function setWith($value, $checkType = true)
 	{
 		$innerAsserter = $this->innerAsserter;
 
@@ -149,7 +149,7 @@ class phpArray extends asserters\variable implements \arrayAccess
 		{
 			parent::setWith($value);
 
-			if ($this->analyzer->isArray($this->value) === true)
+			if ($this->analyzer->isArray($this->value) === true  || $checkType === false)
 			{
 				$this->pass();
 			}

--- a/classes/asserters/phpString.php
+++ b/classes/asserters/phpString.php
@@ -26,6 +26,9 @@ class phpString extends asserters\variable
 			case 'isnotempty':
 				return $this->isNotEmpty();
 
+			case 'toArray':
+				return $this->toArray();
+
 			default:
 				return $this->generator->__get($asserter);
 		}
@@ -238,6 +241,11 @@ class phpString extends asserters\variable
 		}
 
 		return $this;
+	}
+
+	public function toArray()
+	{
+		return $this->generator->castToArray($this->valueIsSet()->value);
 	}
 
 	protected function getLengthAsserter()

--- a/tests/units/classes/asserters/castToArray.php
+++ b/tests/units/classes/asserters/castToArray.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\asserters;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\tools\variable
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class castToArray extends atoum\test
+{
+	public function testClass()
+	{
+		$this->testedClass->extends('mageekguy\atoum\asserters\phpArray');
+	}
+
+	public function test__construct()
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->getGenerator())->isEqualTo(new asserter\generator())
+				->object($this->testedInstance->getAnalyzer())->isEqualTo(new variable\analyzer())
+				->object($this->testedInstance->getLocale())->isEqualTo(new atoum\locale())
+				->variable($this->testedInstance->getValue())->isNull()
+				->boolean($this->testedInstance->wasSet())->isFalse()
+
+			->given($this->newTestedInstance($generator = new atoum\asserter\generator(), $analyzer = new variable\analyzer(), $locale = new atoum\locale()))
+			->then
+				->object($this->testedInstance->getGenerator())->isIdenticalTo($generator)
+				->object($this->testedInstance->getAnalyzer())->isIdenticalTo($analyzer)
+				->object($this->testedInstance->getLocale())->isIdenticalTo($locale)
+				->variable($this->testedInstance->getValue())->isNull()
+				->boolean($this->testedInstance->wasSet())->isFalse()
+		;
+	}
+
+	public function testSetWith()
+	{
+		$this
+			->given(
+				$adapter = new atoum\test\adapter(),
+				$asserter = $this->newTestedInstance
+					->setLocale($locale = new \mock\atoum\locale())
+					->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+					->setAdapter($adapter)
+			)
+			->then
+				->object($asserter->setWith($object = new \exception()))->isIdenticalTo($asserter)
+				->array($asserter->getValue())->isEqualTo((array) $object)
+
+				->object($asserter->setWith($object = new \exception()))->isIdenticalTo($asserter)
+				->array($asserter->getValue())->isEqualTo((array) $object)
+
+			->if(
+				$adapter->str_split = false,
+				$this->calling($locale)->_ = $notAnObject = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid()
+			)
+			->then
+				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notAnObject)
+					->string($asserter->getValue())->isEqualTo($value)
+				->mock($locale)->call('_')->withArguments('%s could not be converted to array', $type)->once
+				->mock($analyzer)->call('getTypeOf')->withArguments($value)->once
+		;
+	}
+
+	public function testToString()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance(new asserter\generator()))
+
+			->if($asserter->setWith($object = new \exception()))
+			->then
+				->castToString($asserter)->isEqualTo('array(' . sizeof((array) $object) . ')')
+		;
+	}
+}

--- a/tests/units/classes/asserters/iterator.php
+++ b/tests/units/classes/asserters/iterator.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\asserters;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\tools\variable
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class iterator extends atoum\test
+{
+	public function testClass()
+	{
+		$this->testedClass->extends('mageekguy\atoum\asserters\object');
+	}
+
+	public function test__construct()
+	{
+		$this
+			->if($this->newTestedInstance())
+			->then
+				->object($this->testedInstance->getGenerator())->isEqualTo(new atoum\asserter\generator())
+				->object($this->testedInstance->getAnalyzer())->isEqualTo(new variable\analyzer())
+				->object($this->testedInstance->getLocale())->isEqualTo(new atoum\locale())
+				->variable($this->testedInstance->getValue())->isNull()
+				->boolean($this->testedInstance->wasSet())->isFalse()
+
+			->if($this->newTestedInstance($generator = new asserter\generator(), $analyzer = new variable\analyzer(), $locale = new atoum\locale()))
+			->then
+				->object($this->testedInstance->getGenerator())->isIdenticalTo($generator)
+				->object($this->testedInstance->getAnalyzer())->isIdenticalTo($analyzer)
+				->object($this->testedInstance->getLocale())->isIdenticalTo($locale)
+				->variable($this->testedInstance->getValue())->isNull()
+				->boolean($this->testedInstance->wasSet())->isFalse()
+		;
+	}
+
+	public function testSetWith()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+			)
+
+			->if(
+				$this->calling($locale)->_ = $notAnArray = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid()
+			)
+			->then
+				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notAnArray)
+				->mock($locale)->call('_')->withArguments('%s is not an object', $type)->once
+
+				->exception(function() use ($asserter, & $value) { $asserter->setWith($value = new \stdClass); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notAnArray)
+				->mock($locale)->call('_')->withArguments('%s is not an object', $type)->once
+
+				->object($asserter->setWith($value = new \mock\iterator()))->isIdenticalTo($asserter)
+				->iterator($asserter->getValue())->isEqualTo($value)
+				->boolean($asserter->isSetByReference())->isFalse()
+		;
+	}
+
+	public function testHasSize()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->hasSize(rand(0, PHP_INT_MAX)); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if(
+				$this->calling($locale)->_ = $badSize = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid(),
+				$asserter->setWith(new \arrayIterator(array()))
+			)
+			->then
+				->exception(function() use ($asserter, & $size) { $asserter->hasSize($size = rand(1, PHP_INT_MAX)); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($badSize)
+				->mock($locale)->call('_')->withArguments('%s has size %d, expected size %d', $asserter, 0, $size)->once
+
+				->exception(function() use ($asserter, & $failMessage) { $asserter->hasSize(rand(1, PHP_INT_MAX), $failMessage = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($failMessage)
+
+				->object($asserter->hasSize(0))->isIdenticalTo($asserter)
+
+			->if($asserter->setWith(new \arrayIterator(range(1, 5))))
+			->then
+				->object($asserter->hasSize(5))->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testIsEmpty()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isEmpty(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if(
+				$this->calling($locale)->_ = $notEmpty = uniqid(),
+				$asserter->setWith(new \arrayIterator(array(uniqid())))
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isEmpty(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notEmpty)
+				->mock($locale)->call('_')->withArguments('%s is not empty', $asserter)->once
+
+				->exception(function() use ($asserter) { $asserter->isEmpty; })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($notEmpty)
+				->mock($locale)->call('_')->withArguments('%s is not empty', $asserter)->twice
+
+				->exception(function() use ($asserter, & $failMessage) { $asserter->isEmpty($failMessage = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($failMessage)
+
+			->if($asserter->setWith(new \arrayIterator(array())))
+			->then
+				->object($asserter->isEmpty())->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testIsNotEmpty()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if(
+				$this->calling($locale)->_ = $isEmpty = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid(),
+				$asserter->setWith(new \arrayIterator(array()))
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isNotEmpty(); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($isEmpty)
+				->mock($locale)->call('_')->withArguments('%s is empty', $asserter)->once
+
+				->exception(function() use ($asserter) { $asserter->isNotEmpty; })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($isEmpty)
+				->mock($locale)->call('_')->withArguments('%s is empty', $asserter)->twice
+
+				->exception(function() use ($asserter, & $failMessage) { $asserter->isNotEmpty($failMessage = uniqid()); })
+						->isInstanceOf('mageekguy\atoum\asserter\exception')
+						->hasMessage($failMessage)
+
+				->if($asserter->setWith(new \arrayIterator(array(uniqid()))))
+				->then
+					->object($asserter->isNotEmpty())->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testSize()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance)
+			->then
+				->exception(function() use ($asserter) { $asserter->size; })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if($asserter->setWith(new \arrayIterator(array())))
+			->then
+				->object($integer = $asserter->size)->isInstanceOf('mageekguy\atoum\asserters\integer')
+				->integer($integer->getValue())->isEqualTo(0)
+
+			->if($asserter->setWith(new \arrayIterator(array(uniqid(), uniqid()))))
+			->then
+				->object($integer = $asserter->size)->isInstanceOf('mageekguy\atoum\asserters\integer')
+				->integer($integer->getValue())->isEqualTo(2)
+		;
+	}
+
+	public function testIsEqualTo()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setDiff($diff = new \mock\atoum\tools\diffs\variable())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+				->setGenerator($generator = new \mock\atoum\asserter\generator())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isEqualTo(new \mock\iterator()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if($asserter->setWith(new \arrayIterator(array())))
+			->then
+				->object($asserter->isEqualTo(new \arrayIterator(array())))->isIdenticalTo($asserter)
+
+			->if($asserter->setWith($iterator = new \arrayIterator(range(1, 5))))
+			->then
+				->object($asserter->isEqualTo($iterator))->isIdenticalTo($asserter)
+
+			->if(
+				$this->calling($locale)->_ = $localizedMessage = uniqid(),
+				$this->calling($diff)->__toString = $diffValue = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid()
+			)
+			->then
+				->exception(function() use ($asserter, & $notEqualValue) { $asserter->isEqualTo($notEqualValue = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($localizedMessage . PHP_EOL . $diffValue)
+				->mock($locale)->call('_')->withArguments('%s is not equal to %s', $asserter, $type)->once
+				->mock($analyzer)->call('getTypeOf')->withArguments($notEqualValue)->once
+
+				->object($asserter->isEqualTo($iterator))->isIdenticalTo($asserter)
+		;
+	}
+
+	public function testIsNotEqualTo()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+				->setGenerator($generator = new \mock\atoum\asserter\generator())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isNotEqualTo(new \mock\iterator()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if($asserter->setWith(new \arrayIterator(array())))
+			->then
+				->object($asserter->isNotEqualTo(new \arrayIterator(range(1, 2))))->isIdenticalTo($asserter)
+
+			->if(
+				$this->calling($locale)->_ = $localizedMessage = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid()
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isNotEqualTo(new \arrayIterator(array())); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($localizedMessage)
+				->mock($locale)->call('_')->withArguments('%s is equal to %s', $asserter, $type)->once
+				->mock($analyzer)->call('getTypeOf')->withArguments(new \arrayIterator(array()))->once
+
+			->if($asserter->setWith($iterator = new \arrayIterator(range(1, 5))))
+			->then
+				->object($asserter->isNotEqualTo(new \arrayIterator(array())))->isIdenticalTo($asserter)
+
+				->exception(function() use ($asserter, $iterator) { $asserter->isNotEqualTo($iterator); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($localizedMessage)
+				->mock($locale)->call('_')->withArguments('%s is equal to %s', $asserter, $type)->twice
+				->mock($analyzer)->call('getTypeOf')->withArguments($iterator)->once
+		;
+	}
+
+	public function testIsIdenticalTo()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setDiff($diff = new \mock\atoum\tools\diffs\variable())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+				->setGenerator($generator = new \mock\atoum\asserter\generator())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isIdenticalTo(new \mock\iterator()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if($asserter->setWith($iterator = new \mock\iterator()))
+			->then
+				->object($asserter->isIdenticalTo($iterator))->isIdenticalTo($asserter)
+
+			->if(
+				$this->calling($locale)->_ = $localizedMessage = uniqid(),
+				$this->calling($diff)->__toString = $diffValue = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid()
+			)
+			->then
+				->exception(function() use ($asserter, & $notIdenticalValue) { $asserter->isIdenticalTo($notIdenticalValue = uniqid()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($localizedMessage . PHP_EOL . $diffValue)
+				->mock($locale)->call('_')->withArguments('%s is not identical to %s', $asserter, $type)->once
+				->mock($analyzer)->call('getTypeOf')->withArguments($notIdenticalValue)->once
+		;
+	}
+
+	public function testIsNotIdenticalTo()
+	{
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+				->setGenerator($generator = new \mock\atoum\asserter\generator())
+			)
+			->then
+				->exception(function() use ($asserter) { $asserter->isNotIdenticalTo(new \mock\iterator()); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+
+			->if($asserter->setWith($iterator = new \mock\iterator()))
+			->then
+				->object($asserter->isNotIdenticalTo(new \mock\iterator()))->isIdenticalTo($asserter)
+
+			->if(
+				$this->calling($locale)->_ = $localizedMessage = uniqid(),
+				$this->calling($analyzer)->getTypeOf = $type = uniqid()
+			)
+			->then
+				->exception(function() use ($asserter, $iterator) { $asserter->isNotIdenticalTo($iterator); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage($localizedMessage)
+				->mock($locale)->call('_')->withArguments('%s is identical to %s', $asserter, $type)->once
+				->mock($analyzer)->call('getTypeOf')->withArguments($iterator)->once
+		;
+	}
+}

--- a/tests/units/classes/asserters/object.php
+++ b/tests/units/classes/asserters/object.php
@@ -266,6 +266,20 @@ class object extends atoum\test
 		;
 	}
 
+	public function testToArray()
+	{
+		$this
+			->if($asserter = $this->newTestedInstance(new asserter\generator()))
+			->then
+				->exception(function() use ($asserter) { $asserter->toArray(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Object is undefined')
+			->if($asserter->setWith($this))
+			->then
+				->object($asserter->toArray())->isInstanceOf('mageekguy\atoum\asserters\castToArray')
+		;
+	}
+
 	public function testIsInstanceOf()
 	{
 		$this

--- a/tests/units/classes/asserters/phpString.php
+++ b/tests/units/classes/asserters/phpString.php
@@ -604,4 +604,18 @@ class phpString extends atoum\test
 				->hasMessage($failMessage)
 		;
 	}
+
+	public function testToArray()
+	{
+		$this
+			->if($asserter = $this->newTestedInstance(new asserter\generator()))
+			->then
+				->exception(function() use ($asserter) { $asserter->toArray(); })
+					->isInstanceOf('mageekguy\atoum\exceptions\logic')
+					->hasMessage('Value is undefined')
+			->if($asserter->setWith(uniqid()))
+			->then
+				->object($asserter->toArray())->isInstanceOf('mageekguy\atoum\asserters\castToArray')
+		;
+	}
 }


### PR DESCRIPTION
This PR adds two new asserters:

* `castToArray` to cast any value to an array and assert on it:

```php
$this->castToArray($actual)->string[0]->isEqualTo($expected);

// OR

$this->string($actual)->toArray->string[0]->isEqualTo($expected);
```

* `iterator` to assert on any instance from a class implemeting the `iterator` interface:

```php
$this->iterator($object)->hasSize(5)
```

Those two asserters can also work together to ease assertions on `iterator` content:

```php
$this
    ->iterator($actual)
    ->hasSize(5)
    ->toArray
        ->object[0]->isEqualTo($expected)
        // ...
```

_Those two asserters have been extracted from #227_