### PR TITLE
Various HHVM compatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ before_script:
   - "[ -n \"$COVERALLS_REPO_TOKEN\" ] && sed -i s/YouCoverallsProjectToken/$COVERALLS_REPO_TOKEN/ .atoum.php || true"
 script:
   - bin/atoum +verbose
-  - mkdir ../phar
-  - php -n -dphar.readonly=Off scripts/phar/generator.php -d ../phar
-  - php -n -ddate.timezone=Europe/Paris ../phar/atoum.phar --test-it -ncc +verbose -c .atoum.php
+  - |
+      if [[ $TRAVIS_PHP_VERSION = php* ]]; then
+        mkdir ../phar
+        php -n -dphar.readonly=Off scripts/phar/generator.php -d ../phar
+        php -n -ddate.timezone=Europe/Paris ../phar/atoum.phar --test-it -ncc +verbose -c .atoum.php
+      fi
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,24 @@
 language: php
 matrix:
   include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: nightly
     - php: hhvm-3.12
       sudo: required
       dist: trusty
       group: edge
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
+  allow_failures:
+    - php: nightly
+    - php: hhvm-3.12
+    - php: hhvm
   fast_finish: true
 notifications:
   irc: "irc.freenode.org##atoum"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: php
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - nightly
-  - hhvm
 matrix:
-  allow_failures:
-    - php: nightly
+  include:
+    - php: hhvm-3.12
+      sudo: required
+      dist: trusty
+      group: edge
   fast_finish: true
 notifications:
   irc: "irc.freenode.org##atoum"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ php:
   - 7.0
   - nightly
   - hhvm
-  - hhvm-nightly
 matrix:
   allow_failures:
     - php: nightly
     - php: hhvm
-    - php: hhvm-nightly
 notifications:
   irc: "irc.freenode.org##atoum"
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 matrix:
   allow_failures:
     - php: nightly
-    - php: hhvm
+  fast_finish: true
 notifications:
   irc: "irc.freenode.org##atoum"
   webhooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # `dev-master`
 
-* [#624](https://github.com/atoum/atoum/pull/625) `atoum\iterators\recursives\directory\factory` is no longer a aggregated iterator ([@hywan])
+* [#625](https://github.com/atoum/atoum/pull/625) Isolation test execution engine is working on HHVM ([@hywan])
+* [#625](https://github.com/atoum/atoum/pull/625) `atoum\iterators\recursives\directory\factory` is no longer a aggregated iterator ([@hywan])
 
 # 2.8.2 - 2016-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#624](https://github.com/atoum/atoum/pull/625) `atoum\iterators\recursives\directory\factory` is no longer a aggregated iterator ([@hywan])
+
 # 2.8.2 - 2016-08-12
 
 * [#620](https://github.com/atoum/atoum/pull/620) Add HTML coverage report from [reports extension](https://github.com/atoum/reports-extension) to AtoumTask for Phing ([@oxman])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#625](https://github.com/atoum/atoum/pull/625) Various HHVM compatibility issues solved ([@hywan])
 * [#625](https://github.com/atoum/atoum/pull/625) Isolation test execution engine is working on HHVM ([@hywan])
 * [#625](https://github.com/atoum/atoum/pull/625) `atoum\iterators\recursives\directory\factory` is no longer a aggregated iterator ([@hywan])
 

--- a/classes/iterators/filters/recursives/dot.php
+++ b/classes/iterators/filters/recursives/dot.php
@@ -6,7 +6,7 @@ class dot extends \recursiveFilterIterator
 {
 	public function __construct($mixed, \closure $iteratorFactory = null)
 	{
-		if ($mixed instanceof \recursiveIterator)
+		if ($mixed instanceof \RecursiveIterator)
 		{
 			parent::__construct($mixed);
 		}

--- a/classes/iterators/filters/recursives/extension.php
+++ b/classes/iterators/filters/recursives/extension.php
@@ -8,7 +8,7 @@ class extension extends \recursiveFilterIterator
 
 	public function __construct($mixed, array $acceptedExtensions = array(), \closure $iteratorFactory = null)
 	{
-		if ($mixed instanceof \recursiveIterator)
+		if ($mixed instanceof \RecursiveIterator)
 		{
 			parent::__construct($mixed);
 		}

--- a/classes/iterators/recursives/directory/factory.php
+++ b/classes/iterators/recursives/directory/factory.php
@@ -6,7 +6,7 @@ use
 	mageekguy\atoum\iterators\filters
 ;
 
-class factory implements \iteratorAggregate
+class factory
 {
 	protected $dotFilterFactory = null;
 	protected $iteratorFactory = null;

--- a/classes/php.php
+++ b/classes/php.php
@@ -41,6 +41,10 @@ class php extends cli\command
 			}
 		}
 
+		if (defined('HHVM_VERSION')) {
+			$phpPath .= ' --php';
+		}
+
 		return parent::setBinaryPath($phpPath);
 	}
 }

--- a/resources/phing/build.xml
+++ b/resources/phing/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="atoum" default="test">
-    <taskdef name="atoum" classpath="./" classname="AtoumTask"/>
+    <taskdef name="atoum" classpath="./" classname="atoumTask"/>
 
     <!-- ============================================  -->
     <!-- Target: Test                                  -->

--- a/tests/units/classes/iterators/recursives/directory/factory.php
+++ b/tests/units/classes/iterators/recursives/directory/factory.php
@@ -12,11 +12,6 @@ use
 
 class factory extends atoum\test
 {
-	public function testClass()
-	{
-		$this->testedClass->implements('iteratorAggregate');
-	}
-
 	public function test__construct()
 	{
 		$this

--- a/tests/units/resources/phing/AtoumTask.php
+++ b/tests/units/resources/phing/AtoumTask.php
@@ -16,7 +16,7 @@ namespace tests\units
 
 	require_once __DIR__ . '/../../runner.php';
 
-	define('mageekguy\atoum\phing\task\path', atoum\mock\streams\fs\file::get());
+	define('mageekguy\atoum\phing\task\path', (string) atoum\mock\streams\fs\file::get());
 
 	require_once __DIR__ . '/../../../../resources/phing/AtoumTask.php';
 


### PR DESCRIPTION
Fix #624.

Various stuff here.

First, HHVM detects an incorrect interface implementation. Don't know why Zend Engine doesn't… So the `IteratorAggregate` interface is removed from the `directory\factory` class.

Second, HHVM binary requires the `--php` to run a PHP file. This is required for the isolation test execution engine.

Third, HHVM nightly is no longer build (see https://github.com/travis-ci/travis-ci/issues/3788) so we can remove it from Travis configuration file.
