### PR TITLE
Disable xdebug on php7 when testing the phar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ script:
   - bin/atoum +verbose
 before_deploy:
   - mkdir phar
-  - rm -f .atoum.php
   - php -n -dphar.readonly=Off scripts/phar/generator.php -d ./phar
   - php -n -ddate.timezone=Europe/Paris ./phar/atoum.phar --test-it -ncc +verbose
 deploy:


### PR DESCRIPTION
This will fix the phar build on travis with PHP7.

Ideally, this PR should go in a 2.5.1 but it not a blocker ATM we can postpone it until 2.6.0