### PR TITLE
Use spaces indentation in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,65 +1,65 @@
 {
-	"name": "atoum/atoum",
-	"type": "library",
-	"description": "Simple modern and intuitive unit testing framework for PHP 5.3+",
-	"keywords": ["TDD","atoum","test","unit testing"],
-	"homepage": "http://www.atoum.org",
-	"license": "BSD-3-Clause",
-	"authors":
-	[
-		{
-			"name": "Frédéric Hardy",
-			"email": "frederic.hardy@atoum.org",
-			"homepage": "http://blog.mageekbox.net"
-		},
-		{
-			"name": "François Dussert",
-			"email": "francois.dussert@atoum.org"
-		},
-		{
-			"name": "Gérald Croes",
-			"email": "gerald.croes@atoum.org"
-		},
-		{
-			"name": "Julien Bianchi",
-			"email": "julien.bianchi@atoum.org"
-		},
-		{
-			"name": "Ludovic Fleury",
-			"email": "ludovic.fleury@atoum.org"
-		}
-	],
-	"require":
-	{
-		"php": "^5.6.0 || ^7.0.0 <7.4.0",
-		"ext-hash": "*",
-		"ext-json": "*",
-		"ext-tokenizer": "*",
-		"ext-xml": "*"
-	},
-	"require-dev":
-	{
-		"friendsofphp/php-cs-fixer": "^2"
-	},
-	"replace": {
-		"mageekguy/atoum": "*"
-	},
-	"bin":
-	[
-		"bin/atoum"
-	],
-	"autoload":
-	{
-		"classmap": [ "classes/" ]
-	},
-	"suggest": {
-		"ext-mbstring": "Provides support for UTF-8 strings",
-		"atoum/stubs": "Provides IDE support (like autocompletion) for atoum",
-		"ext-xdebug": "Provides code coverage report (>= 2.3)"
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "3.x-dev"
-		}
-	}
+    "name": "atoum/atoum",
+    "type": "library",
+    "description": "Simple modern and intuitive unit testing framework for PHP 5.3+",
+    "keywords": ["TDD","atoum","test","unit testing"],
+    "homepage": "http://www.atoum.org",
+    "license": "BSD-3-Clause",
+    "authors":
+    [
+        {
+            "name": "Frédéric Hardy",
+            "email": "frederic.hardy@atoum.org",
+            "homepage": "http://blog.mageekbox.net"
+        },
+        {
+            "name": "François Dussert",
+            "email": "francois.dussert@atoum.org"
+        },
+        {
+            "name": "Gérald Croes",
+            "email": "gerald.croes@atoum.org"
+        },
+        {
+            "name": "Julien Bianchi",
+            "email": "julien.bianchi@atoum.org"
+        },
+        {
+            "name": "Ludovic Fleury",
+            "email": "ludovic.fleury@atoum.org"
+        }
+    ],
+    "require":
+    {
+        "php": "^5.6.0 || ^7.0.0 <7.4.0",
+        "ext-hash": "*",
+        "ext-json": "*",
+        "ext-tokenizer": "*",
+        "ext-xml": "*"
+    },
+    "require-dev":
+    {
+        "friendsofphp/php-cs-fixer": "^2"
+    },
+    "replace": {
+        "mageekguy/atoum": "*"
+    },
+    "bin":
+    [
+        "bin/atoum"
+    ],
+    "autoload":
+    {
+        "classmap": [ "classes/" ]
+    },
+    "suggest": {
+        "ext-mbstring": "Provides support for UTF-8 strings",
+        "atoum/stubs": "Provides IDE support (like autocompletion) for atoum",
+        "ext-xdebug": "Provides code coverage report (>= 2.3)"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Hello, this patch is a CS fix to move from tabs to spaces. In case of `composer.json` files mostly 4 spaces are used in PHP OS projects...

Thanks for considering checking this out or merging it.