### PR TITLE
Fix duplicate variable declaration

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -533,7 +533,7 @@ abstract class test implements observable, \countable
         $asserterGenerator = $this->asserterGenerator;
 
         $this->assertionManager->setDefaultHandler(
-            function ($keyword, $arguments) use ($asserterGenerator, $assertionAliaser, & $lastAsserter) {
+            function ($keyword, $arguments) use ($asserterGenerator, $assertionAliaser) {
                 static $lastAsserter = null;
 
                 if ($lastAsserter !== null) {


### PR DESCRIPTION
On PHP 8.3 alpha 1, a fatal error is triggered:
`Fatal error: Duplicate declaration of static variable $lastAsserter in /var/glpi/vendor/atoum/atoum/classes/test.php on line 537`

The `static` declaration is enough to ensure that variable is initialized only once, and so the declaration by reference in the `use` instruction is useless.