### PR TITLE
Fix tests on PHP 8.4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
-        php-version: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4']
         experimental: [ false ]
-        include:
-          - {os: 'ubuntu-latest', php-version: '8.4', experimental: true}
       fail-fast: false
 
     env:

--- a/tests/units/classes/scripts/phar/generator.php
+++ b/tests/units/classes/scripts/phar/generator.php
@@ -265,6 +265,7 @@ class generator extends atoum\test
                 $pharController->__construct = function () {
                 };
                 $pharController->setStub = function () {
+                    return true;
                 };
                 $pharController->setMetadata = function () {
                 };
@@ -365,6 +366,7 @@ class generator extends atoum\test
                 $pharController->__construct = function () {
                 };
                 $pharController->setStub = function () {
+                    return true;
                 };
                 $pharController->setMetadata = function () {
                 };


### PR DESCRIPTION
The tests were not passing in PHP 8.4 due to the invalid value returned by the `phar::setStub()` mock.

Since PHP 8.4, the returned value is always `true`, see https://github.com/php/php-src/blob/20c274b68879b1a019e0b0a696ed5cb24cf09cbc/ext/phar/phar_object.stub.php#L205

I also removed the `experimental` flag for PHP 8.4 in the test suite configuration, to be sure that any error on this PHP version will be detected.