### PR TITLE
fix arguments priority parsing when thy have no priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * [#569](https://github.com/atoum/atoum/pull/569) Use in-memory cache for resolved asserters ([@jubianchi])
 * [#567](https://github.com/atoum/atoum/pull/567) Extract loop logic from runner and add a looper interface ([@jubianchi], [@agallou])
 
+## Bugfix
+
+* [#578](https://github.com/atoum/atoum/pull/578) Fix arguments priority parsing when they have no priority ([@agallou])
+
 # 2.5.2 - 2016-01-28
 
 * [#561](https://github.com/atoum/atoum/pull/561) Use the fully qualified name when the return type is not `builtin` ([@GuillaumeDievart])

--- a/classes/script/arguments/parser.php
+++ b/classes/script/arguments/parser.php
@@ -82,9 +82,12 @@ class parser implements \iteratorAggregate
 		uksort($values, function($arg1, $arg2) use ($priorities) {
 				switch (true)
 				{
-					case isset($priorities[$arg1]) === false:
-					case isset($priorities[$arg2]) === false:
-						return PHP_INT_MAX;
+					case isset($priorities[$arg1]) === false && isset($priorities[$arg2]) === false:
+						return 0;
+					case isset($priorities[$arg1]) === false && isset($priorities[$arg2]) === true:
+						return 1;
+					case isset($priorities[$arg2]) === false && isset($priorities[$arg1]) === true:
+						return -1;
 
 					default:
 						return ($priorities[$arg1] > $priorities[$arg2] ? -1 : ($priorities[$arg1] == $priorities[$arg2] ? 0 : 1));


### PR DESCRIPTION
When an extension registered a new command line option,
and when the config file the loads this extension is loaded
via the command line, we could have issues depending on the order
of the arguments.

For example, this were not working:

```
 ./bin/atoum -c config/.atoum.php --autoloop
```

(we get this error `Error: Argument '--autoloop' is unknown, did you mean '--help'?`).

But this were working:

```
 ./bin/atoum --autoloop  -c config/.atoum.php
```

That because the --autoloop argument is not is the priorities array
beacause it's still not loaded.

So, in order to fix that, we always put the arguments with no priority
add then end.

Like that, other arguments, like adding a config file, that have the PHP_INT_MAX
value (the maximum priority), will be loaded before the arguments with no priority.
Then the extension will be loaded the the --autoloop argument will exist, and we will
not get an error.