### PR TITLE
Use relative path to find tag file

### DIFF
--- a/classes/script.php
+++ b/classes/script.php
@@ -51,6 +51,17 @@ abstract class script
         return rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }
 
+    public function getRelativeDirectory()
+    {
+        $directory = $this->adapter->dirname($this->getName());
+
+        if ($this->adapter->is_dir($directory) === false) {
+            $directory = $this->adapter->getcwd();
+        }
+
+        return rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+
     public function setAdapter(adapter $adapter = null)
     {
         $this->adapter = $adapter ?: new adapter();

--- a/classes/scripts/git/pusher.php
+++ b/classes/scripts/git/pusher.php
@@ -58,7 +58,7 @@ class pusher extends script\configurable
         if ($tagFile !== null) {
             $tagFile = (string) $tagFile;
         } else {
-            $tagFile = $this->getDirectory() . self::defaultTagFile;
+            $tagFile = $this->getRelativeDirectory() . self::defaultTagFile;
         }
 
         $this->tagFile = $tagFile;

--- a/tests/units/classes/script.php
+++ b/tests/units/classes/script.php
@@ -638,4 +638,26 @@ class script extends atoum\test
                 ->string($script->getDirectory())->isEqualTo($currentDirectory . DIRECTORY_SEPARATOR)
         ;
     }
+
+    public function testGetRelativeDirectory()
+    {
+        $this
+            ->given($script = new mock\script($name = uniqid()))
+            ->and($script->setAdapter($adapter = new atoum\test\adapter()))
+            ->and($adapter->is_dir = true)
+            ->and($adapter->dirname = $directory = uniqid())
+            ->then
+                ->string($script->getRelativeDirectory())->isEqualTo($directory . DIRECTORY_SEPARATOR)
+            ->if($adapter->dirname = $directory . DIRECTORY_SEPARATOR)
+            ->then
+                ->string($script->getRelativeDirectory())->isEqualTo($directory . DIRECTORY_SEPARATOR)
+            ->if($adapter->is_dir = false)
+            ->and($adapter->getcwd = $directory = uniqid())
+            ->then
+                ->string($script->getRelativeDirectory())->isEqualTo($directory . DIRECTORY_SEPARATOR)
+            ->and($adapter->getcwd = $directory . DIRECTORY_SEPARATOR)
+            ->then
+                ->string($script->getRelativeDirectory())->isEqualTo($directory . DIRECTORY_SEPARATOR)
+        ;
+     }
 }


### PR DESCRIPTION
Fix #799 

Since #773, the `scripts/git/pusher.php` is not able to read the `scripts/git/.tag` file as default directory is not relative to the local script, but where the user is.

This PR add a new `getRelativeDirectory` method with the previous behavior of `getDirectory` to allow this script to work as previously. 