### PR TITLE
fix: CLI commands are correctly escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#734](https://github.com/atoum/atoum/pull/734) The `exception::isInstanceOf` asserter correctly works with interfaces ([@jubianchi])
 * [#731](https://github.com/atoum/atoum/pull/731) Remove dependency on `ext-session` ([@jubianchi], [@hywan])
 
+## Bugfix
+
+* [#746](https://github.com/atoum/atoum/pull/746) CLI commands are correctly escaped ([@agallou], [@jubianchi])
+
 # 3.1.1 - 2017-07-19
 
 ## Bugfix

--- a/classes/cli/command.php
+++ b/classes/cli/command.php
@@ -34,7 +34,7 @@ class command
             $command .= ' ' . $option;
 
             if ($value !== null) {
-                $command .= ' ' . $value;
+                $command .= ' ' . escapeshellarg($value);
             }
         }
 
@@ -55,7 +55,7 @@ class command
         if (self::osIsWindows() === true) {
             $command = '"' . $this->binaryPath . '"' . $command;
         } else {
-            $command = escapeshellcmd($this->binaryPath . $command);
+            $command = escapeshellcmd($this->binaryPath) . $command;
         }
 
         return $command;

--- a/tests/units/classes/php.php
+++ b/tests/units/classes/php.php
@@ -42,13 +42,13 @@ class php extends atoum\test
                 ->castToString($php)->isEqualTo((defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '"' : escapeshellcmd($php->getBinaryPath())) . ' ' . escapeshellcmd($option1))
             ->if($php->addOption($option2 = uniqid(), $option2Value = uniqid() . ' ' . uniqid()))
             ->then
-                ->castToString($php)->isEqualTo((defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '"' : escapeshellcmd($php->getBinaryPath())) . ' ' . escapeshellcmd($option1 . ' ' . $option2 . ' ' . $option2Value))
+                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value .'"' : $php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\'')
             ->if($php->addArgument($argument1 = uniqid()))
             ->then
-                ->castToString($php)->isEqualTo((defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '"' : escapeshellcmd($php->getBinaryPath())) . ' ' . escapeshellcmd($option1 . ' ' . $option2 . ' ' . $option2Value . ' -- ' . $argument1))
+                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value.'" -- ' . $argument1 : $php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\' -- ' . $argument1)
             ->if($php->addArgument($argument2 = uniqid(), $argument2Value = uniqid()))
             ->then
-                ->castToString($php)->isEqualTo((defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '"' : escapeshellcmd($php->getBinaryPath())) . ' ' . escapeshellcmd($option1 . ' ' . $option2 . ' ' . $option2Value . ' -- ' . $argument1 . ' ' . $argument2) . ' ' . (defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $argument2Value . '"': escapeshellarg($argument2Value)))
+                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value.'" -- ' . $argument1 . ' ' . $argument2 . ' "' . $argument2Value . '"' : $php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\' -- ' . $argument1 . ' ' . $argument2 . ' \'' . $argument2Value . '\'')
         ;
     }
 


### PR DESCRIPTION
Closes #677, Closes #699, Closes #446