### PR TITLE
fix(runner) Use error reporting level to exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#757](https://github.com/atoum/atoum/pull/757) Take the error reporting level into account to exit the runner ([@hywan])
 * [#752](https://github.com/atoum/atoum/pull/752) Add an os annotation to only run tests on specific OS ([@jubianchi])
 * [#585](https://github.com/atoum/atoum/pull/585) Memory usage is based on the peak & real allocations ([@hywan])
 * [#740](https://github.com/atoum/atoum/pull/740) String asserter now has `notMatches` assertion ([@fvilpoix])

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -688,7 +688,9 @@ class runner extends atoum\script\configurable
             register_shutdown_function(function () use (& $autorunner, $calledClass) {
                 if ($autorunner instanceof $calledClass) {
                     set_error_handler(function ($error, $message, $file, $line) use ($autorunner) {
-                        if (error_reporting() !== 0) {
+                        $errorReporting = error_reporting();
+
+                        if ($errorReporting !== 0 && $errorReporting & $error) {
                             $autorunner->writeError($message . ' in ' . $file . ' at line ' . $line, $error);
 
                             exit(3);


### PR DESCRIPTION
The error reporting level can exclude some error levels. Take this into account before exiting the runner.