### PR TITLE
feat: Display clear errors when mocking function fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#736](https://github.com/atoum/atoum/pull/736) Display clear errors when mocking function fails ([@jubianchi])
 * [#737](https://github.com/atoum/atoum/pull/737) Command line switches override configuration file directives ([@jubianchi])
 * [#733](https://github.com/atoum/atoum/pull/733) Uncompleted methods make atoum exit with an error code ([@jubianchi])
 * [#734](https://github.com/atoum/atoum/pull/734) The `exception::isInstanceOf` asserter correctly works with interfaces ([@jubianchi])

--- a/classes/php/mocker/funktion.php
+++ b/classes/php/mocker/funktion.php
@@ -3,14 +3,15 @@
 namespace mageekguy\atoum\php\mocker;
 
 use mageekguy\atoum;
-use mageekguy\atoum\exceptions;
 use mageekguy\atoum\php\mocker;
+use mageekguy\atoum\test\exceptions;
 
 class funktion extends mocker
 {
     public function __construct($defaultNamespace = '')
     {
         parent::__construct($defaultNamespace);
+
         $this->setReflectedFunctionFactory();
     }
 
@@ -55,13 +56,16 @@ class funktion extends mocker
         $fqdn = $this->getFqdn($functionName);
 
         if ($this->functionExists($fqdn) === false) {
-            if (function_exists($fqdn) === true) {
-                throw new exceptions\logic\invalidArgument('Function \'' . $fqdn . '\' already exists');
-            }
-
             $lastAntislash = strrpos($fqdn, '\\');
             $namespace = substr($fqdn, 0, $lastAntislash);
-            $function = substr($fqdn, $lastAntislash + 1);
+            $function = substr($fqdn, $lastAntislash > 0 ? $lastAntislash + 1 : 0);
+
+            if (function_exists($fqdn) === true) {
+                $message = $namespace === '' ? 'This may be because you are trying to mock a function from a class in the root namespace.' : 'This may be because a function with the same name already exists in the namespace \'' . $namespace . '\'.';
+
+                throw new exceptions\runtime('The function you are trying to mock already exists: \'' . $function . '\'. ' . $message);
+            }
+
             $reflectedFunction = $this->buildReflectedFunction($function);
             static::defineMockedFunction($namespace, get_class($this), $function, $reflectedFunction);
         }

--- a/tests/units/classes/php/mocker/funktion.php
+++ b/tests/units/classes/php/mocker/funktion.php
@@ -127,16 +127,20 @@ class funktion extends atoum\test
                 ->exception(function () use ($mocker) {
                     $mocker->generate(__NAMESPACE__ . '\doesSomething');
                 })
-                    ->isInstanceof(atoum\exceptions\logic\invalidArgument::class)
-                    ->hasMessage('Function \'' . __NAMESPACE__ . '\doesSomething\' already exists')
-
+                    ->isInstanceof(atoum\test\exceptions\runtime::class)
+                    ->hasMessage('The function you are trying to mock already exists: \'doesSomething\'. This may be because a function with the same name already exists in the namespace \''.__NAMESPACE__.'\'.')
+                ->exception(function () use ($mocker) {
+                    $mocker->generate('version_compare');
+                })
+                    ->isInstanceof(atoum\test\exceptions\runtime::class)
+                    ->hasMessage('The function you are trying to mock already exists: \'version_compare\'. This may be because you are trying to mock a function from a class in the root namespace.')
             ->if($this->testedInstance->{$functionName} = $returnValue = uniqid())
             ->then
                 ->string(version_compare(uniqid(), uniqid()))->isEqualTo($returnValue)
                 ->object($this->testedInstance->generate($functionName = __NAMESPACE__ . '\version_compare'))->isIdenticalTo($this->testedInstance)
                 ->boolean(version_compare('5.4.0', '5.3.0'))->isFalse()
                 ->boolean(version_compare('5.3.0', '5.4.0'))->isTrue()
-                ->object($this->testedInstance->generate($unknownFunctionName = __NAMESPACE__ . '\\foo'))->isIdenticalTo($this->testedInstance)
+                ->object($this->testedInstance->generate($unknownFunctionName = __NAMESPACE__ . '\foo'))->isIdenticalTo($this->testedInstance)
                 ->variable(foo())->isNull()
 
             ->if($this->testedInstance->{$unknownFunctionName} = $fooReturnValue = uniqid())


### PR DESCRIPTION
This is to avoid question like the one in #725

Closes #735