### PR TITLE
create report destination folder

### DIFF
--- a/classes/report/fields/runner/coverage/html.php
+++ b/classes/report/fields/runner/coverage/html.php
@@ -307,6 +307,9 @@ class html extends report\fields\runner\coverage\cli
 	{
 		$this->destinationDirectory = (string) $path;
 
+		if (!$this->adapter->is_dir($this->destinationDirectory)) {
+			$this->adapter->mkdir($this->destinationDirectory, 0777, true);
+		}
 		return $this;
 	}
 


### PR DESCRIPTION
I encounter a strange error:

     Error: copy(/work/GIT/galette/tests/coverage/screen.css): failed to open stream: Aucun fichier ou dossier de ce type in /usr/share/atoum/classes/adapter.php at line 18

After digging a little, I understand that the "coverage" destination directory doesn't exists
This seems quite common (it exists on the dev working clone, but of course in .gitignore, so missing on any fresh clone).

Could be a nice idea to create it during the run

