### PR TITLE
Fix deprecated usage of addcslashes

### DIFF
--- a/classes/asserters/phpString.php
+++ b/classes/asserters/phpString.php
@@ -28,7 +28,7 @@ class phpString extends variable
 
     public function __toString()
     {
-        return (is_string($this->value) === false ? parent::__toString() : $this->_('string(%s) \'%s\'', strlen($this->value), addcslashes($this->value, $this->charlist)));
+        return (is_string($this->value) === false ? parent::__toString() : $this->_('string(%s) \'%s\'', strlen($this->value), addcslashes($this->value, $this->charlist ?? '')));
     }
 
     public function getCharlist()

--- a/classes/asserters/utf8String.php
+++ b/classes/asserters/utf8String.php
@@ -22,7 +22,7 @@ class utf8String extends phpString
 
     public function __toString()
     {
-        return (is_string($this->value) === false ? parent::__toString() : $this->_('string(%s) \'%s\'', mb_strlen($this->value, 'UTF-8'), addcslashes($this->value, $this->charlist)));
+        return (is_string($this->value) === false ? parent::__toString() : $this->_('string(%s) \'%s\'', mb_strlen($this->value, 'UTF-8'), addcslashes($this->value, $this->charlist ?? '')));
     }
 
     public function setWith($value, $charlist = null, $checkType = true)


### PR DESCRIPTION
Fixes following error: `addcslashes(): Passing null to parameter #2 ($characters) of type string is deprecated`.

I splited the ternary operation to have a better readability.