### PR TITLE
Remove deprecated methods

### DIFF
--- a/classes/asserters/dateTime.php
+++ b/classes/asserters/dateTime.php
@@ -67,11 +67,6 @@ class dateTime extends object
 		return $this;
 	}
 
-	public function isInYear()
-	{
-		throw new exceptions\runtime('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasYear instead');
-	}
-
 	public function hasMonth($month, $failMessage = null)
 	{
 		if ($this->valueIsSet()->value->format('m') === sprintf('%02d', $month))
@@ -86,11 +81,6 @@ class dateTime extends object
 		return $this;
 	}
 
-	public function isInMonth()
-	{
-		throw new exceptions\runtime('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasMonth instead');
-	}
-
 	public function hasDay($day, $failMessage = null)
 	{
 		if ($this->valueIsSet()->value->format('d') === sprintf('%02d', $day))
@@ -103,11 +93,6 @@ class dateTime extends object
 		}
 
 		return $this;
-	}
-
-	public function isInDay()
-	{
-		throw new exceptions\runtime('The method ' . __METHOD__ . ' is deprecated, please use ' . __CLASS__ . '::hasDay instead');
 	}
 
 	public function hasDate($year, $month, $day, $failMessage = null)

--- a/classes/asserters/stream.php
+++ b/classes/asserters/stream.php
@@ -40,11 +40,6 @@ class stream extends atoum\asserter
 		return $this;
 	}
 
-	public function isWrited($failMessage = null)
-	{
-		return $this->isWritten($failMessage);
-	}
-
 	public function isWritten($failMessage = null)
 	{
 		if (sizeof($this->streamIsSet()->streamController->getCalls(new test\adapter\call('stream_write'))) > 0)

--- a/tests/units/classes/asserters/dateTime.php
+++ b/tests/units/classes/asserters/dateTime.php
@@ -398,48 +398,6 @@ namespace mageekguy\atoum\tests\units\asserters
 			;
 		}
 
-		public function testIsInYear()
-		{
-			$this
-				->if($this->newTestedInstance)
-				->then
-					->exception(function($test) {
-							$test->testedInstance->isInYear(rand(0, PHP_INT_MAX));
-						}
-					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-						->hasMessage('The method ' . $this->getTestedClassName() . '::isInYear is deprecated, please use ' . $this->getTestedClassName() . '::hasYear instead')
-			;
-		}
-
-		public function testIsInMonth()
-		{
-			$this
-				->if($this->newTestedInstance)
-				->then
-					->exception(function($test) {
-							$test->testedInstance->isInMonth(rand(0, PHP_INT_MAX));
-						}
-					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-						->hasMessage('The method ' . $this->getTestedClassName() . '::isInMonth is deprecated, please use ' . $this->getTestedClassName() . '::hasMonth instead')
-			;
-		}
-
-		public function testIsInDay()
-		{
-			$this
-				->if($this->newTestedInstance)
-				->then
-					->exception(function($test) {
-							$test->testedInstance->isInDay(rand(0, PHP_INT_MAX));
-						}
-					)
-						->isInstanceOf('mageekguy\atoum\exceptions\runtime')
-						->hasMessage('The method ' . $this->getTestedClassName() . '::isInDay is deprecated, please use ' . $this->getTestedClassName() . '::hasDay instead')
-			;
-		}
-
 		public function testIsImmutable(atoum\locale $locale)
 		{
 			$this

--- a/tests/units/classes/asserters/stream.php
+++ b/tests/units/classes/asserters/stream.php
@@ -81,12 +81,12 @@ class stream extends atoum\test
 		;
 	}
 
-	public function testIsWrited()
+	public function testIsWritten()
 	{
 		$this
 			->if($asserter = $this->newTestedInstance)
 			->then
-				->exception(function() use ($asserter) { $asserter->isWrited(); })
+				->exception(function() use ($asserter) { $asserter->isWritten(); })
 					->isInstanceOf('mageekguy\atoum\exceptions\logic')
 					->hasMessage('Stream is undefined')
 
@@ -96,20 +96,20 @@ class stream extends atoum\test
 				$asserter
 					->setWith($streamName)
 					->setLocale($locale = new \mock\atoum\locale()),
-				$this->calling($locale)->_ = $streamNotWrited = uniqid()
+				$this->calling($locale)->_ = $streamNotWritten = uniqid()
 			)
 			->then
-				->exception(function() use ($asserter) { $asserter->isWrited(); })
+				->exception(function() use ($asserter) { $asserter->isWritten(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage($streamNotWrited)
+					->hasMessage($streamNotWritten)
 				->mock($locale)->call('_')->withArguments('stream %s is not written', $streamController)->once
 
-				->exception(function() use ($asserter, & $failMessage) { $asserter->isWrited($failMessage = uniqid()); })
+				->exception(function() use ($asserter, & $failMessage) { $asserter->isWritten($failMessage = uniqid()); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage($failMessage)
 
 			->when(function() use ($streamName, $contents) { file_put_contents('atoum://' . $streamName, $contents); })
-				->object($asserter->isWrited())->isIdenticalTo($asserter)
+				->object($asserter->isWritten())->isIdenticalTo($asserter)
 
 			->if(
 				$streamController = atoum\mock\stream::get(uniqid()),
@@ -117,17 +117,17 @@ class stream extends atoum\test
 				$asserter->setWith($streamController)
 			)
 			->then
-				->exception(function() use ($asserter) { $asserter->isWrited(); })
+				->exception(function() use ($asserter) { $asserter->isWritten(); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
-					->hasMessage($streamNotWrited)
+					->hasMessage($streamNotWritten)
 				->mock($locale)->call('_')->withArguments('stream %s is not written', $streamController)->once
 
-				->exception(function() use ($asserter, & $failMessage) { $asserter->isWrited($failMessage = uniqid()); })
+				->exception(function() use ($asserter, & $failMessage) { $asserter->isWritten($failMessage = uniqid()); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage($failMessage)
 
 			->when(function() use ($streamController, $contents) { file_put_contents($streamController, $contents); })
-				->object($asserter->isWrited())->isIdenticalTo($asserter)
+				->object($asserter->isWritten())->isIdenticalTo($asserter)
 		;
 	}
 }


### PR DESCRIPTION
This commit removes the following deprecated methods and the associated tests:

* `mageekguy\atoum\asserters\dateTime::isInYear()`
* `mageekguy\atoum\asserters\dateTime::isInMonth()`
* `mageekguy\atoum\asserters\dateTime::isInDay()`
* `mageekguy\atoum\asserters\stream::isWrited()`

Reference to issue #648