### PR TITLE
feat: Add an os annotation to only run tests on specific OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#752](https://github.com/atoum/atoum/pull/752) Add an os annotation to only run tests on specific OS ([@jubianchi])
 * [#585](https://github.com/atoum/atoum/pull/585) Memory usage is based on the peak & real allocations ([@hywan])
 * [#740](https://github.com/atoum/atoum/pull/740) String asserter now has `notMatches` assertion ([@fvilpoix])
 

--- a/tests/units/classes/php.php
+++ b/tests/units/classes/php.php
@@ -31,24 +31,51 @@ class php extends atoum\test
         ;
     }
 
+    /**
+     * @os !windows !winnt
+     */
     public function test__toString()
     {
         $this
             ->if($php = new testedClass())
             ->then
-                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '"' : escapeshellcmd($php->getBinaryPath()))
+                ->castToString($php)->isEqualTo(escapeshellcmd($php->getBinaryPath()))
             ->if($php->addOption($option1 = uniqid()))
             ->then
-                ->castToString($php)->isEqualTo((defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '"' : escapeshellcmd($php->getBinaryPath())) . ' ' . escapeshellcmd($option1))
+                ->castToString($php)->isEqualTo(escapeshellcmd($php->getBinaryPath()) . ' ' . escapeshellcmd($option1))
             ->if($php->addOption($option2 = uniqid(), $option2Value = uniqid() . ' ' . uniqid()))
             ->then
-                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value .'"' : $php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\'')
+                ->castToString($php)->isEqualTo($php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\'')
             ->if($php->addArgument($argument1 = uniqid()))
             ->then
-                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value.'" -- ' . $argument1 : $php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\' -- ' . $argument1)
+                ->castToString($php)->isEqualTo($php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\' -- ' . $argument1)
             ->if($php->addArgument($argument2 = uniqid(), $argument2Value = uniqid()))
             ->then
-                ->castToString($php)->isEqualTo(defined('PHP_WINDOWS_VERSION_MAJOR') === true ? '"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value.'" -- ' . $argument1 . ' ' . $argument2 . ' "' . $argument2Value . '"' : $php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\' -- ' . $argument1 . ' ' . $argument2 . ' \'' . $argument2Value . '\'')
+                ->castToString($php)->isEqualTo($php->getBinaryPath() . ' ' . $option1 . ' ' . $option2 . ' \'' . $option2Value.'\' -- ' . $argument1 . ' ' . $argument2 . ' \'' . $argument2Value . '\'')
+        ;
+    }
+
+    /**
+     * @os windows winnt
+     */
+    public function test__toStringWindows()
+    {
+        $this
+            ->if($php = new testedClass())
+            ->then
+                ->castToString($php)->isEqualTo('"' . $php->getBinaryPath() . '"')
+            ->if($php->addOption($option1 = uniqid()))
+            ->then
+                ->castToString($php)->isEqualTo('"' . $php->getBinaryPath() . '" ' . escapeshellcmd($option1))
+            ->if($php->addOption($option2 = uniqid(), $option2Value = uniqid() . ' ' . uniqid()))
+            ->then
+                ->castToString($php)->isEqualTo('"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value .'"')
+            ->if($php->addArgument($argument1 = uniqid()))
+            ->then
+                ->castToString($php)->isEqualTo('"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value.'" -- ' . $argument1)
+            ->if($php->addArgument($argument2 = uniqid(), $argument2Value = uniqid()))
+            ->then
+                ->castToString($php)->isEqualTo('"' . $php->getBinaryPath() . '" ' . $option1 . ' ' . $option2 . ' "' . $option2Value.'" -- ' . $argument1 . ' ' . $argument2 . ' "' . $argument2Value . '"')
         ;
     }
 

--- a/tests/units/classes/test.php
+++ b/tests/units/classes/test.php
@@ -28,6 +28,10 @@ namespace mageekguy\atoum
         {
         }
     }
+
+    class osRestricted
+    {
+    }
 }
 
 namespace mageekguy\atoum\mock\mageekguy\atoum
@@ -138,6 +142,31 @@ namespace mageekguy\atoum\tests\units
             $this->setTestedClassName('mageekguy\atoum\withStatic');
 
             parent::__construct();
+        }
+    }
+
+    /**
+     * @ignore on
+     * @os Foo
+     */
+    class osRestricted extends atoum\test
+    {
+        public function testMethod1()
+        {
+        }
+
+        /**
+         * @os bar
+         */
+        public function testMethod2()
+        {
+        }
+
+        /**
+         * @os !foo
+         */
+        public function testMethod3()
+        {
         }
     }
 
@@ -1382,6 +1411,34 @@ namespace mageekguy\atoum\tests\units
                         ->isInstanceOf(\mock\mageekguy\atoum\dummy::class)
                         ->isInstanceOf(atoum\dummy::class)
                     ->object($mock->getMockController())->isIdenticalTo($controller)
+            ;
+        }
+
+        public function testGetClassSupportedOs()
+        {
+            $this
+                ->if($test = new osRestricted())
+                ->then
+                    ->array($test->getClassSupportedOs())
+                        ->string[0]->isEqualTo('foo')
+                ->if($test = new emptyTest())
+                ->then
+                    ->array($test->getClassSupportedOs())->isEmpty
+            ;
+        }
+
+        public function testGetMethodSupportedOs()
+        {
+            $this
+                ->if($test = new osRestricted())
+                ->then
+                    ->array($test->getMethodSupportedOs())
+                        ->array['testMethod1']->isEqualTo(['foo'])
+                        ->array['testMethod2']->isEqualTo(['foo', 'bar'])
+                        ->array['testMethod3']->isEqualTo(['!foo'])
+                    ->array($test->getMethodSupportedOs('testMethod1'))->isEqualTo(['foo'])
+                    ->array($test->getMethodSupportedOs('testMethod2'))->isEqualTo(['foo', 'bar'])
+                    ->array($test->getMethodSupportedOs('testMethod3'))->isEqualTo(['!foo'])
             ;
         }
     }


### PR DESCRIPTION
Here is an example :

```php
namespace tests\units
{
    /**
     * @os !darwin
     */
    class stdClass extends \mageekguy\atoum\test
    {
        /**
         * @os linux
         */
        public function testOnlyOnLinux()
        {

        }

        /**
         * @os !linux
         */
        public function testEverywhereButLinuxAndDarwin()
        {

        }
    }
}
```