### PR TITLE
Now, each mock instance may be unique, even if they are not identical.

### DIFF
--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -327,7 +327,7 @@ class generator
 
 			if ($this->eachInstanceIsUnique === true)
 			{
-				$mockedMethods .= "\t\t" . '$this->id = uniqid();' . PHP_EOL;
+				$mockedMethods .= self::generateUniqueId();
 			}
 
 			if (self::hasVariadic($constructor) === true)
@@ -786,7 +786,7 @@ class generator
 
 		if ($uniqueId === true)
 		{
-			$defaultConstructor .= "\t\t" . '$this->id = uniqid();' . PHP_EOL;
+			$defaultConstructor .= self::generateUniqueId();
 		}
 
 		$defaultConstructor .=
@@ -937,5 +937,10 @@ class generator
 			'while',
 			'xor',
 		);
+	}
+
+	private static function generateUniqueId()
+	{
+		return "\t\t" . '$this->{\'mock\' . uniqid()} = true;' . PHP_EOL;
 	}
 }

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -20,6 +20,7 @@ class generator
 	protected $allowUndefinedMethodsUsage = true;
 	protected $allIsInterface = false;
 	protected $testedClass = '';
+	protected $eachInstanceIsUnique = false;
 
 	private $defaultNamespace = null;
 
@@ -140,6 +141,13 @@ class generator
 		return $this;
 	}
 
+	public function eachInstanceIsUnique()
+	{
+		$this->eachInstanceIsUnique = true;
+
+		return $this;
+	}
+
 	public function testedClassIs($testedClass)
 	{
 		$this->testedClass = strtolower($testedClass);
@@ -173,7 +181,7 @@ class generator
 
 		if ($this->adapter->class_exists($class, true) === false && $this->adapter->interface_exists($class, true) === false)
 		{
-			$code = self::generateUnknownClassCode($class, $mockNamespace, $mockClass);
+			$code = self::generateUnknownClassCode($class, $mockNamespace, $mockClass, $this->eachInstanceIsUnique);
 		}
 		else
 		{
@@ -274,7 +282,7 @@ class generator
 
 		if ($constructor === null || $this->allIsInterface)
 		{
-			$mockedMethods .= self::generateDefaultConstructor();
+			$mockedMethods .= self::generateDefaultConstructor(false, $this->eachInstanceIsUnique);
 			$mockedMethodNames[] = '__construct';
 		}
 		else if ($constructor->isFinal() === false)
@@ -316,6 +324,11 @@ class generator
 
 			$mockedMethods .= PHP_EOL;
 			$mockedMethods .= "\t" . '{' . PHP_EOL;
+
+			if ($this->eachInstanceIsUnique === true)
+			{
+				$mockedMethods .= "\t\t" . '$this->id = uniqid();' . PHP_EOL;
+			}
 
 			if (self::hasVariadic($constructor) === true)
 			{
@@ -562,7 +575,7 @@ class generator
 
 		if ($hasConstructor === false)
 		{
-			$mockedMethods .= self::generateDefaultConstructor();
+			$mockedMethods .= self::generateDefaultConstructor(false, $this->eachInstanceIsUnique);
 			$mockedMethodNames[] = '__construct';
 		}
 
@@ -765,11 +778,18 @@ class generator
 		;
 	}
 
-	protected static function generateDefaultConstructor($disableMethodChecking = false)
+	protected static function generateDefaultConstructor($disableMethodChecking = false, $uniqueId = false)
 	{
 		$defaultConstructor =
 			"\t" . 'public function __construct(\\' . __NAMESPACE__ . '\\controller $mockController = null)' . PHP_EOL .
-			"\t" . '{' . PHP_EOL .
+			"\t" . '{' . PHP_EOL;
+
+		if ($uniqueId === true)
+		{
+			$defaultConstructor .= "\t\t" . '$this->id = uniqid();' . PHP_EOL;
+		}
+
+		$defaultConstructor .=
 			"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 			"\t\t" . '{' . PHP_EOL .
 			"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
@@ -824,13 +844,13 @@ class generator
 		;
 	}
 
-	protected static function generateUnknownClassCode($class, $mockNamespace, $mockClass)
+	protected static function generateUnknownClassCode($class, $mockNamespace, $mockClass, $uniqueId = false)
 	{
 		return 'namespace ' . ltrim($mockNamespace, '\\') . ' {' . PHP_EOL .
 			'final class ' . $mockClass . ' implements \\' . __NAMESPACE__ . '\\aggregator' . PHP_EOL .
 			'{' . PHP_EOL .
 			self::generateMockControllerMethods() .
-			self::generateDefaultConstructor(true) .
+			self::generateDefaultConstructor(true, $uniqueId) .
 			self::generate__call() .
 			self::generateGetMockedMethod(array('__call')) .
 			'}' . PHP_EOL .

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -3610,7 +3610,7 @@ class generator extends atoum\test
 					$this->getMockControllerMethods() .
 					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
 					"\t" . '{' . PHP_EOL .
-					"\t\t" . '$this->id = uniqid();' . PHP_EOL .
+					"\t\t" . '$this->{\'mock\' . uniqid()} = true;' . PHP_EOL .
 					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -3597,6 +3597,43 @@ class generator extends atoum\test
 		;
 	}
 
+	public function testGenerateWithEachInstanceIsUnique()
+	{
+		$this
+			->if($generator = new testedClass())
+			->and($generator->eachInstanceIsUnique())
+			->then
+				->string($generator->getMockedClassCode(__NAMESPACE__ . '\mockable'))->isEqualTo(
+					'namespace mock\\' . __NAMESPACE__ . ' {' . PHP_EOL .
+					'final class mockable extends \\' . __NAMESPACE__ . '\mockable implements \mageekguy\atoum\mock\aggregator' . PHP_EOL .
+					'{' . PHP_EOL .
+					$this->getMockControllerMethods() .
+					"\t" . 'public function __construct(\mageekguy\atoum\mock\controller $mockController = null)' . PHP_EOL .
+					"\t" . '{' . PHP_EOL .
+					"\t\t" . '$this->id = uniqid();' . PHP_EOL .
+					"\t\t" . 'if ($mockController === null)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$mockController = \mageekguy\atoum\mock\controller::get();' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+					"\t\t" . '{' . PHP_EOL .
+					"\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+					"\t\t" . '}' . PHP_EOL .
+					"\t" . '}' . PHP_EOL .
+					"\t" . 'public static function getMockedMethods()' . PHP_EOL .
+					"\t" . '{' . PHP_EOL .
+					"\t\t" . 'return ' . var_export(array('__construct'), true) . ';' . PHP_EOL .
+					"\t" . '}' . PHP_EOL .
+					'}' . PHP_EOL .
+					'}'
+				)
+		;
+	}
+
 	protected function getMockControllerMethods()
 	{
 		return
@@ -3700,6 +3737,10 @@ class generator extends atoum\test
 			'__halt_compiler',
 		);
 	}
+}
+
+class mockable
+{
 }
 
 if (version_compare(PHP_VERSION, '5.6.0', '>='))


