### PR TITLE
fix: Make the exit code consistent with the result bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#733](https://github.com/atoum/atoum/pull/733) Uncompleted methods make atoum exit with an error code ([@jubianchi])
 * [#734](https://github.com/atoum/atoum/pull/734) The `exception::isInstanceOf` asserter correctly works with interfaces ([@jubianchi])
 * [#731](https://github.com/atoum/atoum/pull/731) Remove dependency on `ext-session` ([@jubianchi], [@hywan])
 

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -651,13 +651,11 @@ class runner extends atoum\script\configurable
 
                             exit(3);
                         }
-                    }
-                        );
+                    });
 
                     try {
                         $score = $autorunner->run()->getRunner()->getScore();
-
-                        $isSuccess = $score->getFailNumber() <= 0 && $score->getErrorNumber() <= 0 && $score->getExceptionNumber() <= 0;
+                        $isSuccess = $score->getFailNumber() <= 0 && $score->getErrorNumber() <= 0 && $score->getExceptionNumber() <= 0 && $score->getUncompletedMethodNumber() <= 0;
 
                         if ($autorunner->shouldFailIfVoidMethods() && $score->getVoidMethodNumber() > 0) {
                             $isSuccess = false;


### PR DESCRIPTION
Red bar means the exit code should be greater than 0

Green bar means the exit code should be 0

Closes #732