### PR TITLE
Add method `doNotReceiveAnyMessage` to mock asserter.

### DIFF
--- a/classes/asserters/adapter/call.php
+++ b/classes/asserters/adapter/call.php
@@ -38,6 +38,7 @@ abstract class call extends atoum\asserter
             case 'atleastonce':
             case 'wascalled':
             case 'wasnotcalled':
+            case 'notreceiveanymessage':
                 return $this->{$property}();
 
             default:

--- a/classes/asserters/mock.php
+++ b/classes/asserters/mock.php
@@ -25,6 +25,11 @@ class mock extends adapter
         return $this->call($function);
     }
 
+    public function notReceiveAnyMessage($failMessage = null)
+	 {
+	 	 return $this->wasNotCalled($failMessage ?: $this->_('%s receive some messages', $this->adapterIsSet()->adapter->getMockClass()));
+	 }
+
     public function wasCalled($failMessage = null)
     {
         if ($this->adapterIsSet()->adapter->getCallsNumber() > 0) {

--- a/tests/units/classes/asserters/mock.php
+++ b/tests/units/classes/asserters/mock.php
@@ -265,6 +265,52 @@ class mock extends atoum\test
         ;
     }
 
+    public function testNotReceiveAnyMessage()
+    {
+        $this
+            ->if($asserter = $this->newTestedInstance)
+                ->then
+                    ->exception(function () use ($asserter) {
+                        $asserter->notReceiveAnyMessage();
+                    })
+                        ->isInstanceOf(atoum\exceptions\logic::class)
+                        ->hasMessage('Mock is undefined')
+            ->if(
+                $asserter
+                    ->setWith($mock = new \mock\foo($controller = new \mock\atoum\mock\controller()))
+                    ->setLocale($locale = new \mock\atoum\locale()),
+                $this->calling($locale)->_ = $wasCalled = uniqid(),
+                $this->calling($controller)->getCallsNumber = rand(1, PHP_INT_MAX),
+                $this->calling($controller)->getMockClass = $mockClass = uniqid()
+            )
+            ->then
+                ->exception(function () use ($asserter) {
+                    $asserter->notReceiveAnyMessage();
+                })
+                    ->isInstanceOf(atoum\asserter\exception::class)
+                    ->hasMessage($wasCalled)
+                ->mock($locale)->call('_')->withArguments('%s receive some messages', $mockClass)->once
+
+                ->exception(function () use ($asserter) {
+                    $asserter->notReceiveAnyMessage();
+                })
+                    ->hasMessage($wasCalled)
+                    ->isInstanceOf(atoum\asserter\exception::class)
+                ->mock($locale)->call('_')->withArguments('%s receive some messages', $mockClass)->twice
+
+                ->exception(function () use ($asserter, & $failMessage) {
+                    $asserter->notReceiveAnyMessage($failMessage = uniqid());
+                })
+                    ->isInstanceOf(atoum\asserter\exception::class)
+                    ->hasMessage($failMessage)
+
+            ->if($this->calling($controller)->getCallsNumber = 0)
+            ->then
+                ->object($asserter->notReceiveAnyMessage())->isIdenticalTo($asserter)
+                ->object($asserter->notReceiveAnyMessage)->isIdenticalTo($asserter)
+        ;
+    }
+
     public function testWithArguments()
     {
         $this


### PR DESCRIPTION
There is a method `wasNotCalled` but no respective method with the "message" semantic.  
So, this PR add it.