### PR TITLE
feat(asserter) Normalize the asserter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master`
 
+* [#771](https://github.com/atoum/atoum/pull/771) Normalize and simplify the asserter name when a test case fails ([@hywan])
 * [#754](https://github.com/atoum/atoum/pull/754) Add the dot report ([@jubianchi])
 * [#769](https://github.com/atoum/atoum/pull/769) CLI: Align options to the left, and increase contrast ([@hywan])
 * [#770](https://github.com/atoum/atoum/pull/770) Fix path to the runner for the help ([@hywan])

--- a/classes/asserter/exception.php
+++ b/classes/asserter/exception.php
@@ -31,15 +31,14 @@ class exception extends \runtimeException
                 }
             }
 
-            $asserterName = strtolower(get_class($asserter));
-
-            if ('mageekguy\atoum\asserters\\' === substr($asserterName, 0, 26)) {
-                $asserterName = substr($asserterName, 26);
-            }
-
-            if (0 !== preg_match('/^php./', $asserterName)) {
-                $asserterName = substr($asserterName, 3);
-            }
+            $asserterName = preg_replace(
+                [
+                    '/^' . preg_quote('mageekguy\atoum\asserters\\') . '/',
+                    '/^php(?=.)/'
+                ],
+                '',
+                strtolower(get_class($asserter))
+            );
 
             $code = $test->getScore()->addFail($file, $class, $method, $line, $asserterName . ($function ? '::' . $function : '') . '()', $message);
         }

--- a/classes/asserter/exception.php
+++ b/classes/asserter/exception.php
@@ -31,7 +31,17 @@ class exception extends \runtimeException
                 }
             }
 
-            $code = $test->getScore()->addFail($file, $class, $method, $line, get_class($asserter) . ($function ? '::' . $function : '') . '()', $message);
+            $asserterName = strtolower(get_class($asserter));
+
+            if ('mageekguy\atoum\asserters\\' === substr($asserterName, 0, 26)) {
+                $asserterName = substr($asserterName, 26);
+            }
+
+            if (0 !== preg_match('/^php./', $asserterName)) {
+                $asserterName = substr($asserterName, 3);
+            }
+
+            $code = $test->getScore()->addFail($file, $class, $method, $line, $asserterName . ($function ? '::' . $function : '') . '()', $message);
         }
 
         parent::__construct($message, $code);


### PR DESCRIPTION
Fix #765.

  * Remove the `mageekguy\atoum\asserters` prefix if it exists,
  * Remove the `php` prefix is it exists.