### PR TITLE
Fix bug in `mock\generator\allIsInterface()`.

### DIFF
--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -369,7 +369,7 @@ class generator
 				$mockedMethods .= "\t\t" . '{' . PHP_EOL;
 				$mockedMethods .= "\t\t\t" . '$this->getMockController()->addCall(\'' . $constructorName . '\', $arguments);' . PHP_EOL;
 
-				if ($this->shuntParentClassCalls === false)
+				if ($this->canCallParent())
 				{
 					$mockedMethods .= "\t\t\t" . 'call_user_func_array(\'parent::' . $constructorName . '\', $arguments);' . PHP_EOL;
 				}
@@ -437,7 +437,7 @@ class generator
 
 					$mockedMethods .= "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL;
 
-					if ($this->shuntParentClassCalls === false)
+					if ($this->canCallParent())
 					{
 						$mockedMethods .= "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL;
 						$mockedMethods .= "\t\t\t" . 'return $return;' . PHP_EOL;
@@ -701,6 +701,11 @@ class generator
 		}
 
 		return join(', ', $parameters);
+	}
+
+	protected function canCallParent()
+	{
+		return $this->shuntParentClassCalls === false && $this->allIsInterface === false;
 	}
 
 	protected static function getClassName($class)

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -872,8 +872,6 @@ class generator extends atoum\test
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->addCall(\'foo\', $arguments);' . PHP_EOL .
-					"\t\t\t" . '$return = call_user_func_array(\'parent::foo\', $arguments);' . PHP_EOL .
-					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public static function getMockedMethods()' . PHP_EOL .
@@ -1029,8 +1027,6 @@ class generator extends atoum\test
 					"\t\t" . 'else' . PHP_EOL .
 					"\t\t" . '{' . PHP_EOL .
 					"\t\t\t" . '$this->getMockController()->addCall(\'foo\', $arguments);' . PHP_EOL .
-					"\t\t\t" . '$return = call_user_func_array(\'parent::foo\', $arguments);' . PHP_EOL .
-					"\t\t\t" . 'return $return;' . PHP_EOL .
 					"\t\t" . '}' . PHP_EOL .
 					"\t" . '}' . PHP_EOL .
 					"\t" . 'public static function getMockedMethods()' . PHP_EOL .


### PR DESCRIPTION
Before this commit, if `mock\generator\allIsInterface()` was called and a class is mocked, the parent class will be called in each method.
However, if `mock\generator\allIsInterface()` was used, it's because all mocks MUST be generated as if their base class is an interface (even if the base class is not an interface).
And… an interface has no method's implementation, so, calling the parent in this contexte is a non-sense.
So, this commit remove call to `parent::` if `mock\generator\allIsInterface()` was called.