### PR TITLE
Asserters/Stream::isWritten and Asserters/Stream::isRead can be used w/o brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # `dev-master`
 
-# [#701](https://github.com/atoum/atoum/pull/701) Mock generator supports `strict_types` ([@jubianchi])
+* [#705](https://github.com/atoum/atoum/pull/705) Stream asserter now has isRead and isWritten assertion (without brackets) ([@guiled])
+* [#701](https://github.com/atoum/atoum/pull/701) Mock generator supports `strict_types` ([@jubianchi])
 
 ## Bugfix
 
-# [#701](https://github.com/atoum/atoum/pull/701) Mock generator correctly handles `void` return type ([@jubianchi])
+* [#701](https://github.com/atoum/atoum/pull/701) Mock generator correctly handles `void` return type ([@jubianchi])
 
 # 3.0.0 - 2017-02-22
 
@@ -246,3 +247,4 @@
 [@oxman]: https://github.com/blackprism
 [@mvrhov]: https://github.com/mvrhov
 [@krtek4]: https://github.com/krtek4
+[@guiled]: https://github.com/guiled

--- a/classes/asserters/stream.php
+++ b/classes/asserters/stream.php
@@ -10,6 +10,17 @@ class stream extends atoum\asserter
 {
     protected $streamController = null;
 
+    public function __get($property)
+    {
+        switch (strtolower($property)) {
+            case 'isread':
+            case 'iswritten':
+                return $this->{$property}();
+            default:
+                return parent::__get($property);
+        }
+    }
+
     public function setWith($stream)
     {
         parent::setWith($stream);

--- a/tests/units/classes/asserters/stream.php
+++ b/tests/units/classes/asserters/stream.php
@@ -84,6 +84,7 @@ class stream extends atoum\test
                     file_get_contents('atoum://' . $streamName);
                 })
                     ->object($asserter->isRead())->isIdenticalTo($asserter)
+                    ->object($asserter->isRead)->isIdenticalTo($asserter)
         ;
     }
 
@@ -124,6 +125,7 @@ class stream extends atoum\test
                 file_put_contents('atoum://' . $streamName, $contents);
             })
                 ->object($asserter->isWritten())->isIdenticalTo($asserter)
+                ->object($asserter->isWritten)->isIdenticalTo($asserter)
 
             ->if(
                 $streamController = atoum\mock\stream::get(uniqid()),


### PR DESCRIPTION
I made this PR in order to be consistent with isWritten and isRead like other asserters (ie Boolean::isTrue …)