### PR TITLE
fix: The exception::isInstanceOf asserter correctly works with interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#734](https://github.com/atoum/atoum/pull/734) The `exception::isInstanceOf` asserter correctly works with interfaces ([@jubianchi])
 * [#731](https://github.com/atoum/atoum/pull/731) Remove dependency on `ext-session` ([@jubianchi], [@hywan])
 
 # 3.1.1 - 2017-07-19

--- a/classes/asserters/exception.php
+++ b/classes/asserters/exception.php
@@ -63,7 +63,7 @@ class exception extends phpObject
         try {
             $this->check($value, __FUNCTION__);
         } catch (\logicException $exception) {
-            if (self::classExists($value) === false || (strtolower(ltrim($value, '\\')) !== 'exception' && is_subclass_of($value, version_compare(PHP_VERSION, '7.0.0') >= 0 ? 'throwable' : 'exception') === false)) {
+            if (self::classExists($value) === false || self::isThrowableClass($value) === false) {
                 throw new exceptions\logic\invalidArgument('Argument of ' . __METHOD__ . '() must be a \exception instance or an exception class name');
             }
         }
@@ -143,6 +143,13 @@ class exception extends phpObject
 
     private static function isThrowable($value)
     {
-        return $value instanceof \exception || (version_compare(PHP_VERSION, '7.0.0') >= 0 && $value instanceof \throwable);
+        return $value instanceof \exception || (version_compare(PHP_VERSION, '7.0.0') >= 0 && ($value instanceof \throwable));
+    }
+
+    private static function isThrowableClass($value)
+    {
+        return strtolower(ltrim($value, '\\')) === 'exception' ||
+            (version_compare(PHP_VERSION, '7.0.0') >= 0 && strtolower(ltrim($value, '\\')) === 'throwable') ||
+            is_subclass_of($value, version_compare(PHP_VERSION, '7.0.0') >= 0 ? 'throwable' : 'exception');
     }
 }

--- a/tests/units/classes/asserters/exception.php
+++ b/tests/units/classes/asserters/exception.php
@@ -6,6 +6,14 @@ namespace
         class throwable
         {
         }
+    } else {
+        interface throwableExtended extends throwable
+        {
+        }
+
+        class exceptionExtended extends exception implements throwableExtended
+        {
+        }
     }
 }
 
@@ -150,6 +158,21 @@ namespace mageekguy\atoum\tests\units\asserters
                     })
                         ->isInstanceOf(atoum\asserter\exception::class)
                         ->hasMessage($failMessage)
+            ;
+        }
+
+        /** @php >= 7.0.0 */
+        public function testIsInstanceOfPhpGte7()
+        {
+            $this
+                ->given($this->newTestedInstance
+                    ->setLocale($locale = new \mock\atoum\locale())
+                )
+                ->if($this->testedInstance->setWith(new \exception()))
+                ->then
+                    ->object($this->testedInstance->isInstanceOf(\throwable::class))
+                ->if($this->testedInstance->setWith(new \exceptionExtended()))
+                    ->object($this->testedInstance->isInstanceOf(\throwableExtended::class))
             ;
         }
 


### PR DESCRIPTION
Any interface extending the native throwable interface will be accepted as an argument

Closes #730