### PR TITLE
fix(writers) `file::clear` rewinds the internal pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bugfix
 
+* [#781](https://github.com/atoum/atoum/pull/781) The `file` writer rewinds the internal pointer of the resource when clearing ([@hywan])
 * [#756](https://github.com/atoum/atoum/pull/756) Configuration, autoloader and bootstrap files are correctly loaded when using the PHAR ([@jubianchi])
 * [#755](https://github.com/atoum/atoum/pull/755) String asserter's failure messages are clear ([@jubianchi])
 * [#773](https://github.com/atoum/atoum/pull/773) Directory is the current working directory ([@hywan])

--- a/classes/writers/file.php
+++ b/classes/writers/file.php
@@ -33,6 +33,8 @@ class file extends atoum\writer implements writers\realtime, writers\asynchronou
             throw new exceptions\runtime('Unable to truncate file \'' . $this->filename . '\'');
         }
 
+        $this->adapter->rewind($this->resource);
+
         return $this;
     }
 

--- a/tests/units/classes/writers/file.php
+++ b/tests/units/classes/writers/file.php
@@ -51,6 +51,7 @@ class file extends atoum\test
             ->and($adapter->fopen = $resource = uniqid())
             ->and($adapter->flock = true)
             ->and($adapter->ftruncate = true)
+            ->and($adapter->rewind = true)
             ->and($adapter->fwrite = function ($resource, $data) {
                 return strlen($data);
             })
@@ -83,6 +84,7 @@ class file extends atoum\test
             ->and($adapter->fopen = $resource = uniqid())
             ->and($adapter->flock = true)
             ->and($adapter->ftruncate = true)
+            ->and($adapter->rewind = true)
             ->and($adapter->fflush = function () {
             })
             ->and($adapter->fclose = function () {
@@ -137,6 +139,7 @@ class file extends atoum\test
             ->if($file = new testedClass(null, $adapter))
             ->and($adapter->flock = true)
             ->and($adapter->ftruncate = true)
+            ->and($adapter->rewind = true)
             ->and($adapter->fclose = function () {
             })
             ->and($adapter->fwrite = false)
@@ -203,6 +206,7 @@ class file extends atoum\test
                     ->call('fopen')->withArguments($file->getFilename(), 'c')->once()
                     ->call('flock')->withArguments($resource, LOCK_EX)->once()
             ->if($adapter->ftruncate = true)
+            ->and($adapter->rewind = true)
             ->then
                 ->object($file->clear())->isIdenticalTo($file)
                 ->adapter($adapter)
@@ -210,6 +214,27 @@ class file extends atoum\test
                     ->call('ftruncate')->withArguments($resource, 0)
                         ->after($this->adapter($adapter)->call('flock')->withArguments($resource, LOCK_EX))
                             ->twice()
+                    ->call('rewind')->withArguments($resource)->once()
+        ;
+    }
+
+    public function testRewindWhenClearing()
+    {
+        $this
+            ->if($uri = stream_get_meta_data(tmpfile())['uri'])
+            ->and($file = new testedClass($uri))
+            ->and($file->write('foobar'))
+            ->then
+                ->integer(strlen(file_get_contents($uri)))
+                    ->isEqualTo(6)
+            ->and($file->clear())
+            ->then
+                ->integer(strlen(file_get_contents($uri)))
+                    ->isZero()
+            ->and($file->write('foobar'))
+            ->then
+                ->integer(strlen(file_get_contents($uri)))
+                    ->isEqualTo(6)
         ;
     }
 }


### PR DESCRIPTION
When the file is truncated, its internal pointer must be rewinded to the
beginning.

To see the bug, remove the `rewind` call in the `file::clear` method.

And yes, the test is not really a unit test, but it's not a real integration test neither. The bug was present because everything has been mocked, and the real operations have not been tested.

I can auto-merge the PR since I'm pretty confident, but if anyone would like to review it, it'll be welcome :-). cc @atoum/core 