### PR TITLE
Git pusher now supports tagging beta releases and updates the changelog

### DIFF
--- a/classes/scripts/git/pusher.php
+++ b/classes/scripts/git/pusher.php
@@ -339,19 +339,24 @@ class pusher extends script\configurable
 		return preg_replace_callback($versionPattern, $increment(self::patchVersion), $tag);
 	}
 
-	private function tagSrcWith($tag)
+	private function tagSrcWith($tag, $tagChangelog = false)
 	{
 		$this->taggerEngine
 			->setVersion(sprintf(static::versionPattern, $tag))
 			->tagVersion()
 		;
 
+		if ($tagChangelog === true)
+		{
+			$this->taggerEngine->tagChangelog($tag);
+		}
+
 		return $this;
 	}
 
 	private function tagStableVersion($tag)
 	{
-		$this->tagSrcWith($tag);
+		$this->tagSrcWith($tag, true);
 
 		try
 		{

--- a/classes/scripts/git/pusher.php
+++ b/classes/scripts/git/pusher.php
@@ -28,6 +28,7 @@ class pusher extends script\configurable
 	protected $forceMode = false;
 	protected $tagMajorVersion = false;
 	protected $tagMinorVersion = false;
+	protected $tagBetaVersion = false;
 
 	public function __construct($name, atoum\adapter $adapter = null)
 	{
@@ -135,11 +136,15 @@ class pusher extends script\configurable
 		$this->tagMinorVersion = true;
 	}
 
-
 	public function tagPatchVersion()
 	{
 		$this->tagMajorVersion = false;
 		$this->tagMinorVersion = false;
+	}
+
+	public function tagBetaVersion()
+	{
+		$this->tagBetaVersion = true;
 	}
 
 	protected function setArgumentHandlers()
@@ -202,6 +207,14 @@ class pusher extends script\configurable
 				null,
 				$this->locale->_('Tag a new patch version')
 			)
+			->addArgumentHandler(
+				function($script, $argument, $value) {
+					$script->tagBetaVersion();
+				},
+				array('-B', '--beta-release'),
+				null,
+				$this->locale->_('Tag a new beta version')
+			)
 		;
 
 		return $this;
@@ -260,9 +273,37 @@ class pusher extends script\configurable
 
 	protected function getNextVersion($tag)
 	{
+		$nextVersionSuffix = '';
+		$betaVersionPattern = '/-beta(\d+)$/';
+		if (preg_match($betaVersionPattern, $tag, $matches) > 0)
+		{
+			$tag = preg_replace($betaVersionPattern, '', $tag);
+
+			if ($this->tagBetaVersion === false)
+			{
+				return $tag;
+			}
+
+			if ($this->tagMajorVersion === false && $this->tagMinorVersion == false)
+			{
+				$nextVersionSuffix = '-beta' . (((int) $matches[1]) + 1);
+			}
+			else
+			{
+				$nextVersionSuffix = '-beta1';
+			}
+		}
+		else
+		{
+			if ($this->tagBetaVersion === true)
+			{
+				$nextVersionSuffix = '-beta1';
+			}
+		}
+
 		$versionPattern = '/^(\d+)\.(\d+)\.(\d+)$/';
-		$increment = function($position) {
-			return function($matches) use ($position) {
+		$increment = function($position) use ($nextVersionSuffix) {
+			return function($matches) use ($position, $nextVersionSuffix) {
 				for ($i = 1; $i <= 3; $i++)
 				{
 					if ($i > $position)
@@ -276,7 +317,7 @@ class pusher extends script\configurable
 					}
 				}
 
-				return implode('.', array_slice($matches, 1));
+				return implode('.', array_slice($matches, 1)) . $nextVersionSuffix;
 			};
 		};
 
@@ -288,6 +329,11 @@ class pusher extends script\configurable
 		if ($this->tagMinorVersion === true)
 		{
 			return preg_replace_callback($versionPattern, $increment(self::minorVersion), $tag);
+		}
+
+		if ($this->tagBetaVersion === true && $this->tagMajorVersion === false && $this->tagMajorVersion === false)
+		{
+			return $tag . $nextVersionSuffix;
 		}
 
 		return preg_replace_callback($versionPattern, $increment(self::patchVersion), $tag);

--- a/classes/scripts/tagger/engine.php
+++ b/classes/scripts/tagger/engine.php
@@ -10,11 +10,15 @@ use
 
 class engine
 {
-	const defaultVersionPattern = '/\$Rev: [^ %]+ \$/';
+	const defaultVersionPattern = '/\$Rev: ([^ %]+) \$/';
+	const defaultChangelogName = 'CHANGELOG.md';
+	const defaultChangelogHeader = '# `dev-master`';
 
 	protected $adapter = null;
 	protected $version = null;
 	protected $versionPattern = null;
+	protected $changelogName = null;
+	protected $changelogHeader = null;
 	protected $srcDirectory = null;
 	protected $srcIteratorInjector = null;
 	protected $destinationDirectory = null;
@@ -29,6 +33,8 @@ class engine
 		$this
 			->setAdapter($adapter)
 			->setVersionPattern(static::defaultVersionPattern)
+			->setChangelogName(static::defaultChangelogName)
+			->setChangelogHeader(static::defaultChangelogHeader)
 		;
 	}
 
@@ -64,6 +70,20 @@ class engine
 	public function setVersionPattern($pattern)
 	{
 		$this->versionPattern = (string) $pattern;
+
+		return $this;
+	}
+
+	public function setChangelogName($name)
+	{
+		$this->changelogName = (string) $name;
+
+		return $this;
+	}
+
+	public function setChangelogHeader($header)
+	{
+		$this->changelogHeader = (string) $header;
 
 		return $this;
 	}
@@ -151,7 +171,7 @@ class engine
 
 			if ($fileContents === false)
 			{
-				throw new exceptions\runtime('Unable to tag, path \'' . $path . '\' is unreadable');
+				throw new exceptions\runtime('Unable to tag, path \'' . $path . '\' is not readable');
 			}
 
 			$path = ($this->destinationDirectory == $this->srcDirectory ? $path : $this->destinationDirectory . \DIRECTORY_SEPARATOR . substr($path, strlen($this->srcDirectory) + 1));
@@ -165,8 +185,36 @@ class engine
 
 			if ($this->adapter->file_put_contents($path, preg_replace($this->versionPattern, $this->version, $fileContents), \LOCK_EX) === false)
 			{
-				throw new exceptions\runtime('Unable to tag, path \'' . $path . '\' is unwritable');
+				throw new exceptions\runtime('Unable to tag, path \'' . $path . '\' is not writable');
 			}
+		}
+
+		return $this;
+	}
+
+	public function tagChangelog()
+	{
+		$changelogPath = $this->srcDirectory . DIRECTORY_SEPARATOR . $this->changelogName;
+
+		if ($this->adapter->file_exists($changelogPath) === true)
+		{
+			$changelogContents = @$this->adapter->file_get_contents($changelogPath);
+
+			if ($changelogContents === false)
+			{
+				throw new exceptions\runtime('Unable to tag, path \'' . $changelogPath . '\' is not readable');
+			}
+
+			if (preg_match($this->versionPattern, $this->version, $matches))
+			{
+				$changelogContents = preg_replace('/^' . preg_quote($this->changelogHeader, '/') . '$/m', '# ' . (isset($matches[1]) ? $matches[1] : $this->version) . ' - ' . $this->adapter->date('Y-m-d'), $changelogContents);
+				
+				if ($this->adapter->file_put_contents($changelogPath, $this->changelogHeader . PHP_EOL . PHP_EOL . $changelogContents, \LOCK_EX) === false)
+				{
+					throw new exceptions\runtime('Unable to tag, path \'' . $changelogPath . '\' is not writable');
+				}
+			}
+
 		}
 
 		return $this;

--- a/tests/units/classes/scripts/git/pusher.php
+++ b/tests/units/classes/scripts/git/pusher.php
@@ -140,6 +140,7 @@ class pusher extends atoum
 			->if(
 				$this->function->file_put_contents = function($path, $data) { return strlen($data); },
 				$this->calling($taggerEngine)->tagVersion->doesNothing(),
+				$this->calling($taggerEngine)->tagChangelog->doesNothing(),
 				$this->calling($git)->addAllAndCommit = $git,
 				$this->calling($git)->checkoutAllFiles = $git,
 				$this->calling($git)->createTag = $git,
@@ -154,20 +155,23 @@ class pusher extends atoum
 				->function('file_put_contents')->wasCalledWithArguments($pusher->getTagFile(), '0.0.1')->once()
 				->mock($taggerEngine)
 					->call('tagVersion')
-						->before($this->mock($git)
-							->call('addAllAndCommit')->withArguments('Set version to 0.0.1.')
-							->before($this->mock($git)
-								->call('createTag')->withArguments('0.0.1')
+						->before($this->mock($taggerEngine)
+							->call('tagChangelog')->withArguments('0.0.1')
 								->before($this->mock($git)
-									->call('push')->withArguments($pusher->getRemote())
-									->once()
-								)
-								->before($this->mock($git)
-									->call('pushTag')->withArguments('0.0.1', $pusher->getRemote())
-									->once()
-								)
-								->once()
-							)
+									->call('addAllAndCommit')->withArguments('Set version to 0.0.1.')
+									->before($this->mock($git)
+										->call('createTag')->withArguments('0.0.1')
+										->before($this->mock($git)
+											->call('push')->withArguments($pusher->getRemote())
+											->once()
+										)
+										->before($this->mock($git)
+											->call('pushTag')->withArguments('0.0.1', $pusher->getRemote())
+											->once()
+										)
+										->once()
+									)
+								->once())
 							->once())
 						->after($this->mock($taggerEngine)
 							->call('setSrcDirectory')->withArguments($pusher->getWorkingDirectory())

--- a/tests/units/classes/scripts/tagger.php
+++ b/tests/units/classes/scripts/tagger.php
@@ -45,6 +45,7 @@ class tagger extends atoum\test
 			->and($tagger->setEngine($engine = new \mock\mageekguy\atoum\scripts\tagger\engine()))
 			->and($tagger->setHelpWriter($helpWriter))
 			->and($this->calling($engine)->tagVersion = function() {})
+			->and($this->calling($engine)->tagChangelog = function() {})
 			->then
 				->object($tagger->run())->isIdenticalTo($tagger)
 				->mock($engine)->call('tagVersion')->once()

--- a/tests/units/classes/scripts/tagger/engine.php
+++ b/tests/units/classes/scripts/tagger/engine.php
@@ -16,7 +16,7 @@ class engine extends atoum\test
 	{
 		$this
 			->testedClass
-				->hasConstant('defaultVersionPattern')->isEqualTo('/\$Rev: [^ %]+ \$/')
+				->hasConstant('defaultVersionPattern')->isEqualTo('/\$Rev: ([^ %]+) \$/')
 		;
 	}
 
@@ -207,7 +207,7 @@ class engine extends atoum\test
 					}
 				)
 					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-					->hasMessage('Unable to tag, path \'' . $file2 . '\' is unreadable')
+					->hasMessage('Unable to tag, path \'' . $file2 . '\' is not readable')
 			->if(
 				$adapter->resetCalls(),
 				$adapter->file_get_contents[2] = $contentOfFile2,
@@ -219,7 +219,7 @@ class engine extends atoum\test
 					}
 				)
 					->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-					->hasMessage('Unable to tag, path \'' . $file2 . '\' is unwritable')
+					->hasMessage('Unable to tag, path \'' . $file2 . '\' is not writable')
 			->if(
 				$adapter->resetCalls(),
 				$this->testedInstance->setDestinationDirectory($destinationDirectory = uniqid())


### PR DESCRIPTION
Given the last release is `2.8.1`:

* if I want to tag a release, it will bump to `2.8.2`
* if I want to tag a beta release (`-B`), it will bump to `2.8.2-beta1`
* if I want to tag a beta release for a minor release (`-B -mr`), it will bump to `2.9.0-beta1`
* if I want to tag a beta release for a major release (`-B -MR`), it will bump to `3.0.0-beta1`

Given the last release is `2.8.2-beta1`:

* if I want to tag a release, it will bump to `2.8.2`
* if I want to tag a beta release (`-B`), it will bump to `2.8.2-beta2`
* if I want to tag a beta release for a minor release (`-B -mr`), it will bump to `2.9.0-beta1`
* if I want to tag a beta release for a major release (`-B -MR`), it will bump to `3.0.0-beta1`

This will be very useful when we'll start working on the 3.0.