### PR TITLE
Add sorting to file loading in phing task to unify behaviour

### DIFF
--- a/resources/phing/AtoumTask.php
+++ b/resources/phing/AtoumTask.php
@@ -95,6 +95,8 @@ class AtoumTask extends task
             }
         }
 
+        sort($files);
+
         return $files;
     }
 


### PR DESCRIPTION
The order of files inclusion during a phing check was left to the filesystem, which could lead to inconsistent behaviour when the same tests were run on different systems (as an example, an error caused by a "name already in use" can go undetected by someone and break tests for another, if the first files were included in a way that prevented the error)

This PR aims to make the order of files inclusion the same across all users of the project.

As a side note, it would be great if this could be backported to the 2.x branch