### PR TITLE
Asserter generator

### DIFF
--- a/classes/asserter/definition.php
+++ b/classes/asserter/definition.php
@@ -6,7 +6,6 @@ use mageekguy\atoum;
 
 interface definition
 {
-    public function __construct();
     public function setLocale(atoum\locale $locale = null);
     public function setGenerator(atoum\asserter\generator $generator = null);
     public function setWithTest(atoum\test $test);

--- a/classes/asserters/generator.php
+++ b/classes/asserters/generator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace mageekguy\atoum\asserters;
+
+use mageekguy\atoum\asserters\generator\asserterProxy;
+use mageekguy\atoum\exceptions
+;
+
+class generator extends iterator
+{
+    protected $lastYieldValue;
+    protected $lastRetunedValue;
+
+    public function __get($property)
+    {
+        switch (strtolower($property)) {
+            case 'yields':
+                $generator = $this->valueIsSet()->value;
+
+                $this->lastYieldValue = $generator->current();
+
+                $generator->next();
+
+                return $this;
+            case 'returns':
+                $generator = $this->valueIsSet()->value;
+
+                if (!method_exists($generator, 'getReturn')) {
+                    throw new exceptions\logic("The returns asserter could only be used with PHP>=7.0");
+                }
+
+                $this->lastRetunedValue = $generator->getReturn();
+
+                return $this;
+            default:
+                try {
+                    $asserter = $this->getGenerator()->getAsserterInstance($property);
+
+                    $setWithValue = (null !== $this->lastRetunedValue) ? $this->lastRetunedValue : $this->lastYieldValue;
+                    $asserter->setWith($setWithValue);
+
+                    return new asserterProxy($this, $asserter);
+                } catch (exceptions\logic\invalidArgument $e) {
+                    return parent::__get($property);
+                }
+        }
+    }
+
+    public function setWith($value)
+    {
+        parent::setWith($value);
+
+        if ($value instanceof \Generator) {
+            $this->pass();
+        } else {
+            $this->fail($this->_('%s is not a generator', $this));
+        }
+
+        return $this;
+    }
+}

--- a/classes/asserters/generator/asserterProxy.php
+++ b/classes/asserters/generator/asserterProxy.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace mageekguy\atoum\asserters\generator;
+
+use ArrayAccess;
+use mageekguy\atoum;
+use mageekguy\atoum\asserter\definition;
+
+class asserterProxy implements definition, ArrayAccess
+{
+    private $parent;
+
+    private $proxiedAsserter;
+
+    public function __construct(atoum\asserters\generator $parent, definition $proxiedAsserter)
+    {
+        $this->parent = $parent;
+        $this->proxiedAsserter = $proxiedAsserter;
+    }
+
+    public function __get($property)
+    {
+        switch (strtolower($property)) {
+            case 'yields':
+            case 'returns':
+                return $this->parent->__get($property);
+            default:
+                return $this->proxyfyAsserter($this->proxiedAsserter->{$property});
+        }
+    }
+
+    protected function proxyfyAsserter(definition $asserter)
+    {
+        return new self($this->parent, $asserter);
+    }
+
+    public function __call($name, $arguments)
+    {
+        $return = call_user_func_array([$this->proxiedAsserter, $name], $arguments);
+
+        if ($return instanceof definition) {
+            return $this->proxyfyAsserter($return);
+        }
+
+        return $return;
+    }
+
+    public function setLocale(atoum\locale $locale = null)
+    {
+        return $this->proxiedAsserter->setLocale($locale);
+    }
+
+    public function setGenerator(atoum\asserter\generator $generator = null)
+    {
+        return $this->setGenerator($generator);
+    }
+
+    public function setWithTest(atoum\test $test)
+    {
+        return $this->setWithTest($test);
+    }
+
+    public function setWith($mixed)
+    {
+        return $this->setWith($mixed);
+    }
+
+    public function setWithArguments(array $arguments)
+    {
+        return $this->setWithArguments($arguments);
+    }
+
+    protected function checkIfProxySupportsArrayAccess()
+    {
+        if (!$this->proxiedAsserter instanceof ArrayAccess) {
+            throw new \Exception(sprintf('Cannot use object of type %s as array', get_class($this->proxiedAsserter)));
+        }
+    }
+
+    public function offsetExists($offset)
+    {
+        $this->checkIfProxySupportsArrayAccess();
+        return $this->proxyfyAsserter($this->proxiedAsserter->offsetExists($offset));
+    }
+
+    public function offsetGet($offset)
+    {
+        $this->checkIfProxySupportsArrayAccess();
+        return $this->proxyfyAsserter($this->proxiedAsserter->offsetGet($offset));
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->checkIfProxySupportsArrayAccess();
+        return $this->proxyfyAsserter($this->proxiedAsserter->offsetSet($offset, $value));
+    }
+
+    public function offsetUnset($offset)
+    {
+        $this->checkIfProxySupportsArrayAccess();
+        return $this->proxyfyAsserter($this->proxiedAsserter->offsetUnset($offset));
+    }
+}

--- a/tests/functionals/classes/asserters/generator.php
+++ b/tests/functionals/classes/asserters/generator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace mageekguy\atoum\tests\functionals\asserters;
+
+use mageekguy\atoum
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class generator extends atoum\tests\functionals\test\functional
+{
+    /**
+     * @php >= 7.0
+     */
+    public function testUsage()
+    {
+        if (version_compare(PHP_VERSION, '7.0') >= 0) {
+            $generator = eval(<<<'PHP'
+return function() {
+    for ($i=0; $i<3; $i++) {
+        yield ($i+1);
+    }
+
+    return 42;
+};
+PHP
+            );
+        }
+
+        $this
+            ->generator($generator())
+                ->yields->variable->isEqualTo(1)
+                ->yields->variable->isEqualTo(2)
+                ->yields->variable->isEqualTo(3)
+                ->yields->variable->isNull()
+                ->returns->variable->isEqualTo(42)
+            ->generator($generator())
+                ->size->isEqualTo(3)
+        ;
+    }
+
+    /**
+     * @php >= 7.0
+     */
+    public function testUsageComplect()
+    {
+        if (version_compare(PHP_VERSION, '7.0') >= 0) {
+            $generator = eval(<<<'PHP'
+return function() {
+    yield [
+        "1", "2", "3"
+    ];
+
+    yield 0;
+    yield 0;
+
+    yield ["a" => 1, "b" => 2, "c" => 3];
+
+    return 42;
+};
+PHP
+            );
+        }
+
+        $this
+            ->generator($generator())
+                ->yields
+                    ->array
+                        ->isEqualTo(["1", "2", "3"])
+                        ->contains("1")
+                        ->string[0]->isEqualTo(1)
+                ->yields
+                    ->integer
+                        ->isZero()
+                ->yields
+                    ->integer
+                        ->isZero
+                ->yields
+                    ->array
+                        ->keys->isEqualTo(['a', 'b', 'c'])
+                ->yields
+                    ->variable->isNull
+                ->returns
+                    ->variable
+                        ->isEqualTo(42)
+        ;
+    }
+}

--- a/tests/units/classes/asserters/generator.php
+++ b/tests/units/classes/asserters/generator.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace mageekguy\atoum\tests\units\asserters;
+
+use mageekguy\atoum;
+use mageekguy\atoum\asserter;
+use mageekguy\atoum\tools\variable
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class generator extends atoum\test
+{
+    public function testClass()
+    {
+        $this->testedClass->extends('mageekguy\atoum\asserters\iterator');
+    }
+
+    public function test__construct()
+    {
+        $this
+            ->given($this->newTestedInstance)
+            ->then
+                ->object($this->testedInstance->getGenerator())->isEqualTo(new asserter\generator())
+                ->object($this->testedInstance->getAnalyzer())->isEqualTo(new variable\analyzer())
+                ->object($this->testedInstance->getLocale())->isEqualTo(new atoum\locale())
+                ->variable($this->testedInstance->getValue())->isNull()
+                ->boolean($this->testedInstance->wasSet())->isFalse()
+
+            ->given($this->newTestedInstance($generator = new asserter\generator(), $analyzer = new variable\analyzer(), $locale = new atoum\locale()))
+            ->then
+                ->object($this->testedInstance->getGenerator())->isIdenticalTo($generator)
+                ->object($this->testedInstance->getAnalyzer())->isIdenticalTo($analyzer)
+                ->object($this->testedInstance->getLocale())->isIdenticalTo($locale)
+                ->variable($this->testedInstance->getValue())->isNull()
+                ->boolean($this->testedInstance->wasSet())->isFalse()
+        ;
+    }
+
+    /**
+     * @php < 7.0
+     */
+    public function testReturnsBeforePhp7()
+    {
+        $generator = function () {
+            yield 1;
+            yield 2;
+        };
+
+        $this
+            ->assert('Use all yields then return')
+            ->given($asserter = $this->newTestedInstance
+                ->setLocale($locale = new \mock\atoum\locale())
+                ->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+            )
+            ->then
+            ->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+            ->when($yieldAsserter = $asserter->yields)
+                ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+            ->then($proxiedAsserter = $yieldAsserter->variable)
+                ->object($proxiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                ->integer($proxiedAsserter->getValue())->isEqualTo(1)
+
+            ->when($yieldAsserter = $asserter->yields)
+                ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+            ->then($proxiedAsserter = $yieldAsserter->variable)
+                ->object($proxiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                ->integer($proxiedAsserter->getValue())->isEqualTo(2)
+
+            ->exception(function () use ($asserter) {
+                $asserter->returns;
+            })
+                ->isInstanceOf('mageekguy\atoum\exceptions\logic')
+                ->hasMessage('The returns asserter could only be used with PHP>=7.0')
+        ;
+    }
+
+
+
+    /**
+     * @php >= 7.0
+     */
+    public function testReturns()
+    {
+        if (version_compare(PHP_VERSION, '7.0') >= 0) {
+            $generator = eval(<<<'PHP'
+return function() {
+    for ($i=0; $i<2; $i++) {
+        yield ($i+1);
+    }
+
+    return 42;
+};
+PHP
+            );
+        }
+
+        $this
+            ->assert('Use all yields then return')
+                ->given($asserter = $this->newTestedInstance
+                    ->setLocale($locale = new \mock\atoum\locale())
+                    ->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+                )
+                ->then
+                ->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+                ->when($yieldAsserter = $asserter->yields)
+                    ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator')
+                ->then($proxyfiedAsserter = $yieldAsserter->variable)
+                    ->object($proxyfiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                    ->integer($proxyfiedAsserter->getValue())->isEqualTo(1)
+
+                ->when($yieldAsserter = $asserter->yields)
+                    ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator')
+                ->then($proxyfiedAsserter = $yieldAsserter->variable)
+                    ->object($proxyfiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                    ->integer($proxyfiedAsserter->getValue())->isEqualTo(2)
+
+                ->when($returnedAsserter = $asserter->returns)
+                    ->object($returnedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator')
+                ->then($proxyfiedAsserter = $returnedAsserter->variable)
+                    ->object($proxyfiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                    ->integer($proxyfiedAsserter->getValue())->isEqualTo(42)
+
+            ->assert('Use return before all yields')
+                ->given($asserter = $this->newTestedInstance
+                    ->setLocale($locale = new \mock\atoum\locale())
+                    ->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+                )
+                ->then
+                    ->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+                ->when($yieldAsserter = $asserter->yields)
+                    ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator')
+                ->then($proxyfiedAsserter = $yieldAsserter->variable)
+                    ->integer($proxyfiedAsserter->getValue())->isEqualTo(1)
+
+
+                ->exception(
+                    function () use ($asserter) {
+                        $asserter->returns;
+                    }
+                )
+                    ->isInstanceOf('\Exception')
+                    ->hasMessage("Cannot get return value of a generator that hasn't returned")
+        ;
+    }
+
+    public function testYields()
+    {
+        $generator = function () {
+            for ($i=0; $i<10; $i++) {
+                yield ($i+1);
+            }
+        };
+
+        $this
+            ->given($asserter = $this->newTestedInstance
+                ->setLocale($locale = new \mock\atoum\locale())
+                ->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+            )
+            ->then
+                ->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+            ->when($yieldAsserter = $asserter->yields)
+                ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+            ->then($proxyfiedAsserter = $yieldAsserter->variable)
+                ->object($proxyfiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                ->integer($proxyfiedAsserter->getValue())->isEqualTo(1)
+
+            ->when($yieldAsserter = $asserter->yields)
+                ->object($yieldAsserter)->isInstanceOf('\mageekguy\atoum\asserters\variable')
+            ->then($proxyfiedAsserter = $yieldAsserter->variable)
+                ->object($proxyfiedAsserter)->isInstanceOf('\mageekguy\atoum\asserters\generator\asserterProxy')
+                ->integer($proxyfiedAsserter->getValue())->isEqualTo(2)
+        ;
+    }
+
+    public function testSetWith()
+    {
+        $generator = function () {
+            for ($i=0; $i<10; $i++) {
+                yield ($i+1);
+            }
+        };
+
+        $notAGenerator = function () {
+            for ($i=0; $i<10; $i++) {
+            }
+        };
+
+        $this
+            ->given($asserter = $this->newTestedInstance
+                ->setLocale($locale = new \mock\atoum\locale())
+                ->setAnalyzer($analyzer = new \mock\atoum\tools\variable\analyzer())
+            )
+            ->then
+                ->object($asserter->setWith($generator()))->isIdenticalTo($asserter)
+
+            ->then
+                ->exception(function () use ($asserter) {
+                    $asserter->setWith(true);
+                })
+                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
+                    ->hasMessage("boolean(true) is not an object")
+
+            ->then
+                ->exception(function () use ($asserter, $notAGenerator) {
+                    $asserter->setWith($notAGenerator());
+                })
+                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
+                    ->hasMessage("null is not an object")
+
+            ->then
+                ->exception(function () use ($asserter) {
+                    $asserter->setWith(new \stdClass());
+                })
+                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
+                    ->hasMessage("object(stdClass) is not an iterator")
+
+            ->then
+                ->exception(function () use ($asserter) {
+                    $asserter->setWith(new \ArrayIterator());
+                })
+                    ->isInstanceOf('mageekguy\atoum\asserter\exception')
+                    ->hasMessage("object(ArrayIterator) is not a generator")
+        ;
+    }
+}


### PR DESCRIPTION
new version of the generator asserter after the discussions on #661

it's a work in progress, the unit tests are not fixed, but the functional test works.

@Hywan @mikaelrandy @jubianchi what are your thoughts on that ?

with the code on the PR this test passes : 

``` php
    public function testUsage()
    {
        $generator = function() {
            for ($i=0; $i<3; $i++) {
                yield ($i+1);
            }

            return 42;
        };

        $this
            ->generator($generator())
                ->yields->variable->isEqualTo(1)
                ->yields->variable->isEqualTo(2)
                ->yields->variable->isEqualTo(3)
                ->yields->variable->isNull()
                ->returns->isEqualTo(42)
            ->generator($generator())
                ->size->isEqualTo(3)
        ;
    }

    public function testUsageComplect()
    {
        $generator = function() {
            yield [
                "1", "2", "3"
            ];

            yield 0;
            yield 0;

            yield ["a" => 1, "b" => 2, "c" => 3];

            return 42;
        };

        $this
            ->generator($generator())
                ->yields
                    ->array
                        ->isEqualTo(["1", "2", "3"])
                        ->contains("1")
                        ->string[0]->isEqualTo(1)
                ->yields
                    ->integer
                        ->isZero()
                ->yields
                    ->integer
                        ->isZero
                ->yields
                    ->array
                        ->keys->isEqualTo(['a', 'b', 'c'])
                ->yields
                    ->variable->isNull
                ->returns->isEqualTo(42)
        ;
    }
```
