### PR TITLE
Fix `null` type handling

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
-        php-version: [ '8.0', '8.1' ]
+        php-version: [ '8.0', '8.1', '8.2' ]
         experimental: [ false ]
-        include:
-          - {os: 'ubuntu-latest', php-version: '8.2', experimental: true}
       fail-fast: false
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `dev-master`
 
+* [#893](https://github.com/atoum/atoum/pull/893) Drop PHP 7.4 support ([@cedric-anne])
+* [#892](https://github.com/atoum/atoum/pull/892) Fix `null`, `true` and `false` type handling ([@cedric-anne])
+* [#890](https://github.com/atoum/atoum/pull/890) Fix duplicate variable declaration on PHP 8.3 ([@cedric-anne])
+
 # 4.1.0 - 2022-11-20
 
 * [#883](https://github.com/atoum/atoum/pull/883) and [#884](https://github.com/atoum/atoum/pull/884) Handle `static` return type in mock generator ([@shavounet])

--- a/classes/mock/generator.php
+++ b/classes/mock/generator.php
@@ -664,7 +664,7 @@ class generator
 
         $returnType = $this->getReflectionType($method);
         $returnTypeName = $this->getReflectionTypeName($returnType);
-        $isNullable = $returnTypeName !== 'mixed' && $this->isNullable($returnType);
+        $isNullable = $returnType->allowsNull() === true;
 
         switch (true) {
             case $returnTypeName === 'self':
@@ -685,6 +685,11 @@ class generator
                 $returnTypeCode = ': ' . implode('|', $types);
                 break;
 
+            case in_array($this->getReflectionTypeName($returnType), ['mixed', 'null']):
+                // 'mixed' and 'null' cannot be marked as nullable
+                $returnTypeCode = ': ' . $returnTypeName;
+                break;
+
             case $returnTypeName === 'static':
             case $returnType->isBuiltin():
                 $returnTypeCode = ': ' . ($isNullable ? '?' : '') . $returnTypeName;
@@ -695,11 +700,6 @@ class generator
         }
 
         return $returnTypeCode;
-    }
-
-    protected function isNullable(\reflectionType $type)
-    {
-        return $type->allowsNull() === true;
     }
 
     protected function hasReturnType(\reflectionMethod $method)

--- a/classes/tools/parameter/analyzer.php
+++ b/classes/tools/parameter/analyzer.php
@@ -12,9 +12,12 @@ class analyzer
 
         $parameterType = $parameter->getType();
 
-        if ($parameterType instanceof \reflectionNamedType && $parameterType->getName() === 'mixed') {
-            // 'mixed' cannot be prefixed by nullable flag '?' and cannot be part of union types
-            return 'mixed';
+        if (
+            $parameterType instanceof \reflectionNamedType
+            && in_array($parameterType->getName(), ['mixed', 'null'])
+        ) {
+            // 'mixed' and 'null' cannot be prefixed by nullable flag '?'
+            return $parameterType->getName();
         }
 
         $parameterTypes = $parameterType instanceof \ReflectionUnionType

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -2610,6 +2610,101 @@ class generator extends atoum\test
         ;
     }
 
+    /** @php >= 8.2 */
+    public function testGetMockedClassCodeForMethodWithNullReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController = new mock\controller())
+            ->and($reflectionTypeController->__construct = function () {
+            })
+            ->and($reflectionTypeController->__toString = 'null')
+            ->and($reflectionTypeController->isBuiltIn = true)
+            ->and($reflectionTypeController->allowsNull = true)
+            ->and($reflectionType = new \mock\reflectionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnNull')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $reflectionType)
+            ->and($reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): null' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
     public function testGetMockedClassCodeForMethodWithUnionedReturnType()
     {
         $this

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -2705,6 +2705,196 @@ class generator extends atoum\test
         ;
     }
 
+    /** @php >= 8.2 */
+    public function testGetMockedClassCodeForMethodWithNullableTrueReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController = new mock\controller())
+            ->and($reflectionTypeController->__construct = function () {
+            })
+            ->and($reflectionTypeController->__toString = 'true')
+            ->and($reflectionTypeController->isBuiltIn = true)
+            ->and($reflectionTypeController->allowsNull = true)
+            ->and($reflectionType = new \mock\reflectionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnNullableTrue')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $reflectionType)
+            ->and($reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): ?true' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
+    /** @php >= 8.2 */
+    public function testGetMockedClassCodeForMethodWithFalseReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController = new mock\controller())
+            ->and($reflectionTypeController->__construct = function () {
+            })
+            ->and($reflectionTypeController->__toString = 'false')
+            ->and($reflectionTypeController->isBuiltIn = true)
+            ->and($reflectionTypeController->allowsNull = false)
+            ->and($reflectionType = new \mock\reflectionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnFalse')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $reflectionType)
+            ->and($reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): false' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
     public function testGetMockedClassCodeForMethodWithUnionedReturnType()
     {
         $this

--- a/tests/units/classes/tools/parameter/analyzer.php
+++ b/tests/units/classes/tools/parameter/analyzer.php
@@ -217,6 +217,44 @@ class analyzer extends atoum\test
         ;
     }
 
+    /** @php >= 8.2 */
+    public function getTypeHintStringForTrueAndFalse()
+    {
+        $this
+            ->if($analyzer = new testedClass())
+            ->and($reflectionNamedTypeController = new mock\controller())
+            ->and($reflectionNamedTypeController->__construct = function () {
+            })
+            ->and($reflectionNamedTypeController->isBuiltin = true)
+            ->and($reflectionNamedType = new \mock\reflectionNamedType())
+            ->and($reflectionParameterController = new mock\controller())
+            ->and($reflectionParameterController->__construct = function () {
+            })
+            ->and($reflectionParameterController->getName = 'param')
+            ->and($reflectionParameterController->isPassedByReference = false)
+            ->and($reflectionParameterController->isDefaultValueAvailable = false)
+            ->and($reflectionParameterController->isOptional = false)
+            ->and($reflectionParameterController->isVariadic = false)
+            ->and($reflectionParameterController->hasType = true)
+            ->and($reflectionParameterController->getType = $reflectionNamedType)
+            ->and($reflectionParameter = new \mock\reflectionParameter([uniqid(), uniqid()], 0))
+
+            ->if($reflectionNamedTypeController->getName = 'true')
+            ->and($reflectionParameterController->allowsNull = false)
+            ->then
+                ->string($analyzer->getTypeHintString($reflectionParameter))->isEqualTo('true')
+            ->if($reflectionParameterController->allowsNull = true)
+                ->string($analyzer->getTypeHintString($reflectionParameter))->isEqualTo('?true')
+
+            ->if($reflectionNamedTypeController->getName = 'false')
+            ->and($reflectionParameterController->allowsNull = false)
+            ->then
+                ->string($analyzer->getTypeHintString($reflectionParameter))->isEqualTo('false')
+            ->if($reflectionParameterController->allowsNull = true)
+                ->string($analyzer->getTypeHintString($reflectionParameter))->isEqualTo('?false')
+        ;
+    }
+
     public function getTypeHintStringForUnionType()
     {
         $this

--- a/tests/units/classes/tools/parameter/analyzer.php
+++ b/tests/units/classes/tools/parameter/analyzer.php
@@ -189,6 +189,34 @@ class analyzer extends atoum\test
         ;
     }
 
+    /** @php >= 8.2 */
+    public function getTypeHintStringForNull()
+    {
+        $this
+            ->if($analyzer = new testedClass())
+            ->and($reflectionNamedTypeController = new mock\controller())
+            ->and($reflectionNamedTypeController->__construct = function () {
+            })
+            ->and($reflectionNamedTypeController->getName = 'null')
+            ->and($reflectionNamedTypeController->isBuiltin = true)
+            ->and($reflectionNamedType = new \mock\reflectionNamedType())
+            ->and($reflectionParameterController = new mock\controller())
+            ->and($reflectionParameterController->__construct = function () {
+            })
+            ->and($reflectionParameterController->getName = 'param')
+            ->and($reflectionParameterController->isPassedByReference = false)
+            ->and($reflectionParameterController->isDefaultValueAvailable = false)
+            ->and($reflectionParameterController->isOptional = false)
+            ->and($reflectionParameterController->isVariadic = false)
+            ->and($reflectionParameterController->allowsNull = true)
+            ->and($reflectionParameterController->hasType = true)
+            ->and($reflectionParameterController->getType = $reflectionNamedType)
+            ->and($reflectionParameter = new \mock\reflectionParameter([uniqid(), uniqid()], 0))
+            ->then
+                ->string($analyzer->getTypeHintString($reflectionParameter))->isEqualTo('null')
+        ;
+    }
+
     public function getTypeHintStringForUnionType()
     {
         $this


### PR DESCRIPTION
`null` type introduced in PHP 8.2 was not correctly handled. Tests were failing, but due to experimental flag, it was not considered as a failure (see https://github.com/atoum/atoum/actions/runs/5305286067/job/14356611759#step:5:2847).

1. I updated the CI matrix to remove the `experimental: true` flag on PHP 8.2 and test it also on MacOS and Windows systems.
2. I fixed the `null` built-in type handling (it must not be prefixed by a `?`).
3. I added tests to validate support of `true` and `false` built-in types.