### PR TITLE
feat: Assert on mock arguments

### DIFF
--- a/classes/asserters/adapter.php
+++ b/classes/asserters/adapter.php
@@ -54,6 +54,11 @@ class adapter extends call
         return $this->withAtLeastArguments([]);
     }
 
+    public function verify(callable $verify)
+    {
+        return $this->setVerify($verify);
+    }
+
     protected function adapterIsSet()
     {
         try {

--- a/classes/asserters/adapter/call.php
+++ b/classes/asserters/adapter/call.php
@@ -312,6 +312,7 @@ abstract class call extends atoum\asserter
             ->call
                 ->setFunction($function)
                 ->unsetArguments()
+                ->unsetverify()
         ;
 
         $this->beforeCalls = [];
@@ -328,6 +329,7 @@ abstract class call extends atoum\asserter
             ->setTrace()
             ->call
                 ->setArguments($arguments)
+                ->unsetverify()
         ;
 
         $this->identicalCall = false;
@@ -343,6 +345,37 @@ abstract class call extends atoum\asserter
             ->setTrace()
             ->call
                 ->unsetArguments()
+        ;
+
+        $this->identicalCall = false;
+
+        return $this;
+    }
+
+    protected function setVerify(callable $verify)
+    {
+        $this
+            ->adapterIsSet()
+            ->callIsSet()
+            ->setTrace()
+            ->call
+                ->setVerify($verify)
+                ->unsetArguments()
+        ;
+
+        $this->identicalCall = false;
+
+        return $this;
+    }
+
+    protected function unsetVerify()
+    {
+        $this
+            ->adapterIsSet()
+            ->callIsSet()
+            ->setTrace()
+            ->call
+                ->unsetVerify()
         ;
 
         $this->identicalCall = false;

--- a/classes/test.php
+++ b/classes/test.php
@@ -486,9 +486,7 @@ abstract class test implements observable, \countable
             ->setHandler('if', $returnTest)
             ->setHandler('and', $returnTest)
             ->setHandler('then', $returnTest)
-            ->setHandler('given', function () use ($returnTest) {
-                return $returnTest();
-            })
+            ->setHandler('given', $returnTest)
             ->setMethodHandler('define', $returnTest)
             ->setMethodHandler('let', $returnTest)
         ;

--- a/classes/test/adapter/calls.php
+++ b/classes/test/adapter/calls.php
@@ -128,7 +128,7 @@ class calls implements \countable, \arrayAccess, \iteratorAggregate
     {
         $innerCalls = $this->getCalls($call);
 
-        if ($call->getArguments() !== null) {
+        if ($call->getArguments() !== null || $call->getVerify() !== null) {
             $innerCalls = array_filter($innerCalls, function ($innerCall) use ($call) {
                 return $call->isEqualTo($innerCall);
             });

--- a/tests/units/classes/asserter/resolver.php
+++ b/tests/units/classes/asserter/resolver.php
@@ -4,8 +4,7 @@ namespace mageekguy\atoum\tests\units\asserter;
 
 require __DIR__ . '/../../runner.php';
 
-use atoum
-;
+use atoum;
 
 class resolver extends atoum
 {


### PR DESCRIPTION
In #741 @agallou proposed something to test mock arguments in a more convenient way.

This reminded me about #254 which I could not get merged (too much conflicts to resolve at some point).

I propose an alternative implementation [here](https://github.com/atoum/atoum/pull/741#issuecomment-332015867). This PR provides the implementation for this proposal.

```php
<?php

namespace {
    class bar {
        public function foo($a) {}
    }
}

namespace tests\units {
    use atoum;

    class bar extends atoum {
        public function testLogout()
        {
            $this
                ->given($mock = new \mock\bar())
                ->when($mock->foo([$a = uniqid()]))
                ->then
                    ->mock($mock)->call('foo')->withArguments($this->args->array->string[0]->isEqualTo($a))->once
            ;
        }
    }
}
```