### PR TITLE
fix(script) Directory is the current working directory

### DIFF
--- a/classes/script.php
+++ b/classes/script.php
@@ -46,11 +46,7 @@ abstract class script
 
     public function getDirectory()
     {
-        $directory = $this->adapter->dirname($this->getName());
-
-        if ($this->adapter->is_dir($directory) === false) {
-            $directory = $this->adapter->getcwd();
-        }
+        $directory = $this->adapter->getcwd();
 
         return rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }

--- a/tests/units/classes/script.php
+++ b/tests/units/classes/script.php
@@ -623,14 +623,6 @@ class script extends atoum\test
         $this
             ->given($script = new mock\script($name = uniqid()))
             ->and($script->setAdapter($adapter = new atoum\test\adapter()))
-            ->and($adapter->is_dir = true)
-            ->and($adapter->dirname = $directory = uniqid())
-            ->then
-                ->string($script->getDirectory())->isEqualTo($directory . DIRECTORY_SEPARATOR)
-            ->if($adapter->dirname = $directory . DIRECTORY_SEPARATOR)
-            ->then
-                ->string($script->getDirectory())->isEqualTo($directory . DIRECTORY_SEPARATOR)
-            ->if($adapter->is_dir = false)
             ->and($adapter->getcwd = $currentDirectory = uniqid())
             ->then
                 ->string($script->getDirectory())->isEqualTo($currentDirectory . DIRECTORY_SEPARATOR)

--- a/tests/units/classes/script/configurable.php
+++ b/tests/units/classes/script/configurable.php
@@ -117,14 +117,6 @@ class configurable extends atoum\test
             ->and($this->calling($configurable)->useConfigFile = function () {
             })
             ->and($configurable->setAdapter($adapter = new atoum\test\adapter()))
-            ->and($adapter->is_dir = true)
-            ->then
-                ->object($configurable->useDefaultConfigFiles())->isIdenticalTo($configurable)
-                ->mock($configurable)
-                    ->foreach(testedClass::getSubDirectoryPath($directory), function ($mock, $path) {
-                        $mock->call('useConfigFile')->withArguments($path . testedClass::defaultConfigFile)->atLeastOnce();
-                    })
-            ->if($adapter->is_dir = false)
             ->and($adapter->getcwd = $workingDirectory = uniqid() . DIRECTORY_SEPARATOR . uniqid() . DIRECTORY_SEPARATOR . uniqid())
             ->then
                 ->object($configurable->useDefaultConfigFiles())->isIdenticalTo($configurable)
@@ -132,7 +124,6 @@ class configurable extends atoum\test
                     ->foreach(testedClass::getSubDirectoryPath($workingDirectory), function ($mock, $path) {
                         $mock->call('useConfigFile')->withArguments($path . testedClass::defaultConfigFile)->atLeastOnce();
                     })
-            ->if($adapter->is_dir = true)
             ->and($adapter->getcwd = $otherWorkingDirectory = uniqid() . DIRECTORY_SEPARATOR . uniqid() . DIRECTORY_SEPARATOR . uniqid())
             ->and($this->calling($configurable)->useConfigFile->throw = new atoum\includer\exception())
             ->then

--- a/tests/units/classes/scripts/git/pusher.php
+++ b/tests/units/classes/scripts/git/pusher.php
@@ -31,7 +31,7 @@ class pusher extends atoum
             ->if($pusher = new testedClass(__FILE__))
             ->then
                 ->string($pusher->getRemote())->isEqualTo(testedClass::defaultRemote)
-                ->string($pusher->getTagFile())->isEqualTo(__DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultTagFile)
+                ->string($pusher->getTagFile())->isEqualTo(getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultTagFile)
                 ->object($pusher->getTaggerEngine())->isEqualTo(new scripts\tagger\engine())
                 ->string($pusher->getWorkingDirectory())->isEqualTo(getcwd())
                 ->object($pusher->getGit())->isEqualTo(new commands\git())
@@ -58,7 +58,7 @@ class pusher extends atoum
                 ->object($pusher->setTagFile($tagFile = uniqid()))->isIdenticalTo($pusher)
                 ->string($pusher->getTagFile())->isEqualTo($tagFile)
                 ->object($pusher->setTagFile())->isIdenticalTo($pusher)
