### PR TITLE
Automatically include Composer's autoloader if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `dev-master`
 
+* [#605](https://github.com/atoum/atoum/pull/605) Automatically include Composer's autoloader if it exists ([@jubianchi], [@agallou])
+* [#605](https://github.com/atoum/atoum/pull/605) Handle `.autoloader.atoum.php` files to define tests autoloader ([@jubianchi])
+* [#605](https://github.com/atoum/atoum/pull/605) Add the `--autoloader-file`/`-af` CLI argument to define which autoloader file to user ([@jubianchi])
 * [#596](https://github.com/atoum/atoum/pull/596) Test methods' tags are inherited from test classes ([@jubianchi])
 
 # 2.7.0 - 2016-06-20

--- a/classes/observable.php
+++ b/classes/observable.php
@@ -7,4 +7,5 @@ interface observable
 	public function callObservers($event);
 	public function getScore();
 	public function getBootstrapFile();
+	public function getAutoloaderFile();
 }

--- a/classes/report/fields/runner/coverage.php
+++ b/classes/report/fields/runner/coverage.php
@@ -114,6 +114,18 @@ abstract class coverage extends report\field
 					'require \'' . \mageekguy\atoum\directory . '/classes/autoloader.php\';'
 				;
 
+				$autoloaderFile = $observable->getAutoloaderFile();
+
+				if ($autoloaderFile !== null)
+				{
+					$phpCode .=
+						'$includer = new mageekguy\atoum\includer();' .
+						'try { $includer->includePath(\'' . $autoloaderFile . '\'); }' .
+						'catch (mageekguy\atoum\includer\exception $exception)' .
+						'{ die(\'Unable to include autoloader file \\\'' . $autoloaderFile . '\\\'\'); }'
+					;
+				}
+
 				$bootstrapFile = $observable->getBootstrapFile();
 
 				if ($bootstrapFile !== null)

--- a/classes/runner.php
+++ b/classes/runner.php
@@ -30,6 +30,7 @@ class runner implements observable
 	protected $defaultReportTitle = null;
 	protected $maxChildrenNumber = null;
 	protected $bootstrapFile = null;
+	protected $autoloaderFile = null;
 	protected $testDirectoryIterator = null;
 	protected $debugMode = false;
 	protected $xdebugConfig = null;
@@ -264,6 +265,22 @@ class runner implements observable
 		return $this;
 	}
 
+	public function setAutoloaderFile($path)
+	{
+		try
+		{
+			$this->includer->includePath($path, function($path) { include_once($path); });
+		}
+		catch (includer\exception $exception)
+		{
+			throw new exceptions\runtime\file(sprintf($this->getLocale()->_('Unable to use autoloader file \'%s\''), $path));
+		}
+
+		$this->autoloaderFile = $path;
+
+		return $this;
+	}
+
 	public function getDefaultReportTitle()
 	{
 		return $this->defaultReportTitle;
@@ -318,6 +335,11 @@ class runner implements observable
 	public function getBootstrapFile()
 	{
 		return $this->bootstrapFile;
+	}
+
+	public function getAutoloaderFile()
+	{
+		return $this->autoloaderFile;
 	}
 
 	public function getTestMethods(array $namespaces = array(), array $tags = array(), array $testMethods = array(), $testBaseClass = null)
@@ -552,6 +574,7 @@ class runner implements observable
 						->setAdapter($this->adapter)
 						->setLocale($this->locale)
 						->setBootstrapFile($this->bootstrapFile)
+						->setAutoloaderFile($this->autoloaderFile)
 					;
 
 					if ($this->debugMode === true)

--- a/classes/test.php
+++ b/classes/test.php
@@ -53,6 +53,7 @@ abstract class test implements observable, \countable
 	private $testMethodPrefix = null;
 	private $classEngine = null;
 	private $bootstrapFile = null;
+	private $autoloaderFile = null;
 	private $maxAsynchronousEngines = null;
 	private $asynchronousEngines = 0;
 	private $path = '';
@@ -801,6 +802,18 @@ abstract class test implements observable, \countable
 	public function getBootstrapFile()
 	{
 		return $this->bootstrapFile;
+	}
+
+	public function setAutoloaderFile($path)
+	{
+		$this->autoloaderFile = $path;
+
+		return $this;
+	}
+
+	public function getAutoloaderFile()
+	{
+		return $this->autoloaderFile;
 	}
 
 	public function setTestNamespace($testNamespace)

--- a/classes/test/engines/concurrent.php
+++ b/classes/test/engines/concurrent.php
@@ -69,6 +69,18 @@ class concurrent extends test\engine
 				'require \'' . atoum\directory . '/classes/autoloader.php\';'
 			;
 
+			$autoloaderFile = $this->test->getAutoloaderFile();
+
+			if ($autoloaderFile !== null)
+			{
+				$phpCode .=
+					'$includer = new mageekguy\atoum\includer();' .
+					'try { $includer->includePath(\'' . $autoloaderFile . '\'); }' .
+					'catch (mageekguy\atoum\includer\exception $exception)' .
+					'{ die(\'Unable to include autoloader file \\\'' . $autoloaderFile . '\\\'\'); }'
+				;
+			}
+
 			$bootstrapFile = $this->test->getBootstrapFile();
 
 			if ($bootstrapFile !== null)

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -325,6 +325,20 @@ class runner extends atoum\test
 		;
 	}
 
+	public function testGetAutoloaderFile()
+	{
+		$this
+			->if($runner = new testedClass())
+			->and($includer = new \mock\mageekguy\atoum\includer())
+			->and($includer->getMockController()->includePath = function() {})
+			->and($runner->setIncluder($includer))
+			->then
+				->object($runner->setAutoloaderFile($path = uniqid()))->isIdenticalTo($runner)
+				->string($runner->getAutoloaderFile())->isEqualTo($path)
+				->mock($includer)->call('includePath')->withArguments($path)->once()
+		;
+	}
+
 	public function testHasReports()
 	{
 		$this

--- a/tests/units/classes/scripts/coverage.php
+++ b/tests/units/classes/scripts/coverage.php
@@ -165,9 +165,14 @@ class coverage extends atoum\test
 							'Force output as in terminal'
 						),
 						array(
+							array('-af', '--autoloader-file'),
+							'<file>',
+							'Include autoloader <file> before executing each test method'
+						),
+						array(
 							array('-bf', '--bootstrap-file'),
 							'<file>',
-							'Include <file> before executing each test method'
+							'Include bootstrap <file> before executing each test method'
 						),
 						array(
 							array('-ulr', '--use-light-report'),
@@ -353,9 +358,14 @@ class coverage extends atoum\test
 							'Force output as in terminal'
 						),
 						array(
+							array('-af', '--autoloader-file'),
+							'<file>',
+							'Include autoloader <file> before executing each test method'
+						),
+						array(
 							array('-bf', '--bootstrap-file'),
 							'<file>',
-							'Include <file> before executing each test method'
+							'Include bootstrap <file> before executing each test method'
 						),
 						array(
 							array('-ulr', '--use-light-report'),

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -175,9 +175,14 @@ class runner extends atoum\test
 							'Force output as in terminal'
 						),
 						array(
+							array('-af', '--autoloader-file'),
+							'<file>',
+							'Include autoloader <file> before executing each test method'
+						),
+						array(
 							array('-bf', '--bootstrap-file'),
 							'<file>',
-							'Include <file> before executing each test method'
+							'Include bootstrap <file> before executing each test method'
 						),
 						array(
 							array('-ulr', '--use-light-report'),
@@ -352,9 +357,14 @@ class runner extends atoum\test
 							'Force output as in terminal'
 						),
 						array(
+							array('-af', '--autoloader-file'),
+							'<file>',
+							'Include autoloader <file> before executing each test method'
+						),
+						array(
 							array('-bf', '--bootstrap-file'),
 							'<file>',
-							'Include <file> before executing each test method'
+							'Include bootstrap <file> before executing each test method'
 						),
 						array(
 							array('-ulr', '--use-light-report'),

--- a/tests/units/classes/test/engines/concurrent.php
+++ b/tests/units/classes/test/engines/concurrent.php
@@ -87,6 +87,52 @@ class concurrent extends atoum\test
 						'echo serialize($test->runTestMethod(\'' . $method . '\')->getScore());'
 					)->twice()
 					->call('__set')->withArguments('XDEBUG_CONFIG', $xdebugConfig)->twice()
+			->if($this->calling($test)->getAutoloaderFile = $autoloaderFile = uniqid())
+			->then
+				->object($engine->run($test))->isIdenticalTo($engine)
+				->mock($php)
+					->call('run')->withArguments(
+						'<?php ' .
+						'ob_start();' .
+						'require \'' . atoum\directory . '/classes/autoloader.php\';' .
+						'$includer = new mageekguy\atoum\includer();' .
+						'try { $includer->includePath(\'' . $autoloaderFile . '\'); }' .
+						'catch (mageekguy\atoum\includer\exception $exception)' .
+						'{ die(\'Unable to include autoloader file \\\'' . $autoloaderFile . '\\\'\'); }' .
+						'require \'' . $testPath . '\';' .
+						'$test = new ' . get_class($test) . '();' .
+						'$test->setLocale(new ' . get_class($test->getLocale()) . '(' . $test->getLocale()->get() . '));' .
+						'$test->setPhpPath(\'' . $phpPath . '\');' .
+						'$test->disableCodeCoverage();' .
+						'ob_end_clean();' .
+						'mageekguy\atoum\scripts\runner::disableAutorun();' .
+						'echo serialize($test->runTestMethod(\'' . $method . '\')->getScore());'
+					)->once
+			->if($this->calling($test)->getBootstrapFile = $bootstrapFile = uniqid())
+			->then
+				->object($engine->run($test))->isIdenticalTo($engine)
+				->mock($php)
+					->call('run')->withArguments(
+						'<?php ' .
+						'ob_start();' .
+						'require \'' . atoum\directory . '/classes/autoloader.php\';' .
+						'$includer = new mageekguy\atoum\includer();' .
+						'try { $includer->includePath(\'' . $autoloaderFile . '\'); }' .
+						'catch (mageekguy\atoum\includer\exception $exception)' .
+						'{ die(\'Unable to include autoloader file \\\'' . $autoloaderFile . '\\\'\'); }' .
+						'$includer = new mageekguy\atoum\includer();' .
+						'try { $includer->includePath(\'' . $bootstrapFile . '\'); }' .
+						'catch (mageekguy\atoum\includer\exception $exception)' .
+						'{ die(\'Unable to include bootstrap file \\\'' . $bootstrapFile . '\\\'\'); }' .
+						'require \'' . $testPath . '\';' .
+						'$test = new ' . get_class($test) . '();' .
+						'$test->setLocale(new ' . get_class($test->getLocale()) . '(' . $test->getLocale()->get() . '));' .
+						'$test->setPhpPath(\'' . $phpPath . '\');' .
+						'$test->disableCodeCoverage();' .
+						'ob_end_clean();' .
+						'mageekguy\atoum\scripts\runner::disableAutorun();' .
+						'echo serialize($test->runTestMethod(\'' . $method . '\')->getScore());'
+					)->once
 		;
 	}
 


### PR DESCRIPTION
Handle `.autoloader.atoum.php` files to define tests autoloader: if present this file will be automatically loaded by atoum. It can be useful if the user has to include several autoloaders or do not use composer.

If `.autoloader.atoum.php` does not exist, atoum will try to find the Composer autoloader searching from the current working directory up to the FS root for `vendor/autoload.php`.

Add the `--autoloader-file`/`-af` CLI argument to define which autoloader file to user.

Closes #523