### PR TITLE
[BUGFIX] fix issue related to self, parent and static return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `dev-main`
 
+# 4.4.1 - 2025-10-14
+* [#916](https://github.com/atoum/atoum/pull/916) Fix issue related to self, parent and static return type ([@toxicity1985])
+
 # 4.4.0 - 2025-10-12
 
 * [#905](https://github.com/atoum/atoum/pull/905) Fix linter ([@cedric-anne])

--- a/classes/tools/parameter/analyzer.php
+++ b/classes/tools/parameter/analyzer.php
@@ -40,6 +40,63 @@ class analyzer
         $canBeNull = $force_nullable || $parameter->allowsNull() || ($parameter->isOptional() && !$parameter->isDefaultValueAvailable());
         $prefix = $canBeNull && !($parameterType instanceof \ReflectionUnionType) ? '?' : '';
 
-        return $prefix . implode('|', $names);
+        $typeString = implode('|', $names);
+
+        return $prefix . $typeString;
+    }
+
+    /**
+     * Format a ReflectionType into a string representation
+     * Handles: NamedType, UnionType
+     * Special handling for named types:
+     * - 'self' is resolved to the declaring class name
+     * - 'parent' is resolved to the parent class name
+     * - 'static' is kept as-is (late static binding)
+     */
+    protected function formatReflectionType(\ReflectionType $type, ?\ReflectionClass $declaringClass = null): string
+    {
+        // PHP 8.0+: Named types
+        if ($type instanceof \reflectionNamedType) {
+            $typeName = $type->getName();
+
+            // Handle special keyword types: 'self', 'parent', 'static'
+            if ($typeName === 'static') {
+                // 'static' is always kept as-is (late static binding keyword)
+                return 'static';
+            }
+
+            if ($declaringClass !== null) {
+                if ($typeName === 'self') {
+                    $typeName = $declaringClass->getName();
+                } elseif ($typeName === 'parent') {
+                    $parentClass = $declaringClass->getParentClass();
+                    if ($parentClass !== false) {
+                        $typeName = $parentClass->getName();
+                    }
+                }
+            }
+
+            $prefix = '';
+            // Only add backslash for non-builtin named types
+            if (!$type->isBuiltin()) {
+                $prefix = '\\';
+            }
+
+            return $prefix . $typeName;
+        }
+
+        // PHP 8.0+: Union types
+        if ($type instanceof \ReflectionUnionType) {
+            $types = array_map(
+                function ($t) use ($declaringClass) {
+                    return $this->formatReflectionType($t, $declaringClass);
+                },
+                $type->getTypes()
+            );
+            return implode('|', $types);
+        }
+
+        // Fallback for unknown types
+        return (string) $type;
     }
 }

