### PR TITLE
Ability to register additional error handlers for tests

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -78,6 +78,7 @@ abstract class test implements observable, \countable
 	private $classHasNotVoidMethods = false;
 	private $extensions = null;
 	private $analyzer;
+	private $errorHandlers = array();
 
 	private static $namespace = null;
 	private static $methodPrefix = null;
@@ -1517,8 +1518,23 @@ abstract class test implements observable, \countable
 
 			$doNotCallDefaultErrorHandler = !($errno & E_RECOVERABLE_ERROR);
 		}
+		
+		foreach ($this->errorHandlers as $handler)
+		{
+			call_user_func($handler, $errno, $errstr, $errfile, $errline);
+		}
 
 		return $doNotCallDefaultErrorHandler;
+	}
+	
+	public function registerErrorHandler($errorHandler)
+	{
+		if (!is_callable($errorHandler))
+		{
+			throw new exceptions\logic\invalidArgument('Error handler is not callable');
+		}
+
+		$this->errorHandlers[] = $errorHandler;
 	}
 
 	public function setUp() {}


### PR DESCRIPTION
This patch makes it possible to add one or several error handlers for a test.
This is particularly useful when one wants to deal with silenced errors.

One use case is to deal with Symfony `E_USER_DEPRECATED`, which are silenced on purpose.
Those errors are then caught by the debug bar.

With this patch, one will be able to implement an extension and add one or several error handlers.
My idea is to implement the equivalent of Symfony PHPUnitBridge which would catch deprecation errors.
