### PR TITLE
Change success foreground color to make it more constrasted

### DIFF
--- a/classes/reports/realtime/cli.php
+++ b/classes/reports/realtime/cli.php
@@ -91,8 +91,8 @@ class cli extends realtime
 
         $runnerResultField = new runner\result\cli();
         $runnerResultField
-            ->setSuccessColorizer(new colorizer('0;37', '42'))
-            ->setFailureColorizer(new colorizer('0;37', '41'))
+            ->setSuccessColorizer(new colorizer('1;30', '42'))
+            ->setFailureColorizer(new colorizer('1;37', '41'))
         ;
 
         $this->addField($runnerResultField);

--- a/classes/reports/realtime/cli/light.php
+++ b/classes/reports/realtime/cli/light.php
@@ -23,8 +23,8 @@ class light extends realtime
 
         $resultField = new runner\result\cli();
         $resultField
-            ->setSuccessColorizer(new colorizer('0;37', '42'))
-            ->setFailureColorizer(new colorizer('0;37', '41'))
+            ->setSuccessColorizer(new colorizer('1;30', '42'))
+            ->setFailureColorizer(new colorizer('1;37', '41'))
         ;
 
         $this->addField($resultField);

--- a/tests/units/classes/reports/realtime/cli.php
+++ b/tests/units/classes/reports/realtime/cli.php
@@ -65,8 +65,8 @@ class cli extends atoum\test
                 )
             ->define($runnerResultField = new fields\runner\result\cli())
                 ->and($runnerResultField
-                    ->setSuccessColorizer(new colorizer('0;37', '42'))
-                    ->setFailureColorizer(new colorizer('0;37', '41'))
+                    ->setSuccessColorizer(new colorizer('1;30', '42'))
+                    ->setFailureColorizer(new colorizer('1;37', '41'))
                 )
             ->define($runnerFailuresField = new fields\runner\failures\cli())
                 ->and($runnerFailuresField

--- a/tests/units/classes/reports/realtime/cli/light.php
+++ b/tests/units/classes/reports/realtime/cli/light.php
@@ -23,8 +23,8 @@ class light extends atoum\test
             ->define($eventField = new fields\runner\event\cli())
             ->define($resultField = new fields\runner\result\cli())
             ->define($resultField
-                ->setSuccessColorizer(new colorizer('0;37', '42'))
-                ->setFailureColorizer(new colorizer('0;37', '41'))
+                ->setSuccessColorizer(new colorizer('1;30', '42'))
+                ->setFailureColorizer(new colorizer('1;37', '41'))
             )
             ->define($failuresField = new fields\runner\failures\cli())
             ->define($failuresField


### PR DESCRIPTION
I always have a problem to easily read the success line because of the text color with present a low contrast with background (light-grey on green).
So I made a very minor change to make the text white.
I know this can be make with a configuration file (this is what I've done first locally), but as it concerns accessibilty of atoum, I think it may be more usefull as a change inside atoum itself.