### PR TITLE
Update tested PHP versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
-        php-version: [ '7.4', '8.0', '8.1' ]
+        php-version: [ '7.4', '8.0', '8.1', '8.2' ]
         experimental: [ false ]
         include:
-          - {os: 'ubuntu-latest', php-version: '8.2', experimental: true}
+          - {os: 'ubuntu-latest', php-version: '8.3', experimental: true}
       fail-fast: false
 
     env:


### PR DESCRIPTION
PHP 8.3 is now in beta version, and features are freezed. It is time to check if tests are passing on this PHP version.