### PR TITLE
fix santa report

### DIFF
--- a/classes/report/fields/runner/event/santa.php
+++ b/classes/report/fields/runner/event/santa.php
@@ -32,24 +32,24 @@ class santa extends cli
 	$brown = new colorizer('38;5;94');
 
 	$this->sprite = array(
-	'			_			',
-	'		   {_}		   ',
-	$red->colorize('		   / \\		   '),
-	$red->colorize('		  /   \\		  '),
-	$red->colorize('		 /_____\\		 '),
-	'	   {`_______`}	   ',
-	'		// . . \\\\		',
-	'	   (/(__7__)\\)	   ',
-	'	   |\'-` = `-\'|	   ',
-	'	   |		 |	   ',
-	$red->colorize('	   /') . '\\	   /' . $red->colorize('\\	   '),
-	$red->colorize('	  /  ') . '\'.   .\'' . $red->colorize('  \\	  '),
-	$red->colorize('	 /_/') . '   `"`   ' . $red->colorize('\\_\\	 '),
-	'	{__}' . $brown->colorize('###') . $black->colorize('[_]') . $brown->colorize('###') . '{__}	',
-	'	(_/' . $red->colorize('\\_________/') . '\\_)	',
-	$red->colorize('		|___|___|		'),
-	$red->colorize('		 |--|--|		 '),
-	$brown->colorize('		(__)') . '`' . $brown->colorize('(__)		')
+	'            _            ',
+	'           {_}           ',
+	$red->colorize('           / \\           '),
+	$red->colorize('          /   \\          '),
+	$red->colorize('         /_____\\         '),
+	'       {`_______`}    ',
+	'        // . . \\\\        ',
+	'       (/(__7__)\\)       ',
+	'       |\'-` = `-\'|       ',
+	'       |         |   ',
+	$red->colorize('       /') . '\\       /' . $red->colorize('\\       '),
+	$red->colorize('      /  ') . '\'.   .\'' . $red->colorize('  \\      '),
+	$red->colorize('     /_/') . '   `"`   ' . $red->colorize('\\_\\     '),
+	'    {__}' . $brown->colorize('###') . $black->colorize('[_]') . $brown->colorize('###') . '{__}    ',
+	'    (_/' . $red ->colorize('\\_________/') . '\\_)	',
+	$red->colorize('        |___|___|        '),
+	$red->colorize('         |--|--|         '),
+	$brown->colorize('        (__)') . '`' . $brown->colorize('(__)        ')
 	);
 	}
 


### PR DESCRIPTION
spaces were replaced by strings in the printed string.

before:
![capture du 2016-10-16 11 57 19](https://cloud.githubusercontent.com/assets/320372/19416707/16867e12-9398-11e6-9e1b-baaea6a16eae.png)

after:
![capture du 2016-10-16 11 57 39](https://cloud.githubusercontent.com/assets/320372/19416708/1d37830a-9398-11e6-90ac-ce83cd164504.png)

this fix does not have to also be on the 3.0 branch, but must be cherry-picked on this PR of the reports extension : https://github.com/atoum/reports-extension/pull/26
