### PR TITLE
Add a way to define configuration in atoum/*-edition packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * [#605](https://github.com/atoum/atoum/pull/605) Handle `.autoloader.atoum.php` files to define tests autoloader ([@jubianchi])
 * [#605](https://github.com/atoum/atoum/pull/605) Add the `--autoloader-file`/`-af` CLI argument to define which autoloader file to user ([@jubianchi])
 * [#596](https://github.com/atoum/atoum/pull/596) Test methods' tags are inherited from test classes ([@jubianchi])
+* [#604](https://github.com/atoum/atoum/pull/604) Add a `addConfigurationCallable` method on the runner to allow extenion to register themselves ([@jubianchi], [@agallou])
+* [#604](https://github.com/atoum/atoum/pull/604) Add a `getExtension` method on the runner to configure an already loaded extension ([@jubianchi], [@agallou])
 
 # 2.7.0 - 2016-06-20
 

--- a/classes/iterators/classStorage.php
+++ b/classes/iterators/classStorage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace mageekguy\atoum\iterators;
+
+class classStorage extends \SplObjectStorage
+{
+    public function getHash($object)
+    {
+        return get_class($object);
+    }
+}

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -835,14 +835,27 @@ class runner implements observable
 
 	public function removeExtension(extension $extension)
 	{
-		$this->extensions->detach($extension);
+		try {
+			$extension = $this->getExtension(get_class($extension));
 
-		return $this->removeObserver($extension);
+			$this->extensions->detach($extension);
+
+			$this->removeObserver($extension);
+		} catch (exceptions\logic\invalidArgument $e) {
+		}
+
+		return $this;
 	}
 
 	public function removeExtensionByClassName($classname)
 	{
-		return $this->removeExtension($this->getExtension($classname));
+		try {
+			$this->removeExtension($this->getExtension($classname));
+		} catch (exceptions\logic\invalidArgument $e) {
+		}
+
+		return $this;
+
 	}
 
 	public function removeExtensions()

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -867,6 +867,27 @@ class runner implements observable
 		return $this;
 	}
 
+	public function getExtension($classname)
+	{
+		$extensions = array();
+		foreach ($this->getExtensions() as $extension)
+		{
+			if (get_class($extension) != $classname)
+			{
+				continue;
+			}
+
+			$extensions[] = $extension;
+		}
+
+		if (1 != count($extensions))
+		{
+			throw new exceptions\logic\invalidArgument(sprintf("Extension '%s' not found", $classname));
+		}
+
+		return array_shift($extensions);
+	}
+
 	public static function isIgnored(test $test, array $namespaces, array $tags)
 	{
 		$isIgnored = $test->isIgnored();

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -59,7 +59,7 @@ class runner implements observable
 
 		$this->observers = new \splObjectStorage();
 		$this->reports = new \splObjectStorage();
-		$this->extensions = new \splObjectStorage();
+		$this->extensions = new iterators\classStorage();
 	}
 
 	public function setAdapter(adapter $adapter = null)
@@ -869,7 +869,6 @@ class runner implements observable
 
 	public function getExtension($classname)
 	{
-		$extensions = array();
 		foreach ($this->getExtensions() as $extension)
 		{
 			if (get_class($extension) != $classname)
@@ -877,15 +876,10 @@ class runner implements observable
 				continue;
 			}
 
-			$extensions[] = $extension;
+			return $extension;
 		}
 
-		if (1 != count($extensions))
-		{
-			throw new exceptions\logic\invalidArgument(sprintf("Extension '%s' not found", $classname));
-		}
-
-		return array_shift($extensions);
+		throw new exceptions\logic\invalidArgument(sprintf("Extension '%s' not found", $classname));
 	}
 
 	public static function isIgnored(test $test, array $namespaces, array $tags)

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -840,6 +840,11 @@ class runner implements observable
 		return $this->removeObserver($extension);
 	}
 
+	public function removeExtensionByClassName($classname)
+	{
+		return $this->removeExtension($this->getExtension($classname));
+	}
+
 	public function removeExtensions()
 	{
 		foreach ($this->extensions as $extension)

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -507,25 +507,34 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('\mageekguy\atoum\iterators\classStorage')
+				->array(iterator_to_array($runner->getExtensions()))->isEmpty()
 				->array($runner->getObservers())->isEmpty()
 				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('\mageekguy\atoum\iterators\classStorage')
+				->array(iterator_to_array($runner->getExtensions()))->isEmpty()
 				->array($runner->getObservers())->isEmpty()
 			->if($extension = new \mock\mageekguy\atoum\extension())
-			->and($otherExtension = new \mock\mageekguy\atoum\extension())
-			->and($runner->addExtension($extension)->addExtension($otherExtension))
+				->and($this->mockGenerator->generate('\mageekguy\atoum\extension', '\mock_extensions', 'other_extension'))
+				->and($otherExtension = new \mock_extensions\other_extension())
+				->and($runner->addExtension($extension)->addExtension($otherExtension))
 			->then
 				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
+			->if
 				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
-				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
-				->object($runner->removeExtension($extension))->isIdenticalTo($runner)
+			->then
 				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+			->if
+				->object($runner->removeExtension($extension))->isIdenticalTo($runner)
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+			->if
 				->object($runner->removeExtension($otherExtension))->isIdenticalTo($runner)
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEmpty()
 				->array($runner->getObservers())->isEmpty()
 		;
 	}
@@ -535,7 +544,8 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceof('\mageekguy\atoum\iterators\classStorage')
+				->array(iterator_to_array($runner->getExtensions()))->isEmpty()
 				->array($runner->getObservers())->isEmpty()
 				->object($runner->removeExtensions())->isIdenticalTo($runner)
 				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -539,6 +539,39 @@ class runner extends atoum\test
 		;
 	}
 
+	public function testRemoveExtensionByClassName()
+	{
+		$this
+			->if($runner = new testedClass())
+			->then
+				->object($runner->getExtensions())->isInstanceOf('\mageekguy\atoum\iterators\classStorage')
+				->array(iterator_to_array($runner->getExtensions()))->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+			->if($extension = new \mock\mageekguy\atoum\extension())
+				->and($this->mockGenerator->generate('\mageekguy\atoum\extension', '\mock_extensions', 'other_extension'))
+				->and($otherExtension = new \mock_extensions\other_extension())
+				->and($runner->addExtension($extension)->addExtension($otherExtension))
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
+			->if
+				->object($runner->removeExtensionByClassName('mock\mageekguy\atoum\extension'))->isIdenticalTo($runner)
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+			->if
+				->object($runner->removeExtensionByClassName('mock\mageekguy\atoum\extension'))->isIdenticalTo($runner)
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+			->if
+				->object($runner->removeExtensionByClassName('mock_extensions\other_extension'))->isIdenticalTo($runner)
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEmpty()
+				->array($runner->getObservers())->isEmpty()
+		;
+	}
+
 	public function testRemoveExtensions()
 	{
 		$this


### PR DESCRIPTION
This will allow us to create "editions" of atoum, will extensions preloaded and some stuff configured.

For example : https://github.com/agallou/atoum-standard-edition

By requirering only atoum/standard-edition this will : 
* install atoum/atoum
* install atoum/stubs
* install atoum/autoloop-extension
* install atoum/visibility-extension
* install atoum/config-extension
* install atoum/reports-extension
* load autoloop-extension
* load visibility-extension
* load config-extension
* load reports-extension
* if the TELEMETRY_ENABLED environement variable is defined, the telemetry report will be sent (with different anonymization settings depending of it's value (1, 2 ou 3). 

we could also imagine
*  preconfiguring the coveralls report repending on an COVERALLS_API_KEY environnement variable
* configure the autoloop using the files defined in the autoload from the project's composer.json
* add a XUNIT_REPORT_PATH : that will generate the xunit report in the path specified in the environnement variable : that will also help the integration in CI environments.

you can see an example of usage here : https://github.com/agallou/atoum-std-edition-example (the repositories and atoum/atoum in the require section should not be here. They won't be if diffrent PR are merged).

This standard edition will help users set-up atoum.
This will also : 
* have stubs installed with just one require (we can see the advantages here https://github.com/atoum/atoum/issues/552 : out of the box autocompletion and no phpdoc in the atoum core)
* have the configuration extension preinstalled : users that don't like the configuration in PHP wil be able to set some configuration with a YAML file (for example https://github.com/agallou/atoum-std-edition-example/blob/master/.atoum.yml ). Users that prefers the .atoum.php file will still continue to be able to use it as usual (with all i'ts benefits (configuration in php, we can do everything we want)).

For now we still need to define manually a .bootstrap.atoum.php file, but if the PR https://github.com/atoum/atoum/pull/523 is also merged, the installation/configuration will even be easier.