### PR TITLE
Drop PHP 7.2 and PHP 7.3 support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.4', '8.0', '8.1' ]
         experimental: [ false ]
       fail-fast: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # `dev-master`
 
-# 4.0.3 - 2021-10-22
+* [#868](https://github.com/atoum/atoum/pull/868) Drop PHP 7.2 and PHP 7.3 support ([@cedric-anne])
 
+# 4.0.3 - 2021-10-22
 
 * [#876](https://github.com/atoum/atoum/pull/876) Properly handle output made in setUp() tearDown() and afterTestMethod() ([@cedric-anne])
 * [#873](https://github.com/atoum/atoum/pull/873) Migrate lint job on Github Actions ([@cedric-anne])

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,9 +110,9 @@ $ vendor/bin/php-cs-fixer fix --verbose
 
 ### Compatibility
 
-Your code **must** work on PHP from version 7.2 to the latest stable.
+Your code **must** work on PHP from version 7.4 to the latest stable.
 
-When you need to use a feature that is only available on PHP version greater than 7.2, you **must** either:
+When you need to use a feature that is only available on PHP version greater than 7.4, you **must** either:
 
 * Use version sniffing (`version_compare`),
 * Check if class exists,

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	],
 	"require":
 	{
-		"php": "^7.2 || ^8.0",
+		"php": "^7.4 || ^8.0",
 		"ext-hash": "*",
 		"ext-json": "*",
 		"ext-tokenizer": "*",


### PR DESCRIPTION
PHP end of life will be on [6 Dec 2021](https://www.php.net/supported-versions.php). At this date we will be able to drop its support.

I will keep this PR as a draft until this date.