--- a/tests/functionals/test_self_static_parent_fix.php
+++ b/tests/functionals/test_self_static_parent_fix.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Test fonctionnel pour vérifier que self, static et parent sont correctement gérés
+ * dans les types de retour des mocks.
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Test 1: Union types avec self
+class TestUnionWithSelf
+{
+    public function returnSelfOrString(): self|string
+    {
+        return $this;
+    }
+}
+
+// Test 2: Union types avec static
+class TestUnionWithStatic
+{
+    public function returnStaticOrInt(): static|int
+    {
+        return $this;
+    }
+}
+
+// Test 3: Union types avec parent
+class TestParentBase
+{
+    public function baseMethod(): self
+    {
+        return $this;
+    }
+}
+
+class TestUnionWithParent extends TestParentBase
+{
+    public function returnParentOrNull(): parent|null
+    {
+        return $this;
+    }
+}
+
+// Test 4: Abstract avec static
+abstract class TestAbstractWithStatic
+{
+    abstract public function returnStatic(): static;
+}
+
+$generator = new \atoum\atoum\mock\generator();
+
+echo "Test 1: Union avec self..." . PHP_EOL;
+$generator->generate(TestUnionWithSelf::class);
+$mock1 = new \mock\TestUnionWithSelf();
+$mock1->getMockController()->returnSelfOrString = function () use ($mock1) {
+    return $mock1;
+};
+$result = $mock1->returnSelfOrString();
+assert($result === $mock1, 'Test 1 failed: returnSelfOrString should return the mock instance');
+echo "✓ Test 1 passed" . PHP_EOL;
+
+echo "Test 2: Union avec static..." . PHP_EOL;
+$generator->generate(TestUnionWithStatic::class);
+$mock2 = new \mock\TestUnionWithStatic();
+$mock2->getMockController()->returnStaticOrInt = function () use ($mock2) {
+    return $mock2;
+};
+$result = $mock2->returnStaticOrInt();
+assert($result === $mock2, 'Test 2 failed: returnStaticOrInt should return the mock instance');
+echo "✓ Test 2 passed" . PHP_EOL;
+
+echo "Test 3: Union avec parent..." . PHP_EOL;
+$generator->generate(TestUnionWithParent::class);
+$mock3 = new \mock\TestUnionWithParent();
+$mock3->getMockController()->returnParentOrNull = function () use ($mock3) {
+    return $mock3;
+};
+$result = $mock3->returnParentOrNull();
+assert($result === $mock3, 'Test 3 failed: returnParentOrNull should return the mock instance');
+echo "✓ Test 3 passed" . PHP_EOL;
+
+echo "Test 4: Abstract avec static (valeur par défaut)..." . PHP_EOL;
+$generator->generate(TestAbstractWithStatic::class);
+$mock4 = new \mock\TestAbstractWithStatic();
+// Ne pas définir de mock controller, utiliser la valeur par défaut
+$result = $mock4->returnStatic();
+assert($result === $mock4, 'Test 4 failed: returnStatic should return $this by default');
+echo "✓ Test 4 passed" . PHP_EOL;
+
+echo PHP_EOL . "=== TOUS LES TESTS SONT PASSÉS ===" . PHP_EOL;

--- a/tests/units/classes/mock/fixtures/abstractWithSelf.php
+++ b/tests/units/classes/mock/fixtures/abstractWithSelf.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+abstract class abstractWithSelf
+{
+    abstract public function returnSelf(): self;
+
+    abstract public function returnStatic(): static;
+}
+
+abstract class abstractWithSelfChild extends abstractWithSelf
+{
+    // Hérite des méthodes abstraites
+}

--- a/tests/units/classes/mock/fixtures/abstractWithStaticOnly.php
+++ b/tests/units/classes/mock/fixtures/abstractWithStaticOnly.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+abstract class abstractWithStaticOnly
+{
+    abstract public function returnStatic(): static;
+}

--- a/tests/units/classes/mock/fixtures/interfaceWithSelf.php
+++ b/tests/units/classes/mock/fixtures/interfaceWithSelf.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+interface interfaceWithSelf
+{
+    public function returnSelf(): self;
+
+    public function returnStatic(): static;
+}

--- a/tests/units/classes/mock/fixtures/parentReturnType.php
+++ b/tests/units/classes/mock/fixtures/parentReturnType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+class parentReturnTypeBase
+{
+    public function baseMethod(): self
+    {
+        return $this;
+    }
+}
+
+class parentReturnType extends parentReturnTypeBase
+{
+    public function returnParent(): parent
+    {
+        return parent::baseMethod();
+    }
+
+    public function returnNullableParent(): ?parent
+    {
+        return parent::baseMethod();
+    }
+}

--- a/tests/units/classes/mock/fixtures/selfReturnType.php
+++ b/tests/units/classes/mock/fixtures/selfReturnType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+class selfReturnType
+{
+    public function returnSelf(): self
+    {
+        return $this;
+    }
+
+    public function returnNullableSelf(): ?self
+    {
+        return $this;
+    }
+}

--- a/tests/units/classes/mock/fixtures/staticReturnType.php
+++ b/tests/units/classes/mock/fixtures/staticReturnType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+class staticReturnType
+{
+    public function returnStatic(): static
+    {
+        return $this;
+    }
+
+    public function returnNullableStatic(): ?static
+    {
+        return $this;
+    }
+}

