### PR TITLE
adds a generator asserter

### DIFF
--- a/classes/asserters/generator.php
+++ b/classes/asserters/generator.php
@@ -2,6 +2,10 @@
 
 namespace mageekguy\atoum\asserters;
 
+use
+	mageekguy\atoum\exceptions
+;
+
 class generator extends iterator
 {
 	public function __get($property)
@@ -17,6 +21,14 @@ class generator extends iterator
 				$generator->next();
 
 				return $childAsserter;
+			case 'returns':
+				$generator = $this->valueIsSet()->value;
+
+				if (!method_exists($generator, 'getReturn')) {
+					throw new exceptions\logic("The returns asserter could only be used with PHP>=7.0");
+				}
+
+				return $this->generator->__call('variable', array($generator->getReturn()));
 			default:
 				return parent::__get($property);
 		}

--- a/classes/asserters/generator.php
+++ b/classes/asserters/generator.php
@@ -9,8 +9,14 @@ class generator extends iterator
 		switch (strtolower($property))
 		{
 			case 'yields':
-				return $this->{$property}();
+				$asserter = new generator\child($this);
 
+				$generator = $this->valueIsSet()->value;
+
+				$childAsserter = $asserter->setWith($generator->current());
+				$generator->next();
+
+				return $childAsserter;
 			default:
 				return parent::__get($property);
 		}
@@ -30,12 +36,5 @@ class generator extends iterator
 		}
 
 		return $this;
-	}
-
-	public function yields()
-	{
-		$asserter = $this->generator->__call('variable', array($this->getValue()->current()));
-		$this->getValue()->next();
-		return $asserter;
 	}
 }

--- a/classes/asserters/generator.php
+++ b/classes/asserters/generator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace mageekguy\atoum\asserters;
+
+class generator extends iterator
+{
+	public function __get($property)
+	{
+		switch (strtolower($property))
+		{
+			case 'yields':
+				return $this->{$property}();
+
+			default:
+				return parent::__get($property);
+		}
+	}
+
+	public function setWith($value)
+	{
+		parent::setWith($value);
+
+		if ($value instanceof \Generator)
+		{
+			$this->pass();
+		}
+		else
+		{
+			$this->fail($this->_('%s is not a generator', $this));
+		}
+
+		return $this;
+	}
+
+	public function yields()
+	{
+		$asserter = $this->generator->__call('variable', array($this->getValue()->current()));
+		$this->getValue()->next();
+		return $asserter;
+	}
+}

--- a/classes/asserters/generator/child.php
+++ b/classes/asserters/generator/child.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mageekguy\atoum\asserters\generator;
+
+use
+	mageekguy\atoum\asserters,
+	mageekguy\atoum\exceptions
+;
+
+class child extends asserters\variable {
+	private $parent;
+
+	public function __construct(asserters\generator $parent = null)
+	{
+		parent::__construct($parent->getGenerator(), $parent->getAnalyzer(), $parent->getLocale());
+
+		$this->setWithParent($parent);
+	}
+
+	public function __get($property)
+	{
+		return $this->parentIsSet()->parent->__get($property);
+	}
+
+	public function __call($method, $arguments)
+	{
+		return $this->parentIsSet()->parent->__call($method, $arguments);
+	}
+
+	public function setWithParent(asserters\generator $parent)
+	{
+		$this->parent = $parent;
+
+		return $this;
+	}
+
+	protected function parentIsSet()
+	{
+		if ($this->parent === null)
+		{
+			throw new exceptions\logic('Parent array asserter is undefined');
+		}
+
+		return $this;
+	}
+}
+

--- a/tests/functionals/classes/asserters/generator.php
+++ b/tests/functionals/classes/asserters/generator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace mageekguy\atoum\tests\functionals\asserters;
+
+use
+	mageekguy\atoum
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class generator extends atoum\tests\functionals\test\functional
+{
+	/**
+	 * @php >= 7.0
+	 */
+	public function testUsage()
+	{
+		if (version_compare(PHP_VERSION, '7.0') >= 0) {
+			$generator = eval(<<<'PHP'
+return function() {
+    for ($i=0; $i<3; $i++) {
+        yield ($i+1);
+    }
+
+    return 42;
+};
+PHP
+			);
+		}
+
+		$this
+			->generator($generator())
+				->yields->isEqualTo(1)
+				->yields->isEqualTo(2)
+				->yields->isEqualTo(3)
+				->yields->isNull()
+				->returns->isEqualTo(42)
+			->generator($generator())
+				->size->isEqualTo(3)
+		;
+	}
+}

--- a/tests/units/classes/asserters/generator.php
+++ b/tests/units/classes/asserters/generator.php
@@ -202,7 +202,7 @@ PHP
 			}
 		};
 
-		$notAgenerator = function() {
+		$notAGenerator = function() {
 			for ($i=0; $i<10; $i++) {
 			}
 		};
@@ -221,7 +221,7 @@ PHP
 					->hasMessage("boolean(true) is not an object")
 
 			->then
-				->exception(function() use ($asserter, $notAgenerator) { $asserter->setWith($notAgenerator()); })
+				->exception(function() use ($asserter, $notAGenerator) { $asserter->setWith($notAGenerator()); })
 					->isInstanceOf('mageekguy\atoum\asserter\exception')
 					->hasMessage("null is not an object")
 

--- a/tests/units/classes/asserters/generator.php
+++ b/tests/units/classes/asserters/generator.php
@@ -40,36 +40,6 @@ class generator extends atoum\test
 	}
 
 	/**
-	 * @php >= 7.0
-	 */
-	public function testUsage()
-	{
-		if (version_compare(PHP_VERSION, '7.0') >= 0) {
-			$generator = eval(<<<'PHP'
-return function() {
-    for ($i=0; $i<3; $i++) {
-        yield ($i+1);
-    }
-
-    return 42;
-};
-PHP
-			);
-		}
-
-		$this
-			->generator($generator())
-				->yields->isEqualTo(1)
-				->yields->isEqualTo(2)
-				->yields->isEqualTo(3)
-				->yields->isNull()
-				->returns->isEqualTo(42)
-			->generator($generator())
-				->size->isEqualTo(3)
-		;
-	}
-
-	/**
 	 * @php < 7.0
 	 */
 	public function testReturnsBeforePhp7()

