### PR TITLE
fix(autoloader) Remove a cache warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#726](https://github.com/atoum/atoum/pull/726) Remove an autoloader cache warning ([@hywan])
 * [#723](https://github.com/atoum/atoum/pull/724) `object` is a reserved keyword as of PHP 7.2 ([@trasher])
 * [#713](https://github.com/atoum/atoum/pull/713) Results are folded on Travis CI ([@jubianchi])
 * [#709](https://github.com/atoum/atoum/pull/709) Exception asserter now has `isInstanceOf` without parenthesis ([@guiled])

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -329,14 +329,18 @@ class autoloader
     protected function readCache()
     {
         if ($this->cacheUsed === false) {
-            $cacheContents = @file_get_contents($this->getCacheFileForInstance());
+            $cacheFile = $this->getCacheFileForInstance();
 
-            if ($cacheContents !== false) {
-                $cacheContents = @unserialize($cacheContents) ?: null;
-            }
+            if (file_exists($cacheFile) === true) {
+                $cacheContents = file_get_contents($cacheFile);
 
-            if (is_array($cacheContents) === true && isset($cacheContents['version']) === true && $cacheContents['version'] === static::version) {
-                $this->classes = $cacheContents['classes'];
+                if ($cacheContents !== false) {
+                    $cacheContents = @unserialize($cacheContents) ?: null;
+                }
+
+                if (is_array($cacheContents) === true && isset($cacheContents['version']) === true && $cacheContents['version'] === static::version) {
+                    $this->classes = $cacheContents['classes'];
+                }
             }
 
             $this->cacheUsed = true;


### PR DESCRIPTION
Remove a warning if the cache file is missing by using a simple `file_exists` instead of `@`.

Fix https://github.com/hoaproject/Kitab/issues/9.