--- a/tests/units/classes/mock/fixtures/unionWithSelf.php
+++ b/tests/units/classes/mock/fixtures/unionWithSelf.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace atoum\atoum\tests\units\mock\fixtures;
+
+class unionWithSelf
+{
+    public function returnSelfOrString(): self|string
+    {
+        return $this;
+    }
+
+    public function returnStaticOrInt(): static|int
+    {
+        return $this;
+    }
+}
+
+class unionWithParentBase
+{
+    public function baseMethod(): self
+    {
+        return $this;
+    }
+}
+
+class unionWithParent extends unionWithParentBase
+{
+    public function returnParentOrNull(): parent|null
+    {
+        return $this;
+    }
+}

--- a/tests/units/classes/mock/generator.php
+++ b/tests/units/classes/mock/generator.php
@@ -3318,6 +3318,541 @@ class generator extends atoum\test
             '__halt_compiler',
         ];
     }
+
+    public function testGetMockedClassCodeForMethodWithParentReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController = new mock\controller())
+            ->and($reflectionTypeController->__construct = function () {
+            })
+            ->and($reflectionTypeController->__toString = 'parent')
+            ->and($reflectionTypeController->isBuiltIn = false)
+            ->and($reflectionTypeController->allowsNull = false)
+            ->and($reflectionType = new \mock\reflectionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnParent')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $reflectionType)
+            ->and(version_compare(phpversion(), '8.1', '<') ? true : $reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($parentClass = null)
+            ->and($reflectionParentClassController = new mock\controller())
+            ->and($reflectionParentClassController->__construct = function () {
+            })
+            ->and($reflectionParentClassController->getName = function () use (& $parentClass) {
+                return $parentClass;
+            })
+            ->and($reflectionParentClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClassController->getParentClass = $reflectionParentClass)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->and($parentClass = uniqid())
+            ->string($generator->getMockedClassCode($realClass = uniqid(), null, null))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(?\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): \\' . $parentClass . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
+    public function testGetMockedClassCodeForMethodWithUnionedSelfReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController1 = new mock\controller())
+            ->and($reflectionTypeController1->__construct = function () {
+            })
+            ->and($reflectionTypeController1->allowsNull = false)
+            ->and($reflectionTypeController1->isBuiltin = false)
+            ->and($reflectionTypeController1->getName = 'self')
+            ->and($reflectionType1 = new \mock\reflectionNamedType())
+            ->and($reflectionTypeController2 = new mock\controller())
+            ->and($reflectionTypeController2->__construct = function () {
+            })
+            ->and($reflectionTypeController2->allowsNull = false)
+            ->and($reflectionTypeController2->isBuiltin = true)
+            ->and($reflectionTypeController2->getName = 'string')
+            ->and($reflectionType2 = new \mock\reflectionNamedType())
+            ->and($unionTypeController = new mock\controller())
+            ->and($unionTypeController->getTypes = [$reflectionType1, $reflectionType2])
+            ->and($unionTypeController->allowsNull = false)
+            ->and($unionTypeController->__toString = 'self|string')
+            ->and($unionType = new \mock\reflectionUnionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnSelfOrString')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $unionType)
+            ->and(version_compare(phpversion(), '8.1', '<') ? true : $reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(?\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): \\' . $realClass . '|string' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
+    public function testGetMockedClassCodeForMethodWithUnionedStaticReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController1 = new mock\controller())
+            ->and($reflectionTypeController1->__construct = function () {
+            })
+            ->and($reflectionTypeController1->allowsNull = false)
+            ->and($reflectionTypeController1->isBuiltin = false)
+            ->and($reflectionTypeController1->getName = 'static')
+            ->and($reflectionType1 = new \mock\reflectionNamedType())
+            ->and($reflectionTypeController2 = new mock\controller())
+            ->and($reflectionTypeController2->__construct = function () {
+            })
+            ->and($reflectionTypeController2->allowsNull = false)
+            ->and($reflectionTypeController2->isBuiltin = true)
+            ->and($reflectionTypeController2->getName = 'int')
+            ->and($reflectionType2 = new \mock\reflectionNamedType())
+            ->and($unionTypeController = new mock\controller())
+            ->and($unionTypeController->getTypes = [$reflectionType1, $reflectionType2])
+            ->and($unionTypeController->allowsNull = false)
+            ->and($unionTypeController->__toString = 'static|int')
+            ->and($unionType = new \mock\reflectionUnionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnStaticOrInt')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $unionType)
+            ->and(version_compare(phpversion(), '8.1', '<') ? true : $reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(?\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): static|int' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
+    public function testGetMockedClassCodeForMethodWithUnionedParentReturnType()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController1 = new mock\controller())
+            ->and($reflectionTypeController1->__construct = function () {
+            })
+            ->and($reflectionTypeController1->allowsNull = false)
+            ->and($reflectionTypeController1->isBuiltin = false)
+            ->and($reflectionTypeController1->getName = 'parent')
+            ->and($reflectionType1 = new \mock\reflectionNamedType())
+            ->and($reflectionTypeController2 = new mock\controller())
+            ->and($reflectionTypeController2->__construct = function () {
+            })
+            ->and($reflectionTypeController2->allowsNull = true)
+            ->and($reflectionTypeController2->isBuiltin = true)
+            ->and($reflectionTypeController2->getName = 'null')
+            ->and($reflectionType2 = new \mock\reflectionNamedType())
+            ->and($unionTypeController = new mock\controller())
+            ->and($unionTypeController->getTypes = [$reflectionType1, $reflectionType2])
+            ->and($unionTypeController->allowsNull = true)
+            ->and($unionTypeController->__toString = 'parent|null')
+            ->and($unionType = new \mock\reflectionUnionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnParentOrNull')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = false)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $unionType)
+            ->and(version_compare(phpversion(), '8.1', '<') ? true : $reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($parentClass = null)
+            ->and($reflectionParentClassController = new mock\controller())
+            ->and($reflectionParentClassController->__construct = function () {
+            })
+            ->and($reflectionParentClassController->getName = function () use (& $parentClass) {
+                return $parentClass;
+            })
+            ->and($reflectionParentClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = false)
+            ->and($reflectionClassController->getParentClass = $reflectionParentClass)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->and($parentClass = uniqid())
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(?\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): \\' . $parentClass . '|null' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t\t" . '$return = call_user_func_array([parent::class, \'' . $methodName . '\'], $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName)], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
+
+    public function testGetMockedClassCodeForAbstractMethodWithStaticReturnTypeDefaultValue()
+    {
+        $this
+            ->if($generator = new testedClass())
+            ->and($reflectionTypeController = new mock\controller())
+            ->and($reflectionTypeController->__construct = function () {
+            })
+            ->and($reflectionTypeController->__toString = 'static')
+            ->and($reflectionTypeController->isBuiltIn = false)
+            ->and($reflectionTypeController->allowsNull = false)
+            ->and($reflectionType = new \mock\reflectionType())
+            ->and($reflectionMethodController = new mock\controller())
+            ->and($reflectionMethodController->__construct = function () {
+            })
+            ->and($reflectionMethodController->getName = $methodName = 'returnStatic')
+            ->and($reflectionMethodController->isConstructor = false)
+            ->and($reflectionMethodController->getParameters = [])
+            ->and($reflectionMethodController->isPublic = true)
+            ->and($reflectionMethodController->isProtected = false)
+            ->and($reflectionMethodController->isPrivate = false)
+            ->and($reflectionMethodController->isFinal = false)
+            ->and($reflectionMethodController->isStatic = false)
+            ->and($reflectionMethodController->isAbstract = true)
+            ->and($reflectionMethodController->returnsReference = false)
+            ->and($reflectionMethodController->hasReturnType = true)
+            ->and($reflectionMethodController->getReturnType = $reflectionType)
+            ->and(version_compare(phpversion(), '8.1', '<') ? true : $reflectionMethodController->hasTentativeReturnType = false)
+            ->and($reflectionMethod = new \mock\reflectionMethod(uniqid(), uniqid()))
+            ->and($reflectionClassController = new mock\controller())
+            ->and($reflectionClassController->__construct = function () {
+            })
+            ->and($reflectionClassController->getName = function () use (& $realClass) {
+                return $realClass;
+            })
+            ->and($reflectionClassController->isFinal = false)
+            ->and($reflectionClassController->isInterface = false)
+            ->and($reflectionClassController->getMethods = [$reflectionMethod])
+            ->and($reflectionClassController->getConstructor = null)
+            ->and($reflectionClassController->isAbstract = true)
+            ->and($reflectionClass = new \mock\reflectionClass(uniqid()))
+            ->and($reflectionMethodController->getDeclaringClass = $reflectionClass)
+            ->and($generator->setReflectionClassFactory(function () use ($reflectionClass) {
+                return $reflectionClass;
+            }))
+            ->and($adapter = new atoum\test\adapter())
+            ->and($adapter->class_exists = function ($class) use (& $realClass) {
+                return ($class == '\\' . $realClass);
+            })
+            ->and($generator->setAdapter($adapter))
+            ->string($generator->getMockedClassCode($realClass = uniqid()))->isEqualTo(
+                'namespace mock {' . PHP_EOL .
+                'final class ' . $realClass . ' extends \\' . $realClass . ' implements \atoum\atoum\mock\aggregator' . PHP_EOL .
+                '{' . PHP_EOL .
+                $this->getMockControllerMethods() .
+                "\t" . 'public function __construct(?\atoum\atoum\mock\controller $mockController = null)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if ($mockController === null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$mockController = \atoum\atoum\mock\controller::get();' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if ($mockController !== null)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->setMockController($mockController);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->__construct) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->invoke(\'__construct\', func_get_args());' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function ' . $methodName . '(): static' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . '$arguments = array_merge(array(), array_slice(func_get_args(), 0));' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->' . $methodName . ') === false)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->' . $methodName . ' = function() {' . PHP_EOL .
+                "\t\t\t\t" . 'return $this;' . PHP_EOL .
+                "\t\t\t" . '};' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . '$return = $this->getMockController()->invoke(\'' . $methodName . '\', $arguments);' . PHP_EOL .
+                "\t\t" . 'return $return;' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public function __call($methodName, $arguments)' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'if (isset($this->getMockController()->{$methodName}) === true)' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$return = $this->getMockController()->invoke($methodName, $arguments);' . PHP_EOL .
+                "\t\t\t" . 'return $return;' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t\t" . 'else' . PHP_EOL .
+                "\t\t" . '{' . PHP_EOL .
+                "\t\t\t" . '$this->getMockController()->addCall($methodName, $arguments);' . PHP_EOL .
+                "\t\t" . '}' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                "\t" . 'public static function getMockedMethods()' . PHP_EOL .
+                "\t" . '{' . PHP_EOL .
+                "\t\t" . 'return ' . var_export(['__construct', strtolower($methodName), '__call'], true) . ';' . PHP_EOL .
+                "\t" . '}' . PHP_EOL .
+                '}' . PHP_EOL .
+                '}'
+            )
+        ;
+    }
 }
 
 class mockable


### PR DESCRIPTION
En mettant à jour le bundle symfony atoum, je me suis retrouvé avec des bugs relatifs aux retours typés "static", "self" et "parent".

Erreur lors de la mise à jour du bundle symfony
<img width="1245" height="973" alt="image" src="https://github.com/user-attachments/assets/dfc0e311-03de-4c99-9541-8ed231c6de58" />

Succès après la mise à jour et switch sur mon fork.
<img width="830" height="438" alt="image" src="https://github.com/user-attachments/assets/1ef89c96-e049-48e7-8564-801f313b4663" />
