### PR TITLE
add a way to overload the loop mode behaviour

### DIFF
--- a/classes/script.php
+++ b/classes/script.php
@@ -417,12 +417,12 @@ abstract class script
 		return $this;
 	}
 
-	protected function canRun()
+	public function canRun()
 	{
 		return ($this->doRun === true);
 	}
 
-	protected function stopRun()
+	public function stopRun()
 	{
 		$this->doRun = false;
 

--- a/classes/scripts/loop/runner.php
+++ b/classes/scripts/loop/runner.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace mageekguy\atoum\scripts\loop;
+
+use mageekguy\atoum\php;
+use mageekguy\atoum\scripts\loop\strategy;
+
+class runner
+{
+	protected $strategy;
+
+	public function __construct()
+	{
+		$this
+			->setStrategy()
+		;
+	}
+
+	public function setStrategy(strategy $strategy = null)
+	{
+		$this->strategy = $strategy ?: new strategy\prompt();
+
+		return $this;
+	}
+
+	public function getStrategy()
+	{
+		return $this->strategy;
+	}
+
+	public function run(\mageekguy\atoum\scripts\runner $runner)
+	{
+		$php = new php();
+		$php
+			->addOption('-f', $_SERVER['argv'][0])
+			->addArgument('--disable-loop-mode');
+
+		if ($runner->getCli()->isTerminal() === true) {
+			$php->addArgument('--force-terminal');
+		}
+
+		$addScoreFile = false;
+
+		foreach ($runner->getArgumentsParser()->getValues() as $argument => $values) {
+			switch ($argument) {
+				case '-l':
+				case '--loop':
+				case '--disable-loop-mode':
+					break;
+
+				case '-sf':
+				case '--score-file':
+					$addScoreFile = true;
+					break;
+
+				default:
+					if ($runner->getArgumentsParser()->argumentHasHandler($argument) === false) {
+						$php->addArgument('-f', $argument);
+					} else {
+						$php->addArgument($argument, join(' ', $values));
+					}
+			}
+		}
+
+		if ($runner->getScoreFile() === null) {
+			$runner->setScoreFile(sys_get_temp_dir() . '/atoum.score');
+
+			@unlink($runner->getScoreFile());
+
+			$addScoreFile = true;
+		}
+
+		if ($addScoreFile === true) {
+			$php->addArgument('--score-file', $runner->getScoreFile());
+		}
+
+		while ($runner->canRun() === true) {
+			passthru((string)$php);
+
+			if (!$runner->isLoopModeEnabled() || $this->getStrategy()->runAgain($runner) === false) {
+				$runner->stopRun();
+			}
+		}
+	}
+}

--- a/classes/scripts/loop/strategy.php
+++ b/classes/scripts/loop/strategy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace mageekguy\atoum\scripts\loop;
+
+interface strategy
+{
+	public function runAgain(\mageekguy\atoum\scripts\runner $runner);
+}

--- a/classes/scripts/loop/strategy/prompt.php
+++ b/classes/scripts/loop/strategy/prompt.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace mageekguy\atoum\scripts\loop\strategy;
+
+use mageekguy\atoum\scripts\loop\strategy;
+use mageekguy\atoum\scripts\runner;
+
+class prompt implements strategy
+{
+	public function runAgain(runner $runner)
+	{
+		return ($runner->prompt($runner->getLocale()->_('Press <Enter> to reexecute, press any other key and <Enter> to stop...')) == '');
+	}
+}


### PR DESCRIPTION
When writting the first version of the autoloop extension, the only way to change the runAgain behaviour were to check to the message content. That's not a proper way to do it (it works but tha'ts ugly).


It were done like this : 
```php
$runAgainText = "Press <Enter> to reexecute, press any other key and <Enter> to stop...";
if ($message != $runAgainText) {
  return parent::ask($message);
}
```

This PR adds a way to change the runAgain strategy in extensions. For example we could write something like this : 

```php
            $autoLoopHandler = function(\mageekguy\atoum\scripts\runner $script, $argument, $values) use ($configuration) {
                $script->enableLoopMode();

                $watcherStrategy = new scripts\loop\strategy\watcher();
                $watcherStrategy->setConfiguration($configuration);

                $script->getLoopRunner()->setStrategy($watcherStrategy);
            };

            $script
                ->addArgumentHandler(
                    $autoLoopHandler,
                    array('--autoloop'),
                    null,
                    $script->getLocale()->_('Automaticly relaunch tests on file change (implies --loop)')
                )
            ;
```

A full version of the extension changes could be found here https://github.com/agallou/autoloop-extension/pull/2