### PR TITLE
Replace void by blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#615](https://github.com/atoum/atoum/pull/615) Remove reserved keyword, replace void by blank ([@vonglasow])
 * [#643](https://github.com/atoum/atoum/pull/643) atoum now requires PHP `>=5.6.0` ([@jubianchi])
 * [#634](https://github.com/atoum/atoum/pull/634) Only one extension of a kind can be loaded. Extensions can be unloaded ([@agallou], [@jubianchi])
 * [#619](https://github.com/atoum/atoum/pull/619) Add branches and paths coverage support to AtoumTask for Phing ([@oxman])

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -41,7 +41,12 @@ class autoloader
 			$this->addNamespaceAlias($alias, $target);
 		}
 
-		foreach ($classAliases ?: array('atoum' => __NAMESPACE__ . '\test', __NAMESPACE__ => __NAMESPACE__ . '\test') as $alias => $target)
+		$defaultAliases = array(
+			'atoum' => __NAMESPACE__ . '\test',
+			__NAMESPACE__ => __NAMESPACE__ . '\test'
+		);
+
+		foreach ($classAliases ?: $defaultAliases as $alias => $target)
 		{
 			$this->addClassAlias($alias, $target);
 		}

--- a/classes/report/fields/runner/tests/blank.php
+++ b/classes/report/fields/runner/tests/blank.php
@@ -8,7 +8,7 @@ use
 	mageekguy\atoum\observable
 ;
 
-abstract class void extends report\field
+abstract class blank extends report\field
 {
 	protected $runner = null;
 

--- a/classes/report/fields/runner/tests/blank/cli.php
+++ b/classes/report/fields/runner/tests/blank/cli.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\report\fields\runner\tests\void;
+namespace mageekguy\atoum\report\fields\runner\tests\blank;
 
 use
 	mageekguy\atoum,
@@ -9,7 +9,7 @@ use
 	mageekguy\atoum\cli\colorizer
 ;
 
-class cli extends report\fields\runner\tests\void
+class cli extends report\fields\runner\tests\blank
 {
 	protected $titlePrompt = null;
 	protected $titleColorizer = null;

--- a/classes/reports/asynchronous/vim.php
+++ b/classes/reports/asynchronous/vim.php
@@ -95,7 +95,7 @@ class vim extends reports\asynchronous
 
 		$this->addField($uncompletedField);
 
-		$voidField = new runner\tests\void\cli();
+		$voidField = new runner\tests\blank\cli();
 		$voidField
 			->setTitlePrompt($firstLevelPrompt)
 			->setMethodPrompt($secondLevelPrompt)

--- a/classes/reports/realtime/cli.php
+++ b/classes/reports/realtime/cli.php
@@ -174,7 +174,7 @@ class cli extends realtime
 		$voidTestMethodPrompt = clone $secondLevelPrompt;
 		$voidTestMethodPrompt->setColorizer($voidTestColorizer);
 
-		$runnerVoidField = new runner\tests\void\cli();
+		$runnerVoidField = new runner\tests\blank\cli();
 		$runnerVoidField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($voidTestColorizer)

--- a/classes/reports/realtime/cli/light.php
+++ b/classes/reports/realtime/cli/light.php
@@ -109,7 +109,7 @@ class light extends realtime
 		$voidTestOutputPrompt = clone $thirdLevelPrompt;
 		$voidTestOutputPrompt->setColorizer($voidTestColorizer);
 
-		$voidTestField = new runner\tests\void\cli();
+		$voidTestField = new runner\tests\blank\cli();
 		$voidTestField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($voidTestColorizer)

--- a/classes/reports/realtime/nyancat.php
+++ b/classes/reports/realtime/nyancat.php
@@ -158,7 +158,7 @@ class nyancat extends realtime
 		$voidTestMethodPrompt = clone $secondLevelPrompt;
 		$voidTestMethodPrompt->setColorizer($voidTestColorizer);
 
-		$runnerVoidField = new runner\tests\void\cli();
+		$runnerVoidField = new runner\tests\blank\cli();
 		$runnerVoidField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($voidTestColorizer)

--- a/classes/reports/realtime/phing.php
+++ b/classes/reports/realtime/phing.php
@@ -307,7 +307,7 @@ class phing extends realtime
 
 		$this->addField($runnerUncompletedField);
 
-		$runnerVoidField = new runner\tests\void\cli();
+		$runnerVoidField = new runner\tests\blank\cli();
 		$runnerVoidField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($voidTestColorizer)

--- a/classes/reports/realtime/santa.php
+++ b/classes/reports/realtime/santa.php
@@ -158,7 +158,7 @@ class santa extends realtime
 		$voidTestMethodPrompt = clone $secondLevelPrompt;
 		$voidTestMethodPrompt->setColorizer($voidTestColorizer);
 
-		$runnerVoidField = new runner\tests\void\cli();
+		$runnerVoidField = new runner\tests\blank\cli();
 		$runnerVoidField
 			->setTitlePrompt($firstLevelPrompt)
 			->setTitleColorizer($voidTestColorizer)

--- a/tests/units/classes/autoloader.php
+++ b/tests/units/classes/autoloader.php
@@ -19,27 +19,6 @@ class autoloader extends atoum\test
 		;
 	}
 
-	public function test__construct()
-	{
-		$this
-			->if($autoloader = new testedClass())
-			->then
-				->array($autoloader->getClasses())->isEmpty()
-				->variable($autoloader->getCacheFileForInstance())->isEqualTo(testedClass::getCacheFile())
-				->array($autoloader->getDirectories())->isEqualTo(array(
-						'mageekguy\atoum\\' => array(
-							array(
-								atoum\directory . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR,
-								testedClass::defaultFileSuffix
-							)
-						)
-					)
-				)
-				->array($autoloader->getNamespaceAliases())->isEqualTo(array('atoum\\' => 'mageekguy\\atoum\\'))
-				->array($autoloader->getClassAliases())->isEqualTo(array('atoum' => 'mageekguy\\atoum\\test', 'mageekguy\\atoum' => 'mageekguy\\atoum\\test'))
-		;
-	}
-
 	public function testAddNamespaceAlias()
 	{
 		$this
@@ -79,6 +58,58 @@ class autoloader extends atoum\test
 						$otherAlias . '\\' => $otherTarget . '\\',
 						$anOtherAlias . '\\' => $anOtherTarget . '\\',
 						'foo\\' => $fooTarget . '\\'
+					)
+				)
+		;
+	}
+
+	/**
+	 * @php >= 7.1
+	 */
+	public function testAddClassAliasphp71()
+	{
+		$this
+			->if($autoloader = new testedClass())
+			->then
+				->object($autoloader->addClassAlias($alias = uniqid(), $target = uniqid()))->isIdenticalTo($autoloader)
+				->array($autoloader->getClassAliases())->isEqualTo(array(
+						'atoum' => 'mageekguy\\atoum\\test',
+						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						$alias => $target
+					)
+				)
+				->object($autoloader->addClassAlias($alias, $target))->isIdenticalTo($autoloader)
+				->array($autoloader->getClassAliases())->isEqualTo(array(
+						'atoum' => 'mageekguy\\atoum\\test',
+						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						$alias => $target
+					)
+				)
+				->object($autoloader->addClassAlias('\\' . ($otherAlias = uniqid()), '\\' . ($otherTarget = uniqid())))->isIdenticalTo($autoloader)
+				->array($autoloader->getClassAliases())->isEqualTo(array(
+						'atoum' => 'mageekguy\\atoum\\test',
+						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						$alias => $target,
+						$otherAlias => $otherTarget
+					)
+				)
+				->object($autoloader->addClassAlias('\\' . ($anOtherAlias = uniqid()) . '\\', '\\' . ($anOtherTarget = uniqid()) . '\\'))->isIdenticalTo($autoloader)
+				->array($autoloader->getClassAliases())->isEqualTo(array(
+						'atoum' => 'mageekguy\\atoum\\test',
+						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						$alias => $target,
+						$otherAlias => $otherTarget,
+						$anOtherAlias => $anOtherTarget
+					)
+				)
+				->object($autoloader->addClassAlias('FOO', '\\' . ($fooTarget = uniqid()) . '\\'))->isIdenticalTo($autoloader)
+				->array($autoloader->getClassAliases())->isEqualTo(array(
+						'atoum' => 'mageekguy\\atoum\\test',
+						'mageekguy\\atoum' => 'mageekguy\\atoum\\test',
+						$alias => $target,
+						$otherAlias => $otherTarget,
+						$anOtherAlias => $anOtherTarget,
+						'foo' => $fooTarget
 					)
 				)
 		;

--- a/tests/units/classes/report/fields/runner/tests/blank.php
+++ b/tests/units/classes/report/fields/runner/tests/blank.php
@@ -5,12 +5,12 @@ namespace mageekguy\atoum\tests\units\report\fields\runner\tests;
 use
 	mageekguy\atoum,
 	mageekguy\atoum\runner,
-	mock\mageekguy\atoum\report\fields\runner\tests\void as testedClass
+	mock\mageekguy\atoum\report\fields\runner\tests\blank as testedClass
 ;
 
 require __DIR__ . '/../../../../../runner.php';
 
-class void extends atoum\test
+class blank extends atoum\test
 {
 	public function testClass()
 	{

--- a/tests/units/classes/reports/realtime/cli.php
+++ b/tests/units/classes/reports/realtime/cli.php
@@ -103,7 +103,7 @@ class cli extends atoum\test
 					->setMethodPrompt(new prompt('=> ', new colorizer('0;37')))
 					->setOutputPrompt(new prompt('==> ', new colorizer('0;37')))
 				)
-			->define($runnerVoidField = new fields\runner\tests\void\cli())
+			->define($runnerVoidField = new fields\runner\tests\blank\cli())
 				->and($runnerVoidField
 					->setTitlePrompt(new prompt('> '))
 					->setTitleColorizer(new colorizer('0;34'))

--- a/tests/units/classes/reports/realtime/cli/light.php
+++ b/tests/units/classes/reports/realtime/cli/light.php
@@ -61,7 +61,7 @@ class light extends atoum\test
 					->setMethodPrompt(new prompt('=> ', new colorizer('0;37')))
 					->setOutputPrompt(new prompt('==> ', new colorizer('0;37')))
 			)
-			->define($voidTestField = new fields\runner\tests\void\cli())
+			->define($voidTestField = new fields\runner\tests\blank\cli())
 			->define($voidTestField
 					->setTitlePrompt(new prompt('> '))
 					->setTitleColorizer(new colorizer('0;34'))

--- a/tests/units/classes/reports/realtime/phing.php
+++ b/tests/units/classes/reports/realtime/phing.php
@@ -87,7 +87,7 @@ class phing extends atoum\test
 					->setMethodPrompt(new prompt(' ', new colorizer('0;37')))
 					->setOutputPrompt(new prompt('  ', new colorizer('0;37')))
 				)
-			->define($runnerVoidField = new fields\runner\tests\void\cli())
+			->define($runnerVoidField = new fields\runner\tests\blank\cli())
 				->and($runnerVoidField
 					->setTitlePrompt(new prompt(PHP_EOL))
 					->setTitleColorizer(new colorizer('0;34'))


### PR DESCRIPTION
Void is now a reserved keyword in PHP-7.1. This patch replace all
required call from `void` to `blank`

This PR fix https://github.com/atoum/atoum/issues/598