--- a/tests/units/classes/asserters/generator.php
+++ b/tests/units/classes/asserters/generator.php
@@ -39,6 +39,25 @@ class generator extends atoum\test
 		;
 	}
 
+	public function testUsage()
+	{
+		$generator = function() {
+			for ($i=0; $i<3; $i++) {
+				yield ($i+1);
+			}
+		};
+
+		$this
+			->generator($generator())
+				->yields->isEqualTo(1)
+				->yields->isEqualTo(2)
+				->yields->isEqualTo(3)
+				->yields->isNull(4)
+			->generator($generator())
+				->size->isEqualTo(3)
+		;
+	}
+
 	public function testYields()
 	{
 		$generator = function() {
@@ -55,17 +74,13 @@ class generator extends atoum\test
 			->then
 				->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
 
-			->when($yieldAsserter = $asserter->yields())
+			->when($yieldAsserter = $asserter->yields)
 				->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
 				->integer($yieldAsserter->getValue())->isEqualTo(1)
 
-			->when($yieldAsserter = $asserter->yields())
-				->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
-				->integer($yieldAsserter->getValue())->isEqualTo(2)
-
 			->when($yieldAsserter = $asserter->yields)
 				->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
-				->integer($yieldAsserter->getValue())->isEqualTo(3)
+				->integer($yieldAsserter->getValue())->isEqualTo(2)
 		;
 	}
 

--- a/tests/units/classes/asserters/generator.php
+++ b/tests/units/classes/asserters/generator.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\asserters;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\asserter,
+	mageekguy\atoum\tools\diffs,
+	mageekguy\atoum\tools\variable
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class generator extends atoum\test
+{
+	public function testClass()
+	{
+		$this->testedClass->extends('mageekguy\atoum\asserters\iterator');
+	}
+
+	public function test__construct()
+	{
+		$this
+			->given($this->newTestedInstance)
+			->then
+				->object($this->testedInstance->getGenerator())->isEqualTo(new asserter\generator())
+				->object($this->testedInstance->getAnalyzer())->isEqualTo(new variable\analyzer())
+				->object($this->testedInstance->getLocale())->isEqualTo(new atoum\locale())
+				->variable($this->testedInstance->getValue())->isNull()
+				->boolean($this->testedInstance->wasSet())->isFalse()
+
+			->given($this->newTestedInstance($generator = new asserter\generator(), $analyzer = new variable\analyzer(), $locale = new atoum\locale()))
+			->then
+				->object($this->testedInstance->getGenerator())->isIdenticalTo($generator)
+				->object($this->testedInstance->getAnalyzer())->isIdenticalTo($analyzer)
+				->object($this->testedInstance->getLocale())->isIdenticalTo($locale)
+				->variable($this->testedInstance->getValue())->isNull()
+				->boolean($this->testedInstance->wasSet())->isFalse()
+		;
+	}
+
+	public function testYields()
+	{
+		$generator = function() {
+			for ($i=0; $i<10; $i++) {
+				yield ($i+1);
+			}
+		};
+
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+			)
+			->then
+				->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+			->when($yieldAsserter = $asserter->yields())
+				->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+				->integer($yieldAsserter->getValue())->isEqualTo(1)
+
+			->when($yieldAsserter = $asserter->yields())
+				->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+				->integer($yieldAsserter->getValue())->isEqualTo(2)
+
+			->when($yieldAsserter = $asserter->yields)
+				->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+				->integer($yieldAsserter->getValue())->isEqualTo(3)
+		;
+	}
+
+	public function testSetWith()
+	{
+		$generator = function() {
+			for ($i=0; $i<10; $i++) {
+				yield ($i+1);
+			}
+		};
+
+		$notAgenerator = function() {
+			for ($i=0; $i<10; $i++) {
+			}
+		};
+
+		$this
+			->given($asserter = $this->newTestedInstance
+				->setLocale($locale = new \mock\atoum\locale())
+				->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+			)
+			->then
+				->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+			->then
+				->exception(function() use ($asserter) { $asserter->setWith(true); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage("boolean(true) is not an object")
+
+			->then
+				->exception(function() use ($asserter, $notAgenerator) { $asserter->setWith($notAgenerator()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage("null is not an object")
+
+			->then
+				->exception(function() use ($asserter) { $asserter->setWith(new \stdClass()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage("object(stdClass) is not an iterator")
+
+			->then
+				->exception(function() use ($asserter) { $asserter->setWith(new \ArrayIterator()); })
+					->isInstanceOf('mageekguy\atoum\asserter\exception')
+					->hasMessage("object(ArrayIterator) is not a generator")
+		;
+	}
+}


### PR DESCRIPTION
Example of usage:

```php
	public function testUsage()
	{
		$generator = function() {
			for ($i=0; $i<3; $i++) {
				yield ($i+1);
			}
		};

		$this
			->generator($generator())
				->yields->isEqualTo(1)
				->yields->isEqualTo(2)
				->yields->isEqualTo(3)
				->yields->isNull(4)
			->generator($generator())
				->size->isEqualTo(3)
		;
	}
```

all methods of the iterator asserter could be called on generator
the yields call returns a variable asserter on the yielded value.


see #641 