### PR TITLE
Fix PHP 8.1 compatibility issues

### DIFF
--- a/classes/extension/aggregator.php
+++ b/classes/extension/aggregator.php
@@ -6,7 +6,7 @@ use atoum\atoum\exceptions\logic\invalidArgument;
 
 class aggregator extends \splObjectStorage
 {
-    public function getHash($object)
+    public function getHash($object): string
     {
         if (is_object($object) === false) {
             throw new invalidArgument(__METHOD__ . ' expects parameter 1 to be object, ' . gettype($object) . ' given');

--- a/classes/score/coverage.php
+++ b/classes/score/coverage.php
@@ -52,36 +52,39 @@ class coverage implements \countable, \serializable
         return $this->reflectionClassFactory;
     }
 
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(
-            [
-                $this->classes,
-                $this->methods,
-                $this->paths,
-                $this->branches,
-                $this->excludedClasses,
-                $this->excludedNamespaces,
-                $this->excludedDirectories
-            ]
-        );
+        return [
+            'classes'             => $this->classes,
+            'methods'             => $this->methods,
+            'paths'               => $this->paths,
+            'branches'            => $this->branches,
+            'excludedClasses'     => $this->excludedClasses,
+            'excludedNamespaces'  => $this->excludedNamespaces,
+            'excludedDirectories' => $this->excludedDirectories
+       ];
     }
 
-    public function unserialize($string, \closure $reflectionClassFactory = null)
+    public function serialize()
     {
-        $this->setReflectionClassFactory($reflectionClassFactory);
+        return serialize($this->__serialize());
+    }
 
-        list(
-            $this->classes,
-            $this->methods,
-            $this->paths,
-            $this->branches,
-            $this->excludedClasses,
-            $this->excludedNamespaces,
-            $this->excludedDirectories
-        ) = unserialize($string);
+    public function __unserialize(array $data): void
+    {
+        $this->classes             = $data['classes'];
+        $this->methods             = $data['methods'];
+        $this->paths               = $data['paths'];
+        $this->branches            = $data['branches'];
+        $this->excludedClasses     = $data['excludedClasses'];
+        $this->excludedNamespaces  = $data['excludedNamespaces'];
+        $this->excludedDirectories = $data['excludedDirectories'];
+    }
 
-        return $this;
+    public function unserialize($string)
+    {
+        $data = unserialize($string);
+        $this->__unserialize($data);
     }
 
     public function getClasses()
@@ -670,7 +673,7 @@ class coverage implements \countable, \serializable
         return $this->excludedDirectories;
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->methods);
     }

--- a/classes/script/arguments/parser.php
+++ b/classes/script/arguments/parser.php
@@ -62,7 +62,7 @@ class parser implements \iteratorAggregate
         return $this->priorities;
     }
 
-    public function getIterator()
+    public function getIterator(): \traversable
     {
         return new \arrayIterator($this->getValues());
     }

--- a/classes/test.php
+++ b/classes/test.php
@@ -1088,7 +1088,7 @@ abstract class test implements observable, \countable
         return $this->score->getCoverage();
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->runTestMethods);
     }

--- a/tests/units/classes/superglobals.php
+++ b/tests/units/classes/superglobals.php
@@ -18,7 +18,6 @@ class superglobals extends atoum\test
         $this
             ->if($superglobals = new testedClass())
             ->then
-                ->array->setByReferenceWith($superglobals->GLOBALS)->isReferenceTo($GLOBALS)
                 ->array->setByReferenceWith($superglobals->_SERVER)->isReferenceTo($_SERVER)
                 ->array->setByReferenceWith($superglobals->_GET)->isReferenceTo($_GET)
                 ->array->setByReferenceWith($superglobals->_POST)->isReferenceTo($_POST)
@@ -33,6 +32,16 @@ class superglobals extends atoum\test
         } else {
             $this->assert()->array->setByReferenceWith($superglobals->_SESSION)->isReferenceTo($superglobals->_SESSION);
         }
+    }
+
+    /** @php <= 8.0 */
+    public function test__get_globals()
+    {
+        $this
+            ->if($superglobals = new testedClass())
+            ->then
+                ->array->setByReferenceWith($superglobals->GLOBALS)->isReferenceTo($GLOBALS)
+        ;
     }
 
     public function test__set()


### PR DESCRIPTION
1. Declare missing return types.
2. Implement __(un)serialize magic methods to prevent deprecation warning on Serialize interface usage.