### PR TITLE
Extract loop logic from runner and add a looper interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#567](https://github.com/atoum/atoum/pull/567) Extract loop logic from runner and add a looper interface ([@jubianchi], [@agallou])
+
 # 2.5.2 - 2016-01-28
 
 * [#561](https://github.com/atoum/atoum/pull/561) Use the fully qualified name when the return type is not `builtin` ([@GuillaumeDievart])
@@ -165,3 +167,4 @@
 [@GuillaumeDievart]: https://github.com/GuillaumeDievart
 [@stephpy]: https://github.com/stephpy
 [@evert]: https://github.com/evert
+[@agallou]: https://github.com/agallou

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -27,11 +27,12 @@ class runner extends atoum\script\configurable
 	protected $tags = array();
 	protected $methods = array();
 	protected $loop = false;
+	protected $looper;
 
 	protected static $autorunner = true;
 	protected static $runnerFile = null;
 
-	public function __construct($name, atoum\adapter $adapter = null)
+	public function __construct($name, atoum\adapter $adapter = null, atoum\scripts\runner\looper $looper = null)
 	{
 		parent::__construct($name, $adapter);
 
@@ -39,6 +40,7 @@ class runner extends atoum\script\configurable
 			->setRunner()
 			->setConfiguratorFactory()
 			->setDefaultReportFactory()
+			->setLooper($looper)
 		;
 	}
 
@@ -130,6 +132,18 @@ class runner extends atoum\script\configurable
 	public function getDefaultReportFactory()
 	{
 		return $this->defaultReportFactory;
+	}
+
+	public function setLooper(atoum\scripts\runner\looper $looper = null)
+	{
+		$this->looper = $looper ?: new atoum\scripts\runner\loopers\prompt($this->prompt, $this->outputWriter, $this->cli, $this->locale);
+
+		return $this;
+	}
+
+	public function getLooper()
+	{
+		return $this->looper;
 	}
 
 	public function autorun()
@@ -1182,11 +1196,6 @@ class runner extends atoum\script\configurable
 		return $this;
 	}
 
