### PR TITLE
Fix how annotations are extracted. Only those actually starting with `@` are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * [#615](https://github.com/atoum/atoum/pull/615) Remove reserved keyword, replace void by blank ([@vonglasow])
 * [#643](https://github.com/atoum/atoum/pull/643) atoum now requires PHP `>=5.6.0` ([@jubianchi])
 
+## Bugfix
+
+* [#691](https://github.com/atoum/atoum/pull/691) Fix how annotations are extracted. Only those actually starting with `@` are handled ([@jubianchi])
+
 # 2.9.0 - 2017-02-11
 
 * [#667](https://github.com/atoum/atoum/pull/667) Assert on array values using `mageekguy\atoum\asserters\phpArray::$values` ([@krtek4])

--- a/classes/annotations/extractor.php
+++ b/classes/annotations/extractor.php
@@ -16,7 +16,13 @@ class extractor
             $comments = trim($comments);
 
             foreach (preg_split("/\r?\n/", $comments) as $comment) {
-                $cleanComment = ltrim($comment, "*@ \t\r\n\0\x0B");
+                $cleanComment = ltrim($comment, "* \t\r\n\0\x0B");
+
+                if (preg_match('/^@/', $cleanComment) === 0) {
+                    continue;
+                }
+
+                $cleanComment = ltrim($cleanComment, "@");
 
                 if ($cleanComment != $comment) {
                     $comment = preg_split("/\s+/", $cleanComment);

--- a/tests/functionals/classes/test/annotations/ignore.php
+++ b/tests/functionals/classes/test/annotations/ignore.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace mageekguy\atoum\tests\functionals\test\annotations;
+
+use mageekguy\atoum;
+
+require_once __DIR__ . '/../../../runner.php';
+
+/**
+ * @tags issue issue-684
+ */
+class ignore extends atoum\tests\functionals\test\functional
+{
+    /**
+     * @ignore
+     */
+    public function testShouldBeIgnoredWithOnlyIgnoreAnnotation()
+    {
+        throw new atoum\exceptions\runtime('This test should be ignored');
+    }
+
+    /**
+     * @ignore
+     * Ignore <- starting a comment with "Ignore" should not cause any problem
+     */
+    public function testShouldBeIgnoredWithCommentStartingWithIgnoreWord()
+    {
+        throw new atoum\exceptions\runtime('This test should be ignored');
+    }
+
+    /**
+     * @ignore
+     * Comment starting with anything else than "ignore" "Ignore" should not cause any problem
+     */
+    public function testShouldAlsoBeIgnored()
+    {
+        throw new atoum\exceptions\runtime('This test should be ignored');
+    }
+
+    /**
+     * ignore
+     * Alone, the "ignore" world should not mark the test as ignored
+     */
+    public function testShouldNotBeIgnored()
+    {
+        $this->string(uniqid());
+    }
+}

--- a/tests/functionals/test/functional.php
+++ b/tests/functionals/test/functional.php
@@ -10,4 +10,9 @@ class functional extends atoum\test
     {
         return '#(?:^|\\\)tests?\\\functionals?\\\#i';
     }
+
+    public function getTestedClassName()
+    {
+        return \stdClass::class;
+    }
 }


### PR DESCRIPTION
Closes #684