-                ->string($pusher->getTagFile())->isEqualTo(__DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultTagFile)
+                ->string($pusher->getTagFile())->isEqualTo(getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultTagFile)
         ;
     }
 

--- a/tests/units/classes/scripts/phar/stub.php
+++ b/tests/units/classes/scripts/phar/stub.php
@@ -116,6 +116,9 @@ class stub extends atoum\test
         ;
     }
 
+    /**
+     * @engine inline
+     */
     public function testVersion()
     {
         $this

--- a/tests/units/classes/scripts/runner.php
+++ b/tests/units/classes/scripts/runner.php
@@ -820,8 +820,8 @@ class runner extends atoum\test
                         ->withArguments('Default bootstrap file \'' . testedClass::defaultBootstrapFile . '\' was successfully created in ' . $runner->getDirectory())->once()
                 ->adapter($adapter)
                     ->call('copy')
-                        ->withArguments(atoum\directory . '/resources/configurations/runner/atoum.php.dist', __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile)->once()
-                        ->withArguments(atoum\directory . '/resources/configurations/runner/bootstrap.php.dist', __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultBootstrapFile)->once()
+                        ->withArguments(atoum\directory . '/resources/configurations/runner/atoum.php.dist', getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile)->once()
+                        ->withArguments(atoum\directory . '/resources/configurations/runner/bootstrap.php.dist', getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultBootstrapFile)->once()
             ->if($this->resetAdapter($adapter))
             ->and($this->resetMock($outputWriter))
             ->then
@@ -853,8 +853,8 @@ class runner extends atoum\test
                         ->withArguments('Default bootstrap file \'' . testedClass::defaultBootstrapFile . '\' was successfully created in ' . $runner->getDirectory())->once()
                 ->adapter($adapter)
                     ->call('copy')
-                        ->withArguments(atoum\directory . '/resources/configurations/runner/atoum.php.dist', __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile)->once()
-                        ->withArguments(atoum\directory . '/resources/configurations/runner/bootstrap.php.dist', __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultBootstrapFile)->once()
+                        ->withArguments(atoum\directory . '/resources/configurations/runner/atoum.php.dist', getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile)->once()
+                        ->withArguments(atoum\directory . '/resources/configurations/runner/bootstrap.php.dist', getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultBootstrapFile)->once()
             ->if($this->resetAdapter($adapter))
             ->and($this->resetMock($outputWriter))
             ->and($this->resetMock($prompt))
@@ -872,8 +872,8 @@ class runner extends atoum\test
                         ->withArguments('Default bootstrap file \'' . testedClass::defaultBootstrapFile . '\' was successfully created in ' . $runner->getDirectory())->never()
                 ->adapter($adapter)
                     ->call('copy')
-                        ->withArguments(atoum\directory . '/resources/configurations/runner/atoum.php.dist', __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile)->never()
-                        ->withArguments(atoum\directory . '/resources/configurations/runner/bootstrap.php.dist', __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultBootstrapFile)->never()
+                        ->withArguments(atoum\directory . '/resources/configurations/runner/atoum.php.dist', getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile)->never()
+                        ->withArguments(atoum\directory . '/resources/configurations/runner/bootstrap.php.dist', getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultBootstrapFile)->never()
             ->if($this->resetAdapter($adapter))
             ->and($this->resetMock($outputWriter))
             ->and($this->resetMock($prompt))
@@ -900,7 +900,7 @@ class runner extends atoum\test
                     $runner->init();
                 })
                     ->isInstanceOf(atoum\exceptions\runtime::class)
-                    ->hasMessage('Unable to write \'' . atoum\directory . '/resources/configurations/runner/atoum.php.dist\' to \'' . __DIR__ . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile . '\'')
+                    ->hasMessage('Unable to write \'' . atoum\directory . '/resources/configurations/runner/atoum.php.dist\' to \'' . getcwd() . DIRECTORY_SEPARATOR . testedClass::defaultConfigFile . '\'')
         ;
     }
 


### PR DESCRIPTION
Explicitely use the current working directory the script directory.

This behavior was already present before, but a bug fix (see #770) has revealed this other bug.

The script directory must not rely on the script name (which is defined in the `atoum` binary by the `atoum\scripts\runner` constant). The script name points to the binary name most of the time (it is the case right now), but the script directory is the user current working directory, they are not related.