### PR TITLE
feat: Avoid many allocations in error report

### DIFF
--- a/classes/report/fields/runner/errors/cli.php
+++ b/classes/report/fields/runner/errors/cli.php
@@ -128,9 +128,7 @@ class cli extends report\fields\runner\errors
                         PHP_EOL
                     ;
 
-                    foreach (explode(PHP_EOL, $error['message']) as $line) {
-                        $string .= $line . PHP_EOL;
-                    }
+                    $string .= $error['message'] . PHP_EOL;
                 }
             }
         }


### PR DESCRIPTION
When appending the stack trace of the error, the algorithm splits the
stack trace by line, and adds each line to the final error message.

In this situation, it is simpler to append the whole stack trace
directly without splitting it into an array, iterating over it, and
appending each item. The result is strictly the same but without memory
allocations and probably reallocations.