### PR TITLE
Fix  deprecated. unparenthesized (php 7.4)

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -207,7 +207,7 @@ class autoloader
         }
 
         if (static::exists($realClass) === true) {
-            $alias = ($realClass !== $class ? $class : $this->getClassAlias($realClass) ?: $this->getNamespaceAlias($realClass));
+            $alias = ($realClass !== $class ? $class : ($this->getClassAlias($realClass) ?: $this->getNamespaceAlias($realClass)));
 
             if ($alias !== null) {
                 class_alias($realClass, $alias);

--- a/classes/includer.php
+++ b/classes/includer.php
@@ -55,7 +55,7 @@ class includer
         $this->adapter->restore_error_handler();
 
         if (count($this->errors) > 0) {
-            $realpath = parse_url($this->path, PHP_URL_SCHEME) !== null ? $this->path : realpath($this->path) ?: $this->path;
+            $realpath = (parse_url($this->path, PHP_URL_SCHEME) !== null ? $this->path : (realpath($this->path) ?: $this->path));
 
             if (in_array($realpath, $this->adapter->get_included_files(), true) === false) {
                 throw new includer\exception('Unable to include \'' . $this->path . '\'');

--- a/classes/iterators/recursives/atoum/source.php
+++ b/classes/iterators/recursives/atoum/source.php
@@ -43,7 +43,7 @@ class source implements \outerIterator
 
     public function key()
     {
-        return ($this->pharDirectory === null ? $this->innerIterator->key() : preg_replace('#^(:[^:]+://)?' . preg_quote($this->sourceDirectory, '#') . '#', $this->pharDirectory, $this->innerIterator->current()) ?: null);
+        return ($this->pharDirectory === null ? $this->innerIterator->key() : (preg_replace('#^(:[^:]+://)?' . preg_quote($this->sourceDirectory, '#') . '#', $this->pharDirectory, $this->innerIterator->current()) ?: null));
     }
 
     public function next()


### PR DESCRIPTION
Fix following issue with php 7.4:
```
Fix Unparenthesized `a ? b : c ?: d` is deprecated. Use either `(a ? b : c) ?: d` or `a ? b : (c ?: d)`
``