### PR TITLE
Only one extension of a kind can be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#634](https://github.com/atoum/atoum/pull/634) Only one extension of a kind can be loaded. Extensions can be unloaded ([@agallou], [@jubianchi])
 * [#619](https://github.com/atoum/atoum/pull/619) Add branches and paths coverage support to AtoumTask for Phing ([@oxman])
 
 # 2.8.2 - 2016-08-12

--- a/classes/extension/aggregator.php
+++ b/classes/extension/aggregator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace mageekguy\atoum\extension;
+
+use mageekguy\atoum\exceptions\logic\invalidArgument;
+
+class aggregator extends \splObjectStorage
+{
+    public function getHash($object)
+    {
+        if (is_object($object) === false)
+        {
+            throw new invalidArgument(__METHOD__ . ' expects parameter 1 to be object, ' . gettype($object) . ' given');
+        }
+
+        return get_class($object);
+    }
+}

--- a/tests/units/classes/runner.php
+++ b/tests/units/classes/runner.php
@@ -507,26 +507,45 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
-				->array($runner->getObservers())->isEmpty()
-				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('mageekguy\atoum\extension\aggregator')
+				->sizeOf($runner->getExtensions())->isZero
 				->array($runner->getObservers())->isEmpty()
 			->if($extension = new \mock\mageekguy\atoum\extension())
-			->and($otherExtension = new \mock\mageekguy\atoum\extension())
+			->and(
+				$this->mockClass('mageekguy\atoum\extension', 'otherMock', 'extension'),
+				$otherExtension = new \otherMock\extension()
+			)
 			->and($runner->addExtension($extension)->addExtension($otherExtension))
 			->then
 				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
 				->object($runner->removeExtension(new \mock\mageekguy\atoum\extension()))->isIdenticalTo($runner)
-				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
-				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+			->if($runner->addExtension($extension))
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension, $extension))
 				->object($runner->removeExtension($extension))->isIdenticalTo($runner)
 				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($otherExtension))
+			->if($runner->addExtension($extension))
+			->then
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension, $extension))
+				->object($runner->removeExtension('mock\mageekguy\atoum\extension'))->isIdenticalTo($runner)
+				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($otherExtension))
+				->array($runner->getObservers())->isEqualTo(array($otherExtension))
 				->object($runner->removeExtension($otherExtension))->isIdenticalTo($runner)
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('mageekguy\atoum\extension\aggregator')
+				->sizeOf($runner->getExtensions())->isZero
 				->array($runner->getObservers())->isEmpty()
+			->if($extension = new \mock\mageekguy\atoum\extension())
+			->then
+				->exception(function() use ($runner, $extension) {
+						$runner->removeExtension($extension);
+					}
+				)
+					->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+					->hasMessage('Extension ' . get_class($extension) . ' is not loaded')
 		;
 	}
 
@@ -535,19 +554,25 @@ class runner extends atoum\test
 		$this
 			->if($runner = new testedClass())
 			->then
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('mageekguy\atoum\extension\aggregator')
+				->sizeOf($runner->getExtensions())->isZero
 				->array($runner->getObservers())->isEmpty()
 				->object($runner->removeExtensions())->isIdenticalTo($runner)
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('mageekguy\atoum\extension\aggregator')
+				->sizeOf($runner->getExtensions())->isZero
 				->array($runner->getObservers())->isEmpty()
 			->if($extension = new \mock\mageekguy\atoum\extension())
-			->and($otherExtension = new \mock\mageekguy\atoum\extension())
+			->and(
+				$this->mockClass('mageekguy\atoum\extension', 'otherMock', 'extension'),
+				$otherExtension = new \otherMock\extension()
+			)
 			->and($runner->addExtension($extension)->addExtension($otherExtension))
 			->then
 				->array(iterator_to_array($runner->getExtensions()))->isEqualTo(array($extension, $otherExtension))
 				->array($runner->getObservers())->isEqualTo(array($extension, $otherExtension))
 				->object($runner->removeExtensions())->isIdenticalTo($runner)
-				->object($runner->getExtensions())->isEqualTo(new \splObjectStorage())
+				->object($runner->getExtensions())->isInstanceOf('mageekguy\atoum\extension\aggregator')
+				->sizeOf($runner->getExtensions())->isZero
 				->array($runner->getObservers())->isEmpty()
 		;
 	}


### PR DESCRIPTION
This is a partial port of what @agallou did in #604: extensions
are indexed by class name.

* We can load an extension the way we already did:

```php
<?php

$extension = new mageekguy\atoum\blackfire\extension($script);
$extension
    ->setClientConfiguration(new \Blackfire\ClientConfiguration(
        $_ENV['BLACKFIRE_CLIENT_ID'],
        $_ENV['BLACKFIRE_CLIENT_TOKEN']
    ))
    ->addToRunner($runner)
;
```

* If we later try to re-register the same extension, only its
  configuration will be updated:

```php
<?php

$extension = new mageekguy\atoum\blackfire\extension($script);
$extension
    ->setClientConfiguration(new \Blackfire\ClientConfiguration(
        'foo',
        'bar'
    ))
    ->addToRunner($runner)
;
```

* We can also unload an extension, either using an instance or its
  class name:

```php
$extension = new mageekguy\atoum\blackfire\extension($script);
$extension->addToRunner($runner);

$runner->removeExtension($extension);
$runner->removeExtension(new mageekguy\atoum\blackfire\extension());
$runner->removeExtension(mageekguy\atoum\blackfire\extension::class);
```