### PR TITLE
Memory usage is based on the peak & real allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#585](https://github.com/atoum/atoum/pull/585) Memory usage is based on the peak & real allocations ([@hywan])
 * [#740](https://github.com/atoum/atoum/pull/740) String asserter now has `notMatches` assertion ([@fvilpoix])
 
 # 3.2.0 - 2017-09-07

--- a/classes/test.php
+++ b/classes/test.php
@@ -1264,7 +1264,7 @@ abstract class test implements observable, \countable
 
                     $assertionNumber = $this->score->getAssertionNumber();
                     $time = microtime(true);
-                    $memory = memory_get_usage(true);
+                    $memory = memory_get_peak_usage();
 
                     if (isset($this->dataProviders[$testMethod]) === false) {
                         $this->{$testMethod}();
@@ -1308,7 +1308,7 @@ abstract class test implements observable, \countable
                     $this->mockControllerLinker->reset();
                     $this->testAdapterStorage->reset();
 
-                    $memoryUsage = memory_get_usage(true) - $memory;
+                    $memoryUsage = memory_get_peak_usage() - $memory;
                     $duration = microtime(true) - $time;
 
                     $this->score


### PR DESCRIPTION
The memory usage was previously based on the system memory. By system, PHP means the VM. So first, we should use the real allocated memory. Second, we use `memory_get_peak_usage` instead of `memory_get_usage` because the GC (Garbage Collector) can run and free the memory. Thus, a test case can report 0 byte while it has allocated 1Mb for instance. The peak is what is interesting for us, and the allocated peak.
