### PR TITLE
like for exception, now output can use assertion directly

### DIFF
--- a/classes/asserters/output.php
+++ b/classes/asserters/output.php
@@ -19,7 +19,11 @@ class output extends phpString
     {
         if ($value instanceof \closure) {
             ob_start();
-            $value($this->getTest());
+            if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+                $value($this->getTest());
+            } else {
+                $value();
+            }
             $value = ob_get_clean();
         } elseif ($value === null && ob_get_level() > 0) {
             $value = ob_get_clean();


### PR DESCRIPTION
Instead of writing this:
```php
$this
    ->output(function(atoum\test $test) { 
        $test->testedInstance->doSomethingAndEcho();
    })
;
```
we can now write this:

```php
$this
    ->output(function() { 
        $this->testedInstance->doSomethingAndEcho();
    })
;
```