### PR TITLE
Reports override correctly when using -ulr/-utr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bugfix
 
+* [#600](https://github.com/atoum/atoum/pull/600) Reports override correctly when using -ulr/-utr ([@jubianchi])
 * [#593](https://github.com/atoum/atoum/pull/593) Assertions on PHP 7 exceptions/throwables/errors are now working correctly ([@jubianchi])
 
 # 2.6.1 - 2016-04-08

--- a/classes/report/fields/runner/event/cli.php
+++ b/classes/report/fields/runner/event/cli.php
@@ -66,10 +66,6 @@ class cli extends report\fields\runner\event
 					case test::skipped:
 						$this->progressBar->refresh('-');
 						break;
-
-					case runner::runStop:
-						$this->progressBar->reset();
-						break;
 				}
 
 				$string = (string) $this->progressBar;

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -725,7 +725,7 @@ class runner implements observable
 	{
 		if ($this->reportSet === null)
 		{
-			$this->removeReports()->addReport($report);
+			$this->removeReports($report)->addReport($report);
 
 			$this->reportSet = $report;
 		}
@@ -757,14 +757,32 @@ class runner implements observable
 		return $this->removeObserver($report);
 	}
 
-	public function removeReports()
+	public function removeReports(report $override = null)
 	{
-		foreach ($this->reports as $report)
+		if ($override === null)
 		{
-			$this->removeObserver($report);
+			foreach ($this->reports as $report)
+			{
+				$this->removeObserver($report);
+			}
+
+			$this->reports = new \splObjectStorage();
+
+		}
+		else
+		{
+			foreach ($this->reports as $report)
+			{
+				if ($report->isOverridableBy($override) === true)
+				{
+					continue;
+				}
+
+				$this->removeObserver($report);
+				$this->reports->detach($report);
+			}
 		}
 
-		$this->reports = new \splObjectStorage();
 		$this->reportSet = null;
 
 		return $this;

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -442,6 +442,29 @@ class runner extends atoum\test
 			->then
 				->array($runner->getReports())->isEqualTo(array($report1, $report2))
 				->array($runner->getObservers())->isEqualTo(array($report1, $report2))
+			->given(
+				$firstReport = new \mock\mageekguy\atoum\report(),
+				$secondReport = new \mock\mageekguy\atoum\report(),
+				$overrideReport = new \mock\mageekguy\atoum\report(),
+				$runner->removeReports()
+			)
+			->if(
+				$this->calling($firstReport)->isOverridableBy = function($report) use ($overrideReport) { return $report === $overrideReport; },
+				$this->calling($secondReport)->isOverridableBy = function($report) use ($overrideReport) { return $report !== $overrideReport; },
+				$runner->addReport($firstReport)
+			)
+			->when($runner->removeReports($secondReport))
+			->then
+				->array($runner->getReports())->isEmpty
+				->array($runner->getObservers())->isEmpty
+			->if(
+				$runner->addReport($firstReport),
+				$runner->addReport($secondReport)
+			)
+			->when($runner->removeReports($overrideReport))
+			->then
+				->array($runner->getReports())->isEqualTo(array($firstReport))
+				->array($runner->getObservers())->isEqualTo(array($firstReport))
 		;
 	}
 


### PR DESCRIPTION
Before this patch, if we had a configuration file like this one:

```php
<?php

$script->addDefaultReport();

$report = new some\report();
//...
$runner->addReport($telemetry);
```

And used the `-utr` or `-ulr` options, atoum would have dropped the additional report we added through the configuration file and only used the light CLI report or TAP report.

Now, when we do that, atoum will only remove reports which are conflicting with light or TAP report and keep the others.