### PR TITLE
Catch afterTestMethod() output; fixes #820

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `dev-master`
 
-* [#876](https://github.com/atoum/atoum/pull/876) Properly handle output made in afterTestMethod() ([@cedric-anne])
+* [#876](https://github.com/atoum/atoum/pull/876) Properly handle output made in setUp() tearDown() and afterTestMethod() ([@cedric-anne])
 * [#873](https://github.com/atoum/atoum/pull/873) Migrate lint job on Github Actions ([@cedric-anne])
 * [#872](https://github.com/atoum/atoum/pull/872) Migrate Windows test job on Github Actions and add a MacOS test job ([@cedric-anne])
 * [#871](https://github.com/atoum/atoum/pull/871) Fix PHP8.1 compatibility issue related to unexpected arguments types ([@cedric-anne])

--- a/classes/test.php
+++ b/classes/test.php
@@ -1563,7 +1563,10 @@ abstract class test implements observable, \countable
     protected function callSetUp()
     {
         if (method_exists($this, 'setUp')) {
+            ob_start();
             $this->setUp();
+            $this->score
+                ->addOutput($this->path, $this->class, 'setUp', ob_get_clean());
         }
 
         return $this;
@@ -1572,7 +1575,10 @@ abstract class test implements observable, \countable
     protected function callTearDown()
     {
         if (method_exists($this, 'tearDown')) {
+            ob_start();
             $this->tearDown();
+            $this->score
+                ->addOutput($this->path, $this->class, 'tearDown', ob_get_clean());
         }
 
         return $this;

--- a/tests/functionals/classes/test.php
+++ b/tests/functionals/classes/test.php
@@ -8,14 +8,24 @@ require_once __DIR__ . '/../runner.php';
 
 class test extends atoum\tests\functionals\test\functional
 {
+    public function setUp()
+    {
+        echo __METHOD__;
+    }
+
     public function beforeTestMethod($method)
     {
-        echo "start\n";
+        echo __METHOD__;
     }
 
     public function afterTestMethod($method)
     {
-        echo "end\n";
+        echo __METHOD__;
+    }
+
+    public function tearDown()
+    {
+        echo __METHOD__;
     }
 
     /** @tags issue issue-820 */


### PR DESCRIPTION
I added this piece of code in `atoum\atoum\tests\units\annotations\extractor``test class:
```php
    public function beforeTestMethod($method)
    {
        echo "start\n";
    }

    public function afterTestMethod($method)
    {
        echo "end\n";
    }
```

It produces the following result:
```
> Total tests duration: 12.81 seconds.
> Total tests memory usage: 500.94 Mb.
> Running duration: 20.59 seconds.
Success (230 tests, 1825/1827 methods, 0 void method, 2 skipped methods, 28614 assertions)!
> There are 16 outputs:
=> In atoum\atoum\tests\units\annotations\extractor::testResetHandlers():
start
=> In atoum\atoum\tests\units\annotations\extractor::testResetHandlers():
end
=> In atoum\atoum\tests\units\annotations\extractor::testUnsetHandler():
start
=> In atoum\atoum\tests\units\annotations\extractor::testUnsetHandler():
end
=> In atoum\atoum\tests\units\annotations\extractor::test__construct():
start
=> In atoum\atoum\tests\units\annotations\extractor::test__construct():
end
=> In atoum\atoum\tests\units\annotations\extractor::testExtract():
start
=> In atoum\atoum\tests\units\annotations\extractor::testExtract():
end
=> In atoum\atoum\tests\units\annotations\extractor::testSpace():
start
=> In atoum\atoum\tests\units\annotations\extractor::testSpace():
end
=> In atoum\atoum\tests\units\annotations\extractor::testStar():
start
=> In atoum\atoum\tests\units\annotations\extractor::testStar():
end
=> In atoum\atoum\tests\units\annotations\extractor::testToBoolean():
start
=> In atoum\atoum\tests\units\annotations\extractor::testToBoolean():
end
=> In atoum\atoum\tests\units\annotations\extractor::testToArray():
start
=> In atoum\atoum\tests\units\annotations\extractor::testToArray():
end
```

So it works as expected, but I have no idea how I can test this.