### PR TITLE
backport a feature to 2.x : load order of files in phing task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#720](https://github.com/atoum/atoum/pull/720) Add sorting to file loading in phing task to unify behaviour  ([@gbouchez])
+
 # 2.9.1 - 2017-07-19
 
 ## Bugfix

--- a/constants.php
+++ b/constants.php
@@ -6,7 +6,7 @@ if (defined(__NAMESPACE__ . '\running') === false)
 {
 	define(__NAMESPACE__ . '\running', true);
 	define(__NAMESPACE__ . '\directory', __DIR__);
-	define(__NAMESPACE__ . '\version', preg_replace('/\$Rev: ([^ ]+) \$/', '$1', '$Rev: 2.9.1 $'));
+	define(__NAMESPACE__ . '\version', preg_replace('/\$Rev: ([^ ]+) \$/', '$1', '$Rev: dev-master $'));
 	define(__NAMESPACE__ . '\author', 'Frédéric Hardy');
 	define(__NAMESPACE__ . '\mail', 'support@atoum.org');
 	define(__NAMESPACE__ . '\repository', 'http://www.atoum.org/atoum');

--- a/resources/phing/AtoumTask.php
+++ b/resources/phing/AtoumTask.php
@@ -101,6 +101,8 @@ class atoumTask extends task
 			}
 		}
 
+        sort($files);
+
 		return $files;
 	}
 

--- a/resources/phing/AtoumTask.php
+++ b/resources/phing/AtoumTask.php
@@ -101,7 +101,7 @@ class atoumTask extends task
 			}
 		}
 
-        sort($files);
+		sort($files);
 
 		return $files;
 	}


### PR DESCRIPTION
Add sorting to file loading in phing task to unify behaviour (backport to 2.9.X)