### PR TITLE
Fix deprecations

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,7 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             php-version: ${{ matrix.php-version }}
+            ini-values: error_reporting=E_ALL
             coverage: ${{ env.coverage }}
 
       -   name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `dev-master`
 
+* [#903](https://github.com/atoum/atoum/pull/903) Fix some PHP deprecations ([@cedric-anne])
+
 # 4.3.0 - 2025-05-16
 
 * [#899](https://github.com/atoum/atoum/pull/899) Fix PHP 8.4 deprecations ([@cedric-anne])

--- a/classes/asserters/error.php
+++ b/classes/asserters/error.php
@@ -177,7 +177,7 @@ class error extends asserter
             case E_USER_NOTICE:
                 return 'E_USER_NOTICE';
 
-            case E_STRICT:
+            case 2048: // E_STRICT is deprecated since PHP 8.4
                 return 'E_STRICT';
 
             case E_RECOVERABLE_ERROR:

--- a/classes/mock/php/method/argument.php
+++ b/classes/mock/php/method/argument.php
@@ -24,7 +24,13 @@ class argument
         }
 
         if ($this->type !== null) {
-            $string = $this->type . ' ' . $string;
+            $type = $this->type;
+
+            if ($this->defaultValueIsSet === true && $this->defaultValue === null) {
+                $type = '?' . $type;
+            }
+
+            $string = $type . ' ' . $string;
         }
 
         if ($this->defaultValueIsSet === true) {

--- a/classes/mock/stream.php
+++ b/classes/mock/stream.php
@@ -10,6 +10,8 @@ class stream
     public const defaultProtocol = 'atoum';
     public const protocolSeparator = '://';
 
+    public $context;
+
     protected $streamController = null;
 
     protected static $adapter = null;

--- a/classes/php/tokenizer.php
+++ b/classes/php/tokenizer.php
@@ -11,6 +11,9 @@ class tokenizer implements \iteratorAggregate
 
     private $tokens = null;
     private $currentIterator = null;
+    private $currentNamespace = null;
+    private $currentImportation = null;
+    private $currentFunction = null;
 
     public function __construct()
     {

--- a/classes/tools/parameter/analyzer.php
+++ b/classes/tools/parameter/analyzer.php
@@ -37,7 +37,8 @@ class analyzer
             $names[] = 'null';
         }
 
-        $prefix = ($force_nullable || $parameter->allowsNull()) && !($parameterType instanceof \ReflectionUnionType) ? '?' : '';
+        $canBeNull = $force_nullable || $parameter->allowsNull() || ($parameter->isOptional() && !$parameter->isDefaultValueAvailable());
+        $prefix = $canBeNull && !($parameterType instanceof \ReflectionUnionType) ? '?' : '';
 
         return $prefix . implode('|', $names);
     }

--- a/tests/units/classes/asserters/error.php
+++ b/tests/units/classes/asserters/error.php
@@ -62,7 +62,7 @@ class error extends atoum\test
             ->string(atoum\asserters\error::getAsString(E_USER_ERROR))->isEqualTo('E_USER_ERROR')
             ->string(atoum\asserters\error::getAsString(E_USER_WARNING))->isEqualTo('E_USER_WARNING')
             ->string(atoum\asserters\error::getAsString(E_USER_NOTICE))->isEqualTo('E_USER_NOTICE')
-            ->string(atoum\asserters\error::getAsString(E_STRICT))->isEqualTo('E_STRICT')
+            ->string(atoum\asserters\error::getAsString(2048))->isEqualTo('E_STRICT')
             ->string(atoum\asserters\error::getAsString(E_RECOVERABLE_ERROR))->isEqualTo('E_RECOVERABLE_ERROR')
             ->string(atoum\asserters\error::getAsString(E_DEPRECATED))->isEqualTo('E_DEPRECATED')
             ->string(atoum\asserters\error::getAsString(E_USER_DEPRECATED))->isEqualTo('E_USER_DEPRECATED')

--- a/tests/units/classes/mock/controller.php
+++ b/tests/units/classes/mock/controller.php
@@ -97,7 +97,7 @@ class controller extends atoum\test
             ->and($mockController->doesSomething = function () use (& $public) {
                 $this->public = $public = uniqid();
             })
-            ->and($mock->doesSomething())
+            ->and(@$mock->doesSomething())
             ->then
                 ->string($mock->public)->isEqualTo($public)
             ->if($mockController = new testedClass())


### PR DESCRIPTION
While trying to run the test suite locally, I figured out that there was many deprecations, resulting in test errors.

The first commit permit to be sure that all errors are reported, so the test suite fails, see https://github.com/atoum/atoum/pull/903/checks?sha=de1e856ca863fbcfed46283d28de3fcce617f02b.

Following commits permit to fix the test suite.