### PR TITLE
Mock generator correctly handles the `static` return type

### DIFF
--- a/classes/asserters/adapter/call.php
+++ b/classes/asserters/adapter/call.php
@@ -31,18 +31,18 @@ abstract class call extends atoum\asserter
             return $this->exactly($property);
         } else {
             switch (strtolower($property)) {
-            case 'once':
-            case 'twice':
-            case 'thrice':
-            case 'never':
-            case 'atleastonce':
-            case 'wascalled':
-            case 'wasnotcalled':
-                return $this->{$property}();
+                case 'once':
+                case 'twice':
+                case 'thrice':
+                case 'never':
+                case 'atleastonce':
+                case 'wascalled':
+                case 'wasnotcalled':
+                    return $this->{$property}();
 
-            default:
-                return parent::__get($property);
-        }
+                default:
+                    return parent::__get($property);
+            }
         }
     }
 

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -667,6 +667,7 @@ class generator
         $isNullable = $returnTypeName !== 'mixed' && $this->isNullable($returnType);
 
         switch (true) {
+            case $returnTypeName === 'static':
             case $returnTypeName === 'self':
                 $returnTypeCode = ': ' . ($isNullable ? '?' : '') . '\\' . $method->getDeclaringClass()->getName();
                 break;

--- a/classes/report/fields/test/event/phing.php
+++ b/classes/report/fields/test/event/phing.php
@@ -14,28 +14,28 @@ class phing extends report\fields\test\event\cli
                 return '[';
 
             case atoum\test::runStop:
-                 return '] ';
+                return '] ';
 
             case atoum\test::success:
-                 return 'S';
+                return 'S';
 
             case atoum\test::void:
-                 return '0';
+                return '0';
 
             case atoum\test::uncompleted:
-                 return 'U';
+                return 'U';
 
             case atoum\test::fail:
-                 return 'F';
+                return 'F';
 
             case atoum\test::error:
-                 return 'e';
+                return 'e';
 
             case atoum\test::exception:
-                 return 'E';
+                return 'E';
 
             default:
-                 return '';
+                return '';
         }
     }
 }

--- a/classes/scripts/runner.php
+++ b/classes/scripts/runner.php
@@ -864,7 +864,7 @@ class runner extends atoum\script\configurable
                     $script
                             ->resetExcludedDirectoriesFromCoverage()
                             ->excludeDirectoriesFromCoverage($directories)
-                        ;
+                    ;
                 },
                 ['-nccid', '--no-code-coverage-in-directories'],
                 '<directory>...',
@@ -879,7 +879,7 @@ class runner extends atoum\script\configurable
                     $script
                             ->resetExcludedNamespacesFromCoverage()
                             ->excludeNamespacesFromCoverage($namespaces)
-                        ;
+                    ;
                 },
                 ['-nccfns', '--no-code-coverage-for-namespaces'],
                 '<namespace>...',
@@ -894,7 +894,7 @@ class runner extends atoum\script\configurable
                     $script
                             ->resetExcludedClassesFromCoverage()
                             ->excludeClassesFromCoverage($classes)
-                        ;
+                    ;
                 },
                 ['-nccfc', '--no-code-coverage-for-classes'],
                 '<class>...',
@@ -909,7 +909,7 @@ class runner extends atoum\script\configurable
                     $script
                             ->resetExcludedMethodsFromCoverage()
                             ->excludeMethodsFromCoverage($classes)
-                        ;
+                    ;
                 },
                 ['-nccfm', '--no-code-coverage-for-methods'],
                 '<method>...',
@@ -1018,7 +1018,7 @@ class runner extends atoum\script\configurable
                     $script
                             ->resetTestedNamespaces()
                             ->testNamespaces($namespaces)
-                        ;
+                    ;
                 },
                 ['-ns', '--namespaces'],
                 '<namespace>...',

