### PR TITLE
Mock generator should not replace `static` return type by class name

### DIFF
--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -667,7 +667,6 @@ class generator
         $isNullable = $returnTypeName !== 'mixed' && $this->isNullable($returnType);
 
         switch (true) {
-            case $returnTypeName === 'static':
             case $returnTypeName === 'self':
                 $returnTypeCode = ': ' . ($isNullable ? '?' : '') . '\\' . $method->getDeclaringClass()->getName();
                 break;
@@ -686,6 +685,7 @@ class generator
                 $returnTypeCode = ': ' . implode('|', $types);
                 break;
 
+            case $returnTypeName === 'static':
             case $returnType->isBuiltin():
                 $returnTypeCode = ': ' . ($isNullable ? '?' : '') . $returnTypeName;
                 break;

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -2586,7 +2586,7 @@ class generator extends atoum\test
                 "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
                 "\t\t" . '}' . PHP_EOL .
                 "\t" . '}' . PHP_EOL .
-                "\t" . 'public function ' . $methodName . '(): \\' . $realClass . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): static' . PHP_EOL .
                 "\t" . '{' . PHP_EOL .
                 "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
                 "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .


### PR DESCRIPTION
## Description

Following #883, the feature was not properly implemented. The `static` return type cannot be replaced by any class name. I couldn't find the explicit rule from [PHP doc](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.static), but while [testing](https://gist.github.com/shavounet/011ad9180494a45aeb76eb03dd477d0d) I found that not even the mock class name can be used (even if it follows covariance rules :shrug:).

In conclusion, we should keep it as-is.

Previous test was failing to detect this because code is not evaluated, but I'm not sure it's a good idea to do this...