### PR TITLE
add a way to assert on mocks arguments

### DIFF
--- a/classes/asserters/adapter/call.php
+++ b/classes/asserters/adapter/call.php
@@ -225,6 +225,42 @@ abstract class call extends atoum\asserter
         return $this;
     }
 
+    public function onceAndCheckFirstCallArguments(callable $test, $failMessage = null)
+    {
+        return $this->exactlyAndCheckFirstCallArguments($test, 1, $failMessage);
+    }
+
+    public function twiceAndCheckFirstCallArguments(callable $test, $failMessage = null)
+    {
+        return $this->exactlyAndCheckFirstCallArguments($test,2, $failMessage);
+    }
+
+    public function thriceAndCheckFirstCallArguments(callable $test, $failMessage = null)
+    {
+        return $this->exactlyAndCheckFirstCallArguments($test,3, $failMessage);
+    }
+
+    public function exactlyAndCheckFirstCallArguments(callable $test, $number, $failMessage = null)
+    {
+        $this->exactly($number, $failMessage);
+
+        /** @var \mageekguy\atoum\test\adapter\calls $calls */
+        $calls = $this->callIsSet()->adapter->getCalls($this->call, $this->identicalCall);
+
+        $callsArray = $calls->toArray();
+
+        /** @var \mageekguy\atoum\test\adapter\call $call */
+        $call = $callsArray[1];
+
+        if (!isset($callsArray[1])) {
+            $this->fail("Call not found");
+        }
+
+        $test(array_values($call->getArguments()));
+
+        return $this;
+    }
+
     public function never($failMessage = null)
     {
         return $this->exactly(0, $failMessage);

--- a/tests/functionals/classes/asserters/mock.php
+++ b/tests/functionals/classes/asserters/mock.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace mageekguy\atoum\tests\functionals\asserters;
+
+use mageekguy\atoum
+;
+
+require_once __DIR__ . '/../../runner.php';
+
+class objectAMocker
+{
+    public function run($test) {
+
+    }
+}
+
+class mock extends atoum\tests\functionals\test\functional
+{
+    public function testUsage()
+    {
+        $mock = new \mock\mageekguy\atoum\tests\functionals\asserters\objectAMocker();
+        $mock->run('42', ['aaa']);
+        //$mock->run('42', ['aaa']);
+        $this
+            ->mock($mock)
+                ->call('run')
+                ->onceAndCheckFirstCallArguments(function($arguments) {
+                    $this
+                        ->string($arguments[0])
+                            ->isEqualTo('42')
+                            ->hasLength(2)
+                        ->array($arguments[1])
+                            ->hasSize(1)
+                    ;
+                })
+
+        ;
+    }
+}


### PR DESCRIPTION
It would be usefull to run assertions on mock arguments,
like that we would be able to check for example a format like a datetime
and not the exact value.

Here is how it could look like :

```php
  $mock = new \mock\mageekguy\atoum\tests\functionals\asserters\objectAMocker();
  $mock->run('42', ['aaa']);
  $this
      ->mock($mock)
          ->call('run')
          ->onceAndCheckFirstCallArguments(function($arguments) {
              $this
                  ->string($arguments[0])
                      ->isEqualTo('42')
                      ->hasLength(2)
              ;
          })
;
```

There would be the same methods as usual but with a callback, and this callback has as first argument an array with the arguments passed to the asserted method. In this callback, the user will be able to do any assertion he needs.

This PR is not finished (for example unit tests are missing), it's a first draft to discuss how
 we could do that.

//cc @brunoroux for the original user need