### PR TITLE
Handle usage of assertions in `test::afterTestMethod()`

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -1281,6 +1281,7 @@ abstract class test implements observable, \countable
                     }
                 }
 
+                $testException = null;
                 try {
                     ob_start();
 
@@ -1407,9 +1408,13 @@ abstract class test implements observable, \countable
                 } catch (\exception $exception) {
                     $this->score->addOutput($this->path, $this->class, $this->currentMethod, ob_get_clean());
 
-                    throw $exception;
+                    $testException = $exception;
                 } finally {
                     $this->callAfterTestMethod($this->currentMethod);
+
+                    if ($testException) {
+                        throw $testException;
+                    }
                 }
             } catch (asserter\exception $exception) {
                 foreach ($this->executeOnFailure as $closure) {

--- a/classes/test.php
+++ b/classes/test.php
@@ -1408,6 +1408,8 @@ abstract class test implements observable, \countable
                     $this->score->addOutput($this->path, $this->class, $this->currentMethod, ob_get_clean());
 
                     throw $exception;
+                } finally {
+                    $this->callAfterTestMethod($this->currentMethod);
                 }
             } catch (asserter\exception $exception) {
                 foreach ($this->executeOnFailure as $closure) {
@@ -1433,8 +1435,6 @@ abstract class test implements observable, \countable
             } catch (\exception $exception) {
                 $this->addExceptionToScore($exception);
             }
-
-            $this->callAfterTestMethod($this->currentMethod);
 
             $this->currentMethod = null;
 

--- a/classes/test.php
+++ b/classes/test.php
@@ -1410,10 +1410,17 @@ abstract class test implements observable, \countable
 
                     $testException = $exception;
                 } finally {
-                    $this->callAfterTestMethod($this->currentMethod);
+                    $afterTestException = null;
+                    try {
+                        $this->callAfterTestMethod($this->currentMethod);
+                    } catch (\exception $exception) {
+                        $afterTestException = $exception;
+                    }
 
-                    if ($testException) {
+                    if ($testException !== null) {
                         throw $testException;
+                    } elseif ($afterTestException !== null) {
+                        throw $afterTestException;
                     }
                 }
             } catch (asserter\exception $exception) {


### PR DESCRIPTION
On our test suite, we are trying to handle an assertion that should be done after every test method. In order to do this, we added an assertion inside the `afterTestMethod()` of our base test class.
When this assertion fails, the exception is not catched, resulting in following log:
```
Failure (1 test, 28/29 methods, 0 void method, 0 skipped method, 1 uncompleted method, 0 failure, 0 error, 0 exception)!
> There is 1 uncompleted method:
=> tests\units\AuthLDAP::testPrepareInputForUpdate() with exit code 255:
==> output(328) "Uncaught Exception atoum\atoum\asserter\exception: Some messages has not been handled in tests\units\AuthLDAP::testPrepareInputForUpdate:
==> Array
==> (
==>     [1] => Array
==>         (
==>             [0] => Synchronization field cannot be changed once in use.
==>         )
==> 
==> )
==>  in /var/www/glpi/vendor/atoum/atoum/classes/asserter.php at line 131"
```

With proposed change, result is:
```
Failure (1 test, 29/29 methods, 0 void method, 0 skipped method, 0 uncompleted method, 1 failure, 0 error, 0 exception)!
> There are 1 failure:

=> tests\units\AuthLDAP::testPrepareInputForUpdate():
In file /var/www/glpi/tests/functionnal/AuthLdap.php on line 68, array() failed: Some messages has not been handled in tests\units\AuthLDAP::testPrepareInputForUpdate:
Array
(
    [1] => Array
        (
            [0] => Synchronization field cannot be changed once in use.
        )

)
```