-	protected function runAgain()
-	{
-		return ($this->prompt($this->locale->_('Press <Enter> to reexecute, press any other key and <Enter> to stop...')) == '');
-	}
-
 	protected function loop()
 	{
 		$php = new php();
@@ -1246,7 +1255,7 @@ class runner extends atoum\script\configurable
 		{
 			passthru((string) $php);
 
-			if ($this->loop === false || $this->runAgain() === false)
+			if ($this->loop === false || $this->looper->runAgain() === false)
 			{
 				$this->stopRun();
 			}

--- a/classes/scripts/runner/looper.php
+++ b/classes/scripts/runner/looper.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace mageekguy\atoum\scripts\runner;
+
+interface looper
+{
+	public function runAgain();
+}

--- a/classes/scripts/runner/loopers/prompt.php
+++ b/classes/scripts/runner/loopers/prompt.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace mageekguy\atoum\scripts\runner\loopers;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\script,
+	mageekguy\atoum\writers,
+	mageekguy\atoum\scripts\runner\looper
+;
+
+class prompt implements looper
+{
+	private $writer;
+	private $prompt;
+	private $locale;
+	private $cli;
+
+	public function __construct(script\prompt $prompt = null, atoum\writer $writer = null, atoum\cli $cli = null, atoum\locale $locale = null)
+	{
+		$this
+			->setCli($cli)
+			->setOutputWriter($writer)
+			->setPrompt($prompt)
+			->setLocale($locale)
+		;
+	}
+
+	public function setCli(atoum\cli $cli = null)
+	{
+		$this->cli = $cli ?: new atoum\cli();
+
+		return $this;
+	}
+
+	public function getCli()
+	{
+		return $this->cli;
+	}
+
+	public function setOutputWriter(atoum\writer $writer = null)
+	{
+		$this->writer = $writer ?: new writers\std\out($this->cli);
+
+		return $this;
+	}
+
+	public function getOutputWriter()
+	{
+		return $this->writer;
+	}
+
+	public function setPrompt(script\prompt $prompt = null)
+	{
+		if ($prompt === null)
+		{
+			$prompt = new script\prompt();
+		}
+
+		$this->prompt = $prompt->setOutputWriter($this->writer);
+
+		return $this;
+	}
+
+	public function getPrompt()
+	{
+		return $this->prompt;
+	}
+
+	public function setLocale(atoum\locale $locale = null)
+	{
+		$this->locale = $locale ?: new atoum\locale();
+
+		return $this;
+	}
+
+	public function getLocale()
+	{
+		return $this->locale;
+	}
+
+	public function runAgain()
+	{
+		return ($this->prompt($this->locale->_('Press <Enter> to reexecute, press any other key and <Enter> to stop...')) == '');
+	}
+
+	private function prompt($message)
+	{
+		return trim($this->prompt->ask(rtrim($message)));
+	}
+}

--- a/tests/units/classes/scripts/runner/loopers/prompt.php
+++ b/tests/units/classes/scripts/runner/loopers/prompt.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\scripts\runner\loopers;
+
+use mageekguy\atoum;
+
+class prompt extends atoum\test
+{
+	public function testClass()
+	{
+		$this->testedClass->extends('mageekguy\atoum\scripts\runner\looper');
+	}
+
+	public function test__construct(atoum\cli $cli, atoum\writer $writer, atoum\script\prompt $prompt, atoum\locale $locale)
+	{
+		$this
+			->if($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->getCli())->isInstanceof('mageekguy\atoum\cli')
+				->object($this->testedInstance->getOutputWriter())->isInstanceof('mageekguy\atoum\writer')
+				->object($this->testedInstance->getPrompt())->isInstanceOf('mageekguy\atoum\script\prompt')
+				->object($this->testedInstance->getLocale())->isInstanceOf('mageekguy\atoum\locale')
+			->if($this->newTestedInstance($prompt, $writer, $cli, $locale))
+			->then
+				->object($this->testedInstance->getCli())->isIdenticalTo($cli)
+				->object($this->testedInstance->getOutputWriter())->isIdenticalTo($writer)
+				->object($this->testedInstance->getPrompt())->isIdenticalTo($prompt)
+				->object($this->testedInstance->getLocale())->isIdenticalTo($locale)
+		;
+	}
+
+	public function testGetSetCli(atoum\cli $cli)
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->setCli())->isTestedInstance
+				->object($this->testedInstance->getCli())->isInstanceof('mageekguy\atoum\cli')
+				->object($this->testedInstance->setCli($cli))->isTestedInstance
+				->object($this->testedInstance->getCli())->isIdenticalTo($cli)
+		;
+	}
+
+	public function testGetSetOutputWriter(atoum\cli $cli, atoum\writer $writer)
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->setOutputWriter())->isTestedInstance
+				->object($this->testedInstance->getOutputWriter())->isInstanceof('mageekguy\atoum\writer')
+				->object($this->testedInstance->setOutputWriter($writer))->isTestedInstance
+				->object($this->testedInstance->getOutputWriter())->isIdenticalTo($writer)
+			->if($this->testedInstance->setCli($cli))
+			->then
+				->object($this->testedInstance->setOutputWriter())->isTestedInstance
+				->object($this->testedInstance->getOutputWriter())->isInstanceof('mageekguy\atoum\writer')
+				->object($this->testedInstance->getOutputWriter()->getCli())->isIdenticalTo($cli)
+		;
+	}
+
+	public function testGetSetPrompt(atoum\writer $writer, atoum\script\prompt $prompt)
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->setPrompt())->isTestedInstance
+				->object($this->testedInstance->getPrompt())->isInstanceof('mageekguy\atoum\script\prompt')
+				->object($this->testedInstance->getPrompt()->getOutputWriter())->isInstanceof('mageekguy\atoum\writer')
+				->object($this->testedInstance->setPrompt($prompt))->isTestedInstance
+				->object($this->testedInstance->getPrompt())->isIdenticalTo($prompt)
+				->object($this->testedInstance->getPrompt()->getOutputWriter())->isInstanceof('mageekguy\atoum\writer')
+			->if($this->testedInstance->setOutputWriter($writer))
+			->then
+				->object($this->testedInstance->setPrompt())->isTestedInstance
+				->object($this->testedInstance->getPrompt())->isInstanceof('mageekguy\atoum\script\prompt')
+				->object($this->testedInstance->getPrompt()->getOutputWriter())->isIdenticalTo($writer)
+		;
+	}
+
+	public function testGetSetLocale(atoum\locale $locale)
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->setLocale())->isTestedInstance
+				->object($this->testedInstance->getLocale())->isInstanceof('mageekguy\atoum\locale')
+				->object($this->testedInstance->setLocale($locale))->isTestedInstance
+				->object($this->testedInstance->getLocale())->isIdenticalTo($locale)
+		;
+	}
+
+	public function testRunAgain(atoum\script\prompt $prompt, atoum\locale $locale)
+	{
+		$this
+			->given(
+				$this->newTestedInstance($prompt, null, null, $locale),
+				$this->calling($locale)->_ = $promptMessage = uniqid()
+			)
+			->if($this->calling($prompt)->ask = uniqid())
+			->then
+				->boolean($this->testedInstance->runAgain())->isFalse
+				->mock($prompt)
+					->call('ask')->withArguments($promptMessage)->once
+				->mock($locale)
+					->call('_')->withArguments('Press <Enter> to reexecute, press any other key and <Enter> to stop...')->once
+			->if($this->calling($prompt)->ask = '')
+			->then
+				->boolean($this->testedInstance->runAgain())->isTrue
+				->mock($prompt)
+					->call('ask')->withArguments($promptMessage)->twice
+				->mock($locale)
+					->call('_')->withArguments('Press <Enter> to reexecute, press any other key and <Enter> to stop...')->twice
+		;
+	}
+}


### PR DESCRIPTION
See #555 for the original idea and PR by @agallou.

I just extracted the loop logic (asking the user to hit enter) and made an interface allowing new strategy to be plugged. Here is another one I implemented to test the feature:

```php
<?php

namespace mageekguy\atoum\scripts\runner\loopers;

use mageekguy\atoum\scripts\runner\looper;

class signal implements looper
{
	private $runAgain = false;

	public function __construct()
	{
		$runAgain = & $this->runAgain;

		pcntl_signal(SIGUSR1, function() use  (& $runAgain) { $runAgain = true; });
	}

	public function runAgain()
	{
		while ($this->runAgain === false)
		{
			usleep(100);

			pcntl_signal_dispatch();
		}

		$this->runAgain = false;

		return true;
	}
}

```