### PR TITLE
Mock generator correctly handles the `self` and `parent` return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfix
 
+* [#633](https://github.com/atoum/atoum/pull/633) Mock generator correctly handles the `self` return type ([@jubianchi])
 * [#637](https://github.com/atoum/atoum/pull/637) Errors are displayed in the TAP report ([@jubianchi])
 
 # 2.8.2 - 2016-08-12

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -612,13 +612,22 @@ class generator
 
 		if($method->getName() !== '__construct' && method_exists($method, 'hasReturnType') && $method->hasReturnType())
 		{
-			if($method->getReturnType()->isBuiltin())
+			switch (true)
 			{
-				$returnTypeCode = ': ' . $method->getReturnType();
-			}
-			else
-			{
-				$returnTypeCode = ': \\' . $method->getReturnType();
+				case (string) $method->getReturnType() === 'self':
+					$returnTypeCode = ': \\' . $method->getDeclaringClass()->getName();
+					break;
+
+				case (string) $method->getReturnType() === 'parent':
+					$returnTypeCode = ': \\' . $method->getDeclaringClass()->getParentClass()->getName();
+					break;
+
+				case $method->getReturnType()->isBuiltin():
+					$returnTypeCode = ': ' . $method->getReturnType();
+					break;
+
+				default:
+					$returnTypeCode = ': \\' . $method->getReturnType();
 			}
 		}
 

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -3447,6 +3447,90 @@ class generator extends atoum\test
 		;
 	}
 
+	/** @php >= 7.0 */
+	public function testGetMockedClassCodeForMethodWithSelfReturnType()
+	{
+		$this
+			->if($generator = new testedClass())
+			->and($reflectionTypeController = new mock\controller())
+			->and($reflectionTypeController->__construct = function() {})
+			->and($reflectionTypeController->__toString = 'self')
+			->and($reflectionTypeController->isBuiltIn = false)
+			->and($reflectionType = new \mock\reflectionType())
+			->and($reflectionMethodController = new mock\controller())
+			->and($reflectionMethodController->__construct = function() {})
+			->and($reflectionMethodController->getName = $methodName = 'returnSelf')
+			->and($reflectionMethodController->isConstructor = false)
+			->and($reflectionMethodController->getParameters = array())
+			->and($reflectionMethodController->isPublic = true)
+			->and($reflectionMethodController->isProtected = false)
+			->and($reflectionMethodController->isPrivate = false)
+			->and($reflectionMethodController->isFinal = false)
+			->and($reflectionMethodController->isStatic = false)
+			->and($reflectionMethodController->isAbstract = false)
+			->and($reflectionMethodController->returnsReference = false)
+			->and($reflectionMethodController->hasReturnType = true)
+			->and($reflectionMethodController->getReturnType = $reflectionType)
+			->and($reflectionMethod = new \mock\reflectionMethod(null, null))
+			->and($reflectionClassController = new mock\controller())
+			->and($reflectionClassController->__construct = function() {})
+			->and($reflectionClassController->getName = function() use (& $realClass) { return $realClass; })
+			->and($reflectionClassController->isFinal = false)
+			->and($reflectionClassController->isInterface = false)
+			->and($reflectionClassController->getMethods = array($reflectionMethod))
+			->and($reflectionClassController->getConstructor = null)
+			->and($reflectionClassController->isAbstract = false)
+			->and($reflectionClass = new \mock\reflectionClass(null))
+			->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+			->and($generator->setReflectionClassFactory(function() use ($reflectionClass) { return $reflectionClass; }))
+			->and($adapter = new atoum\test\adapter())
+			->and($adapter->class_exists = function($class) use (& $realClass) { return ($class == '\\' . $realClass); })
+			->and($generator->setAdapter($adapter))
+			->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+					'namespace mock {' . PHP_EOL .
+					'final class ' . $realClass . ' extends \\' . $realClass . ' implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'{' . PHP_EOL .
+					$this->getMockControllerMethods() .
+					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . '{' . PHP_EOL .
+					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t" . '}' . PHP_EOL .
+					"\t" . 'public function ' . $methodName . '(): \\' . $realClass . PHP_EOL .
+					"\t" . '{' . PHP_EOL .
+					"\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+					"\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t\t" . 'else' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+					"\t\t\t" . 'return $return;' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t" . '}' . PHP_EOL .
+					"\t" . 'public static function getMockedMethods()' . PHP_EOL .
+					"\t" . '{' . PHP_EOL .
+					"\t\t" . 'return ' . var_export(array('__construct', strtolower($methodName)), true) . ';' . PHP_EOL .
+					"\t" . '}' . PHP_EOL .
+					'}' . PHP_EOL .
+					'}'
+				)
+		;
+	}
+
 	protected function getMockControllerMethods()
 	{
 		return


### PR DESCRIPTION
Closes #623

```php
<?php

declare(strict_types=1);

namespace
{
    class foo
    {
        public function bar() : self
        {
            return $this;
        }
    }
}

namespace tests\units
{
    use atoum;

    class foo extends atoum
    {
        public function testBar()
        {
            $this->object(new \mock\foo())->isInstanceOf($this->newTestedInstance);
        }
    }
}
```

This works  without error:

```shell
bin/atoum mock-self.php 
> atoum path: /Users/julien.bianchi/repositories/atoum/atoum/bin/atoum
> atoum version: dev-master
> PHP path: /usr/local/Cellar/php70/7.0.9/bin/php
> PHP version:
=> PHP 7.0.9 (cli) (built: Jul 27 2016 15:51:40) ( ZTS )
=> Copyright (c) 1997-2016 The PHP Group
=> Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
=>     with Xdebug v2.4.1-dev, Copyright (c) 2002-2016, by Derick Rethans
=>     with blackfire v1.11.1, https://blackfire.io, by Blackfireio Inc.
> tests\units\foo...
[S___________________________________________________________][1/1]
=> Test duration: 0.01 second.
=> Memory usage: 0.00 Mb.
> Total test duration: 0.01 second.
> Total test memory usage: 0.00 Mb.
> Code coverage value: 0.00%
=> Class foo: 0.00%
==> foo::bar(): 0.00%
> Running duration: 0.07 second.
Success (1 test, 1/1 method, 0 void method, 0 skipped method, 2 assertions)!
```