### PR TITLE
Cache resolved asserters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#569](https://github.com/atoum/atoum/pull/569) Use in-memory cache for resolved asserters ([@jubianchi])
 * [#567](https://github.com/atoum/atoum/pull/567) Extract loop logic from runner and add a looper interface ([@jubianchi], [@agallou])
 
 # 2.5.2 - 2016-01-28

--- a/classes/asserter/resolver.php
+++ b/classes/asserter/resolver.php
@@ -15,6 +15,7 @@ class resolver
 	protected $baseClass = '';
 	protected $namespaces = array();
 	private $analyzer;
+	private $resolved = array();
 
 	public function __construct($baseClass = null, $namespace = null, analyzer $analyzer = null)
 	{
@@ -63,6 +64,10 @@ class resolver
 
 	public function resolve($asserter)
 	{
+		if (isset($this->resolved[$asserter])) {
+			return $this->resolved[$asserter];
+		}
+
 		if (false === $this->analyzer->isValidNamespace($asserter))
 		{
 			return null;
@@ -90,6 +95,8 @@ class resolver
 				break;
 			}
 		}
+
+		$this->resolved[$asserter] = $class;
 
 		return $class;
 	}


### PR DESCRIPTION
This tiny patch let us improve performances on atoum tests (this is really clear with inline engine).

_All the metrics above were generated using the [phpunit-extension](https://github.com/atoum/phpunit-extension) and the [PHP-DI test suite](https://github.com/jubianchi/PHP-DI/compare/e6f30a337cdbff13a1dd9ac73c59654ce44177ab...HEAD) (`vendor/bin/atoum -d tests/UnitTest/ tests/IntegrationTest`)_

### Before

```
PHP 7.0.0 (cli) (built: Dec  2 2015 13:06:23) ( NTS )
Copyright (c) 1997-2015 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies
    with blackfire v1.9.0, https://blackfire.io, by Blackfireio Inc.

> Total tests duration: 29.46 seconds.
> Total tests memory usage: 4.00 Mb.
> Running duration: 29.53 seconds.
```

### After

```
PHP 7.0.0 (cli) (built: Dec  2 2015 13:06:23) ( NTS )
Copyright (c) 1997-2015 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies
    with blackfire v1.9.0, https://blackfire.io, by Blackfireio Inc.

> Total tests duration: 1.84 seconds.
> Total tests memory usage: 4.00 Mb.
> Running duration: 1.89 seconds.
```

Here is the diff generated with blackfire (`blackfire run --samples=5 vendor/bin/atoum -d tests/UnitTest/ tests/IntegrationTest`):

![blackfire](https://cloud.githubusercontent.com/assets/327237/12761381/0f6a008a-c9eb-11e5-838b-46152d009fc9.png)



