### PR TITLE
Fix some issues on PHP 8.2

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,8 @@ jobs:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
         php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
         experimental: [ false ]
+        include:
+          - {os: 'ubuntu-latest', php-version: '8.2', experimental: true}
       fail-fast: false
 
     env:

--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -499,7 +499,7 @@ class phpArray extends variable implements \arrayAccess
     protected function callAssertion($method, array $arguments)
     {
         if ($this->innerAsserterCanUse($method) === false) {
-            call_user_func_array(['parent', $method], $arguments);
+            call_user_func_array([parent::class, $method], $arguments);
         } else {
             $this->callInnerAsserterMethod($method, $arguments);
         }

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -363,7 +363,7 @@ class generator
                 $mockedMethods .= "\t\t\t" . '$this->getMockController()->addCall(\'' . $constructorName . '\', $arguments);' . PHP_EOL;
 
                 if ($this->canCallParent()) {
-                    $mockedMethods .= "\t\t\t" . 'call_user_func_array(\'parent::' . $constructorName . '\', $arguments);' . PHP_EOL;
+                    $mockedMethods .= "\t\t\t" . 'call_user_func_array([parent::class, \'' . $constructorName . '\'], $arguments);' . PHP_EOL;
                 }
 
                 $mockedMethods .= "\t\t" . '}' . PHP_EOL;
@@ -444,7 +444,7 @@ class generator
                     $mockedMethods .= "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL;
 
                     if ($this->canCallParent()) {
-                        $mockedMethods .= "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL;
+                        $mockedMethods .= "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL;
 
                         if ($this->isVoid($method) === false) {
                             $mockedMethods .= "\t\t\t" . 'return $return;' . PHP_EOL;

--- a/classes/report/fields/runner/event/cli/dot.php
+++ b/classes/report/fields/runner/event/cli/dot.php
@@ -10,6 +10,7 @@ use atoum\atoum\test;
 class dot extends report\fields\runner\event
 {
     protected $count = 0;
+    protected $progressBar;
 
     public function __construct(progressBar\dot $progressBar = null)
     {

--- a/tests/units/classes/asserters/castToArray.php
+++ b/tests/units/classes/asserters/castToArray.php
@@ -47,10 +47,10 @@ class castToArray extends atoum\test
                     ->setAdapter($adapter)
             )
             ->then
-                ->object($asserter->setWith($object = new \exception()))->isIdenticalTo($asserter)
+                ->object($asserter->setWith($object = new \arrayiterator()))->isIdenticalTo($asserter)
                 ->array($asserter->getValue())->isEqualTo((array) $object)
 
-                ->object($asserter->setWith($object = new \exception()))->isIdenticalTo($asserter)
+                ->object($asserter->setWith($object = new \arrayiterator()))->isIdenticalTo($asserter)
                 ->array($asserter->getValue())->isEqualTo((array) $object)
 
             ->if(

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -2597,7 +2597,7 @@ class generator extends atoum\test
                 "\t\t" . 'else' . PHP_EOL .
                 "\t\t" . '{' . PHP_EOL .
                 "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                 "\t\t\t" . 'return $return;' . PHP_EOL .
                 "\t\t" . '}' . PHP_EOL .
                 "\t" . '}' . PHP_EOL .

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -323,7 +323,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'__construct\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . 'call_user_func_array(\'parent::__construct\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . 'call_user_func_array([parent::class, \'__construct\'], $arguments);' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
                     "\t" . 'public static function getMockedMethods()' . PHP_EOL .
@@ -396,7 +396,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $realClass . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . 'call_user_func_array(\'parent::' . $realClass . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . 'call_user_func_array([parent::class, \'' . $realClass . '\'], $arguments);' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
                     "\t" . 'public static function getMockedMethods()' . PHP_EOL .
@@ -580,7 +580,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'__construct\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . 'call_user_func_array(\'parent::__construct\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . 'call_user_func_array([parent::class, \'__construct\'], $arguments);' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
                     "\t" . 'public static function getMockedMethods()' . PHP_EOL .
@@ -1366,7 +1366,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -1460,7 +1460,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -1554,7 +1554,7 @@ class generator extends atoum\test
                 "\t\t" . 'else' . PHP_EOL .
                 "\t\t" . '{' . PHP_EOL .
                 "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                 "\t\t\t" . 'return $return;' . PHP_EOL .
                 "\t\t" . '}' . PHP_EOL .
                 "\t" . '}' . PHP_EOL .
@@ -1640,7 +1640,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -2228,7 +2228,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -2322,7 +2322,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -2408,7 +2408,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -2502,7 +2502,7 @@ class generator extends atoum\test
                 "\t\t" . 'else' . PHP_EOL .
                 "\t\t" . '{' . PHP_EOL .
                 "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                 "\t\t\t" . 'return $return;' . PHP_EOL .
                 "\t\t" . '}' . PHP_EOL .
                 "\t" . '}' . PHP_EOL .
@@ -2616,7 +2616,7 @@ class generator extends atoum\test
                 "\t\t" . 'else' . PHP_EOL .
                 "\t\t" . '{' . PHP_EOL .
                 "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                 "\t\t\t" . 'return $return;' . PHP_EOL .
                 "\t\t" . '}' . PHP_EOL .
                 "\t" . '}' . PHP_EOL .
@@ -2711,7 +2711,7 @@ class generator extends atoum\test
                 "\t\t" . 'else' . PHP_EOL .
                 "\t\t" . '{' . PHP_EOL .
                 "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                 "\t\t\t" . 'return $return;' . PHP_EOL .
                 "\t\t" . '}' . PHP_EOL .
                 "\t" . '}' . PHP_EOL .
@@ -2844,7 +2844,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .
@@ -2896,7 +2896,7 @@ class generator extends atoum\test
                     "\t\t" . 'else' . PHP_EOL .
                     "\t\t" . '{' . PHP_EOL .
                     "\t\t\t" . '$this->getMockController()->addCall(\'foo\', $arguments);' . PHP_EOL .
-                    "\t\t\t" . '$return = call_user_func_array(\'parent::foo\', $arguments);' . PHP_EOL .
+                    "\t\t\t" . '$return = call_user_func_array([parent::class, \'foo\'], $arguments);' . PHP_EOL .
                     "\t\t\t" . 'return $return;' . PHP_EOL .
                     "\t\t" . '}' . PHP_EOL .
                     "\t" . '}' . PHP_EOL .


### PR DESCRIPTION
I found some issues while trying to run my test suite on PHP 8.2.

1. `['parent', 'mymethod']` is now deprecated, so I replaced it with `[parent::class, 'mymethod']`.
2. Usage of dynamic properties is now deprecated, so I added `atoum\atoum\report\fields\runner\event\cli\dot::$progressBar` declaration.
3. Casting an exception to array seems to be impossible now, so I changed the `atoum\atoum\tests\units\asserters\castToArray::testSetWith()` test to a variable that can be cast to array.

I added PHP 8.2 as experimental in the test suite.