### PR TITLE
Remove deprecated CLI flags

### DIFF
--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -195,13 +195,6 @@ class runner extends atoum\script\configurable
 		return $this->defaultArguments;
 	}
 
-	public function addTestAllDirectory($directory)
-	{
-		$this->writeError('--test-all argument is deprecated, please replace call to ' . __METHOD__ . '(\'path/to/default/tests/directory\') by $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in your configuration files and use atoum without any argument instead');
-
-		return $this;
-	}
-
 	public function run(array $arguments = array())
 	{
 		# Default bootstrap file MUST be included here because some arguments on the command line can include some tests which depends of this file.
@@ -1010,14 +1003,6 @@ class runner extends atoum\script\configurable
 					array('--test-it'),
 					null,
 					$this->locale->_('Execute atoum unit tests')
-				)
-			->addArgumentHandler(
-					function($script, $argument, $values) {
-						$script->writeError('--test-all argument is deprecated, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead');
-					},
-					array('--test-all'),
-					null,
-					$this->locale->_('DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead')
 				)
 			->addArgumentHandler(
 					function($script, $argument, $values) {

--- a/tests/units/classes/scripts/coverage.php
+++ b/tests/units/classes/scripts/coverage.php
@@ -155,11 +155,6 @@ class coverage extends atoum\test
 							'Execute atoum unit tests'
 						),
 						array(
-							array('--test-all'),
-							null,
-							'DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead'
-						),
-						array(
 							array('-ft', '--force-terminal'),
 							null,
 							'Force output as in terminal'
@@ -346,11 +341,6 @@ class coverage extends atoum\test
 							array('--test-it'),
 							null,
 							'Execute atoum unit tests'
-						),
-						array(
-							array('--test-all'),
-							null,
-							'DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead'
 						),
 						array(
 							array('-ft', '--force-terminal'),

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -165,11 +165,6 @@ class runner extends atoum\test
 							'Execute atoum unit tests'
 						),
 						array(
-							array('--test-all'),
-							null,
-							'DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead'
-						),
-						array(
 							array('-ft', '--force-terminal'),
 							null,
 							'Force output as in terminal'
@@ -347,11 +342,6 @@ class runner extends atoum\test
 							'Execute atoum unit tests'
 						),
 						array(
-							array('--test-all'),
-							null,
-							'DEPRECATED, please do $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in a configuration file and use atoum without any argument instead'
-						),
-						array(
 							array('-ft', '--force-terminal'),
 							null,
 							'Force output as in terminal'
@@ -432,20 +422,6 @@ class runner extends atoum\test
 				->boolean($runner->getRunner()->codeCoverageIsEnabled())->isTrue()
 				->object($runner->useConfigFile((string) $configFile))->isIdenticalTo($runner)
 				->boolean($runner->getRunner()->codeCoverageIsEnabled())->isFalse()
-		;
-	}
-
-	public function testAddTestAllDirectory()
-	{
-		$this
-			->if($runner = new \mock\mageekguy\atoum\scripts\runner(uniqid()))
-			->and($stderr = new \mock\mageekguy\atoum\writers\std\err())
-			->and($this->calling($stderr)->clear = $stderr)
-			->and($this->calling($stderr)->write = function() {})
-			->and($runner->setErrorWriter($stderr))
-			->then
-				->object($runner->addTestAllDirectory(uniqid()))->isIdenticalTo($runner)
-				->mock($stderr)->call('write')->withArguments('--test-all argument is deprecated, please replace call to mageekguy\atoum\scripts\runner::addTestAllDirectory(\'path/to/default/tests/directory\') by $runner->addTestsFromDirectory(\'path/to/default/tests/directory\') in your configuration files and use atoum without any argument instead')->once()
 		;
 	}
 


### PR DESCRIPTION
This commit removes:

* `--test-all` and its handler
* `mageekguy\atoum\scripts\runner::addTestAllDirectory()`

Reference to issue #652

Tell me if something is missing 🙂 