--- a/classes/test.php
+++ b/classes/test.php
@@ -1711,14 +1711,14 @@ abstract class test implements observable, \countable
                             $version = $value[1];
 
                             switch ($value[0]) {
-                            case '<':
-                            case '<=':
-                            case '=':
-                            case '==':
-                            case '>=':
-                            case '>':
-                                $operator = $value[0];
-                        }
+                                case '<':
+                                case '<=':
+                                case '=':
+                                case '==':
+                                case '>=':
+                                case '>':
+                                    $operator = $value[0];
+                            }
                         }
 
                         $this->addClassPhpVersion($version, $operator);
@@ -1778,14 +1778,14 @@ abstract class test implements observable, \countable
                             $version = $value[1];
 
                             switch ($value[0]) {
-                            case '<':
-                            case '<=':
-                            case '=':
-                            case '==':
-                            case '>=':
-                            case '>':
-                                $operator = $value[0];
-                        }
+                                case '<':
+                                case '<=':
+                                case '=':
+                                case '==':
+                                case '>=':
+                                case '>':
+                                    $operator = $value[0];
+                            }
                         }
 
                         $this->addMethodPhpVersion($methodName, $version, $operator);

--- a/tests/units/classes/asserters/phpObject.php
+++ b/tests/units/classes/asserters/phpObject.php
@@ -387,7 +387,7 @@ class phpObject extends atoum\test
                 ->object($asserter->isInstanceOf(get_class($test)))->isIdenticalTo($asserter)
                 ->object($asserter->isInstanceOf('\\' . get_class($test)))->isIdenticalTo($asserter)
                 ->object($asserter->isInstanceOf($test))->isIdenticalTo($asserter)
-            ;
+        ;
     }
 
     public function testIsNotInstanceOf()

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -2517,6 +2517,101 @@ class generator extends atoum\test
     }
 
     /** @php >= 8.0 */
+    public function testGetMockedClassCodeForMethodWithStaticReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController = new mock\controller())
+            ->and($reflectionTypeController->__construct = function () {
+            })
+            ->and($reflectionTypeController->__toString = 'static')
+            ->and($reflectionTypeController->isBuiltIn = false)
+            ->and($reflectionTypeController->allowsNull = false)
+            ->and($reflectionType = new \mock\reflectionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnStatic')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $reflectionType)
+            ->and(version_compare(phpversion(), '8.1', '<') ? true : $reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): \\' . $realClass . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array(\'parent::' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
+    /** @php >= 8.0 */
     public function testGetMockedClassCodeForMethodWithUnionedReturnType()
     {
         $this

--- a/tests/units/classes/reports/realtime/phing.php
+++ b/tests/units/classes/reports/realtime/phing.php
@@ -150,7 +150,7 @@ class phing extends atoum\test
                         $testMemoryField,
                     ]
                 )
-          ;
+        ;
     }
 
     public function testShowProgress()

--- a/tests/units/classes/template.php
+++ b/tests/units/classes/template.php
@@ -508,7 +508,7 @@ class template extends atoum\test
                 })
                     ->isInstanceOf(atoum\exceptions\runtime::class)
                     ->hasMessage('Id \'' . $id . '\' is already defined')
-            ;
+        ;
     }
 
     public function testDeleteChild()


### PR DESCRIPTION
Since Symfony 6, the [`static` return type](https://www.php.net/manual/fr/language.types.declarations.php#language.types.declarations.static) is sometime used (see [Request](https://github.com/symfony/http-foundation/blob/5f0f9ef2e714ea5b2038a73fbf26bc75c04a4a6a/Request.php#L436) for example).
Atoum do not handle it properly : it generates a `: \static` method signature which fails...
```
==> Error FATAL ERROR in ... on unknown line, generated by file /src/vendor/atoum/atoum/classes/mock/generator.php(219) : eval()'d code on line 66:
'\static' is an invalid class name
```

This PR should fix it by using the same behavior as [`self`](https://github.com/atoum/atoum/pull/633).

I also applied latest CS fixer rules (as required by this package), which changed a few files... This is included in another commit, if you prefer to create 2 independent PR. It seems that it doesn't fix the CI though :disappointed: 

Note that the `never` return type is also missing, but not included in this PR.