### PR DESCRIPTION
Hi folks,

That made a very loooooong time, and i'm very happy to contribute once again to `atoum`.  
Maybe you can see this PR as a gift for Xmas, with all my love ;), because you do an awesome job.  
However, now that I have say that, i can say that this PR may be seems weird at first look, but… i have very good reasons to do it.  
So, this is a test:

```
$this
	->given(
		$output = new mockOfOutput,

		$outputOfBlock1 = new mockOfOutput,
		$block1 = new mockOfBlock,
		$this->calling($block1)->blockArgumentsAre = function($output, $recipient) use ($outputOfBlock1) {
			$recipient->outputIs($outputOfBlock1);
		},

		$outputOfBlock2 = new mockOfOutput,
		$outputOfBlock2->id = uniqid(),
		$block2 = new mockOfBlock,
		$this->calling($block2)->blockArgumentsAre = function($output, $recipient) use ($outputOfBlock2) {
			$recipient->outputIs($outputOfBlock2);
		}
	)
	->if(
		$this->newTestedInstance($output)
	)
	->then
		->object($this->testedInstance->blockCollectionIs(new block\collection($block1, $block2)))
			->isEqualTo($this->newTestedInstance($outputOfBlock2))
		->mock($block1)
			->receive('blockArgumentsAre')
				->withArguments($output)
					->once
		->mock($block2)
			->receive('blockArgumentsAre')
				->withArguments($outputOfBlock1)
					->once
;
```

This test is perfectly valid at first look, but… there is a trap!  
In this context, `$output` is ALWAYS strictly equal to `$outputOfBlock2`, so to be clear, `$output == $outputOfBlock2`.  
So, `$this->newTestedInstance($output) == $this->newTestedInstance($outputOfBlock2)`, and assertion `->isEqualTo($this->newTestedInstance($outputOfBlock2))` is ALWAYS true.  
So, if i'm using `$output` instead of `$outputOfBlock2` if in the tested code, the test will be… GREEN, and not RED, whereas there is a bug in the tested code!  
And in this context, it's not possible to use `->withIdenticalArguments` to check that the return value was built with the right instance of `output` class.   
The only trick is to add `$outputOfBlock2->id = uniqid();` after `$outputOfBlock2` instantiation to be able to differentiate it from `$output`.  
And it's exactly that this PR do, but automatically.  
However, this change can introduce BC breaks in some tests, and we don't like BC breaks.  
So, this ID is added in mock instances only if `mock\generator::eachInstanceIsUnique()` was called somewhere during test setup.  
Happy code review!